### PR TITLE
Fixed wrong configure flag in gcc block

### DIFF
--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -216,8 +216,8 @@ class EB_GCC(ConfigureMake):
 
         # configure for a release build
         self.configopts += " --enable-checking=release "
-        # enable C++ support (required for GMP build), disable multilib (???)
-        self.configopts += " --enable-cxx --disable-multilib"
+        # disable multilib (???)
+        self.configopts += " --disable-multilib"
         # build both static and dynamic libraries (???)
         self.configopts += " --enable-shared=yes --enable-static=yes "
         # use POSIX threads


### PR DESCRIPTION
enable-cxx is a flag for gmp, not gcc. gcc does not need the C++
bindings of GMP to build. It can cause linking errors with libstdc+.
More information:  Issue #128
