### PR TITLE
176 bugfix matlab

### DIFF
--- a/easybuild/easyblocks/m/matlab.py
+++ b/easybuild/easyblocks/m/matlab.py
@@ -54,7 +54,7 @@ class EB_MATLAB(EasyBlock):
     @staticmethod
     def extra_options():
         extra_vars = [
-                      ('java_options', ['-Xmx128M', "$_JAVA_OPTIONS value set for install and in module file.", CUSTOM]),
+                      ('java_options', ['-Xmx256m', "$_JAVA_OPTIONS value set for install and in module file.", CUSTOM]),
                      ]
         return EasyBlock.extra_options(extra_vars)
 


### PR DESCRIPTION
summary:
- permit preinstallopts, installopts for generality and all-around-hackability
- unhardwire `_JAVA_OPTIONS` definition
- sanity_check_step & make_module_extra, to permit variations across MATLAB versions
- remove spurious dependency on `DISPLAY` variable
- cosmetic: rename license file to matlab.lic for conformity with other license business
