### PR TITLE
code style fixes in OpenFOAM easyblock

### DIFF
--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -120,8 +120,11 @@ class EB_OpenFOAM(EasyBlock):
         # parallel build spec
         env.setvar("WM_NCOMPPROCS", str(self.cfg['parallel']))
 
-        if 'extend' in self.name.lower() and LooseVersion(self.version) >= LooseVersion('3.0'):
-            self.openfoamdir = 'foam-extend-%s' % self.version
+        if 'extend' in self.name.lower():
+            if LooseVersion(self.version) >= LooseVersion('3.0'):
+                self.openfoamdir = 'foam-extend-%s' % self.version
+            else:
+                self.openfoamdir = 'OpenFOAM-%s-ext' % self.version
         else:
             self.openfoamdir = '-'.join([self.name, '-'.join(self.version.split('-')[:2])])
         self.log.debug("openfoamdir: %s" % self.openfoamdir)


### PR DESCRIPTION
The OpenFOAM easyblock was touched during the build of OpenFOAM-1.6-ext, but nothing was changed except for code style fixes.
The MUMPS easyblock was ported from an old implementation, and further enhanced (to add support for building with GCC).
