### PR TITLE
install EasyBuild packages in reverse order

### DIFF
--- a/easybuild/easyblocks/e/easybuildmeta.py
+++ b/easybuild/easyblocks/e/easybuildmeta.py
@@ -48,7 +48,7 @@ class EB_EasyBuildMeta(PythonPackage):
 
         try:
             subdirs = os.listdir(self.builddir)
-            for pkg in ['framework', 'easyblocks', 'easyconfigs']:
+            for pkg in ['easyconfigs', 'easyblocks', 'framework']:
                 seldirs = [x for x in subdirs if x.startswith('easybuild-%s-' % pkg)]
                 if not len(seldirs) == 1:
                     self.log.error("Failed to find EasyBuild %s package (subdirs: %s, seldirs: %s)" % (pkg, subdirs, seldirs))


### PR DESCRIPTION
install EasyBuild packages in reverse order to avoid problems with auto-resolved dependencies (to readily installed easybuild- packages available in Python search path)
