### PR TITLE
set compiler env vars in NEURON module, update use of load_fake_module

### DIFF
--- a/easybuild/easyblocks/n/neuron.py
+++ b/easybuild/easyblocks/n/neuron.py
@@ -139,7 +139,7 @@ class EB_NEURON(ConfigureMake):
         super(EB_NEURON, self).sanity_check_step(custom_paths=custom_paths)
 
         try:
-            fake_mod_path, orig_env = self.load_fake_module()
+            fake_mod_data = self.load_fake_module()
         except EasyBuildError, err:
             self.log.debug("Loading fake module failed: %s" % err)
 
@@ -184,7 +184,7 @@ class EB_NEURON(ConfigureMake):
             self.log.info("Parallel hello world OK!")
 
         # cleanup
-        self.clean_up_fake_module(fake_mod_path, orig_env)
+        self.clean_up_fake_module(fake_mod_data)
 
     def make_module_req_guess(self):
         """Custom guesses for environment variables (PATH, ...) for NEURON."""

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -84,7 +84,7 @@ class EB_Python(ConfigureMake):
         pyver = "python%s" % '.'.join(self.version.split('.')[0:2])
 
         try:
-            fake_mod_path, orig_env = self.load_fake_module()
+            fake_mod_data = self.load_fake_module()
         except EasyBuildError, err:
             self.log.error("Loading fake module failed: %s" % err)
 
@@ -104,6 +104,6 @@ class EB_Python(ConfigureMake):
                        }
 
         # cleanup
-        self.clean_up_fake_module(fake_mod_path, orig_env)
+        self.clean_up_fake_module(fake_mod_data)
 
         super(EB_Python, self).sanity_check_step(custom_paths=custom_paths)


### PR DESCRIPTION
Depends on https://github.com/hpcugent/easybuild-framework/pull/431 to get it to work correctly. Without it, MPICH_CC would no longer be set when creating the final module file.
