### PR TITLE
Fixed small bug with license file.

### DIFF
--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -163,11 +163,11 @@ class IntelBase(EasyBlock):
             if self.license_file:
                 self.log.info("Using license file %s" % self.license_file)
             else:
-                self.log.error("No license file defined")
+                self.log.error("No license file defined, consider setting $%s that will be picked up" % lic_env_var)
 
             # verify license path
             if not os.path.exists(self.license_file):
-                self.log.error("Can't find license at %s" % self.license_file)
+                self.log.error("%s not found, correct 'license_file' value or $%s" % (self.license_file, lic_env_var))
 
             # set INTEL_LICENSE_FILE
             env.setvar(lic_env_var, self.license_file)


### PR DESCRIPTION
$INTEL_LICENSE_FILE can be a list of directory which contain the license
file. For the install cfg, PSET_LICENSE_FILE must point to the license
file itself, not a directory. This patch iterates throught the
directories in $INTEL_LICENSE_FILE until a .lic file is found.
