### PR TITLE
stop hardcoding list of libraries for BLAS libs, ask toolchain modules instead

### DIFF
--- a/easybuild/easyblocks/l/lapack.py
+++ b/easybuild/easyblocks/l/lapack.py
@@ -50,6 +50,7 @@ def get_blas_lib(log):
     """
     Determine BLAS lib to provide to e.g. LAPACK for building/testing
     """
+    log.deprecated("get_blas_lib uses hardcoded list of known BLAS libs, should rely on toolchain support", "2.0")
     blaslib = None
     known_blas_libs = {
                        'GotoBLAS': GotoBLAS.BLAS_LIB,

--- a/easybuild/easyblocks/s/scalapack.py
+++ b/easybuild/easyblocks/s/scalapack.py
@@ -70,6 +70,7 @@ class EB_ScaLAPACK(ConfigureMake):
 
         # make sure required dependencies are available
         deps = [("LAPACK", "ACML", "OpenBLAS")]
+        self.log.deprecated("EB_ScaLAPACK.configure_step uses hardcoded list of LAPACK libs", "2.0")
         # BLACS is only a dependency for ScaLAPACK versions prior to v2.0.0
         if self.loosever < LooseVersion("2.0.0"):
             deps.append(("BLACS",))
@@ -99,6 +100,7 @@ class EB_ScaLAPACK(ConfigureMake):
 
         # set BLAS and LAPACK libs
         extra_makeopts = None
+        self.log.deprecated("EB_ScaLAPACK.build_step doesn't use toolchain support for BLAS/LAPACK libs", "2.0")
         if get_software_root('LAPACK'):
             extra_makeopts = [
                               'BLASLIB="%s -lpthread"' % lapack_get_blas_lib(self.log),


### PR DESCRIPTION
This is a fix required to build the `goolf` toolchain.

Although this fixes the issue, a more proper way may be to define a compiler+MPI+BLAS toolchain (e.g. `goo`), and make the toolchain support in the framework take care of this.

We're not going to go there for now however...
