### PR TITLE
readd get_sitearch_suffix for backward compatiblity

### DIFF
--- a/easybuild/easyblocks/p/perl.py
+++ b/easybuild/easyblocks/p/perl.py
@@ -94,3 +94,9 @@ def get_site_suffix(tag):
     (sitesuffix, _) = run_cmd(cmd, log_all=True, log_output=True, simple=False)
     # obtained value usually contains leading '/', so strip it off
     return sitesuffix.lstrip(os.path.sep)
+
+def get_sitearch_suffix():
+    """Deprecated more specific version of get_site_suffix. Only here for backward compatibility."""
+    _log = fancylogger.getLogger('Perl.get_sitearch_suffix', fname=False)
+    _log.deprecated("Use get_site_suffix('sitearch') instead of get_sitearch_suffix()", "2.0")
+    return get_site_suffix('sitearch')


### PR DESCRIPTION
I'm aware of someone that may be relying on `get_sitearch_suffix`, so better add it back.
