### PR TITLE
Remove sanity check for libnpp for CUDA 5.5 compat

### DIFF
--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -76,7 +76,7 @@ class EB_CUDA(Binary):
         custom_paths = {
             'files': ["bin/%s" % x for x in ["fatbinary", "nvcc", "nvlink", "ptxas"]] +
                      ["%s/lib%s.so" % (x, y) for x in ["lib", "lib64"] for y in ["cublas", "cudart", "cufft",
-                                                                                 "curand", "cusparse", "npp"]] +
+                                                                                 "curand", "cusparse"]] +
                      ["open64/bin/nvopencc"],
             'dirs': ["include"],
         }


### PR DESCRIPTION
CUDA 5.5 splits libnpp into three libraries: libnppc, libnppi and
libnpps. This causes the sanity check for libnpp.so to fail on version
5.5.22.

Simply removed this check to maintain compatibility with CUDA 5.0. It's
debatable whether it's better to special-case this check by version, but
given that the CUDA installer is monolithic we probably don't need this
check in addition to the others.

Also removed executable bit from cuda.py permissions for consistency
with other EasyBlocks.
