### PR TITLE
pick up $INTEL_LICENSE_FILE if it's set

### DIFF
--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -172,7 +172,7 @@ class IntelBase(EasyBlock):
         else:
             # pick up $INTEL_LICENSE_FILE if it's set
             self.log.info("Picking up Intel license file specification from $%s: %s" % (lic_env_var, intel_license_file))
-            self.setcfg('license_file', intel_license_file)
+            self.cfg['license_file'] = intel_license_file
             self.license_file = intel_license_file
 
         # clean home directory


### PR DESCRIPTION
Picking up `$INTEL_LICENSE_FILE` was included in easyconfigs in https://github.com/hpcugent/easybuild-easyconfigs/pull/400, but let's do it properly and simply pick it up in the generic `IntelBase` easyblock.
