### PR TITLE
Add easyblock for libint2

### DIFF
--- a/easybuild/easyblocks/l/libint2.py
+++ b/easybuild/easyblocks/l/libint2.py
@@ -33,9 +33,34 @@ import os.path
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 
 class EB_libint2(ConfigureMake):
+    def configure_step(self):
+        """Add some extra configure options."""
+
+        if self.toolchain.options['pic']:
+            # Enforce consistency.
+            self.cfg.update('configopts', "--with-pic")
+
+        # The code in libint is automatically generated and hence it is in some
+        # parts so compex that -O2 or -O3 compiler optimization takes forever.
+        self.cfg.update('configopts', "--with-cxx-optflags='-O1'")
+
+        # Also build shared libraries. (not enabled by default)
+        self.cfg.update('configopts', "--enable-shared")
+
+        super(EB_libint2, self).configure_step()
+
+    def sanity_check_step(self):
+        """Custom sanity check for Libint2."""
+
+        custom_paths = {
+            'files': ['lib/libint2.a', 'lib/libint2.so', 'include/libint2/libint2.h'],
+            'dirs': [],
+        }
+        super(EB_libint2, self).sanity_check_step(custom_paths=custom_paths)
+
     def make_module_req_guess(self):
         """Specify correct LD_LIBRARY_PATH and CPATH for this installation."""
-        guesses = ConfigureMake.make_module_req_guess(self)
+        guesses = super(EB_libint2, self).make_module_req_guess()
         guesses.update({
             'CPATH': [os.path.join("include", "libint2")],
         })


### PR DESCRIPTION
Second attempt ...

Original PR (which targeted `master` in error), was #235.

This is a tiny easyblock. I've tested it on several occasions. A corresponding pull request for the easyconfigs was just created.

It seems a bit silly to make an easyblock for something minor like this. Would it not be better to allow for a bit extra functionality in the easyconfigs, such that this can be take care of with a more local solution? For example, I've wondered from the beginning why easyconfigs are not implemented as subclasses of easyblocks. That would (intentionally) blur the lines between what is an easyblock and what is an easyconfig.
