### PR TITLE
GCC: unset env vars

### DIFF
--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -60,7 +60,7 @@ class EB_GCC(ConfigureMake):
         self.stagedbuild = False
 
         # unset some environment variables that are known to may cause nasty build errors when bootstrapping
-        self.cfg['unwanted_env_vars'].extend(['CPATH', 'C_INCLUDE_PATH', 'CPLUS_INCLUDE_PATH', 'OBJC_INCLUDE_PATH', 'LIBRARY_PATH'])
+        self.cfg.update('unwanted_env_vars', ['CPATH', 'C_INCLUDE_PATH', 'CPLUS_INCLUDE_PATH', 'OBJC_INCLUDE_PATH', 'LIBRARY_PATH'])
 
     @staticmethod
     def extra_options():


### PR DESCRIPTION
Makes use of the functionality added in hpcugent/easybuild-framework#673
