### PR TITLE
don't force jellyfish build, rely on Makefile is no separate jellyfish source was specified

### DIFF
--- a/easybuild/easyblocks/t/trinity.py
+++ b/easybuild/easyblocks/t/trinity.py
@@ -170,9 +170,8 @@ class EB_Trinity(EasyBlock):
         elif jellyfishdirs:
             self.log.error("Found multiple 'jellyfish-*' directories: %s", jellyfishdirs)
         else:
-            self.log.info("no seperate source found for jellyfish, using shipped version")
+            self.log.info("no seperate source found for jellyfish, letting Makefile build shipped version")
 
-            self.trinityplugin('jellyfish')
         self.log.debug("end jellyfish")
 
     def kmer(self):


### PR DESCRIPTION
minor fix, but required for https://github.com/hpcugent/easybuild-easyconfigs/pull/341
