### PR TITLE
Support for binary Glasgow Haskell Compiler (GHC) packages

### DIFF
--- a/easybuild/easyblocks/g/ghc.py
+++ b/easybuild/easyblocks/g/ghc.py
@@ -25,6 +25,7 @@
 """
 EasyBuild support for binary GHC packages, see http://haskell.org/ghc
 """
+from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 


### PR DESCRIPTION
Custom easyblock that skips the build step from ConfigureMake.
