### PR TITLE
add zip_safe flag to setup, to silence multitude of warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,5 +96,6 @@ particular (groups of) software packages with EasyBuild.""",
                   ],
     platforms = "Linux",
     provides = ["easybuild", "easybuild.easyblocks", "easybuild.easyblocks.generic"],
-    install_requires = ["easybuild-framework >= %s" % API_VERSION]
+    install_requires = ["easybuild-framework >= %s" % API_VERSION],
+    zip_safe = False,
 )


### PR DESCRIPTION
without the `zip_safe` flag set to `False`, a whole bunch of warnings are spit out when installing easybuild-easyblocks

```
zip_safe flag not set; analyzing archive contents...
easybuild.__init__: module references __path__
easybuild.easyblocks.__init__: module references __file__
easybuild.easyblocks.__init__: module references __path__
easybuild.easyblocks.generic.__init__: module references __path__
```

see also http://stackoverflow.com/questions/8362510/getting-rid-of-the-easy-install-message-module-references-file
