### PR TITLE
hardcode Python lib path, since setuptools/distribute hardcode it

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -52,7 +52,7 @@ def det_pylibdir():
     pyver = get_software_version('Python')
     if not pyver:
         log = fancylogger.getLogger('det_pylibdir', fname=False)
-        log.error("Python module not loaded?")
+        log.error("Python module not loaded.")
     else:
         short_pyver = '.'.join(pyver.split('.')[:2])
         return "lib/python%s/site-packages" % short_pyver


### PR DESCRIPTION
`lib/python-2.x/site-packages` is hardcoded by `setuptools` and `distribute` (see below), so we shouldn't be relying on `distutils.sysconfig.get_python_lib` because it doesn't work as we want/expect on various OSs

```
setuptools-0.6c11 $ sed -n "1107,1114p" setuptools/command/easy_install.py

    INSTALL_SCHEMES = dict(
        posix = dict(
            install_dir = '$base/lib/python$py_version_short/site-packages',
            script_dir  = '$base/bin',
        ),
    )
```

and

```
distribute-0.6.35 $ sed -n "1322,1327p" setuptools/command/easy_install.py
    INSTALL_SCHEMES = dict(
        posix = dict(
            install_dir = '$base/lib/python$py_version_short/site-packages',
            script_dir  = '$base/bin',
        ),
    )
```

This patch should fix https://github.com/hpcugent/easybuild-framework/issues/595 and https://github.com/hpcugent/easybuild-framework/issues/597.
