### PR TITLE
include zlib lib dir in link path dirs if it is loaded

### DIFF
--- a/easybuild/easyblocks/w/wps.py
+++ b/easybuild/easyblocks/w/wps.py
@@ -111,7 +111,7 @@ class EB_WPS(EasyBlock):
         if libpng:
             paths = [libpng]
             if zlib:
-                paths.prepend(zlib)
+                paths.insert(0, zlib)
             libpnginc = ' '.join(['-I%s' % os.path.join(path, 'include') for path in paths])
             libpnglib = ' '.join(['-L%s' % os.path.join(path, 'lib') for path in paths])
         else:


### PR DESCRIPTION
This is required for building WPS 3.5 on SL6 with zlib 1.2.7 as an (indirect) dependency, to avoid problems like:

```
/apps/gent/SL6/magnycours/software/libpng/1.6.3-ictce-4.1.13/lib/libpng.so: undefined reference to `inflateReset2@ZLIB_1.2.3.4'
make[1]: [ungrib.exe] Error 1 (ignored)
```
