### PR TITLE
add easyblock for installing Allinea tools

### DIFF
--- a/easybuild/easyblocks/a/allinea.py
+++ b/easybuild/easyblocks/a/allinea.py
@@ -32,6 +32,7 @@ import shutil
 from os.path import expanduser
 
 from easybuild.easyblocks.generic.binary import Binary
+from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
 
 


### PR DESCRIPTION
This currently requires X forwarding to be enabled, and thus this is not ready to be merged in yet (although it works fine)...

We need to figure out a way around the X forwarding mess.

The `ddt` tool _doesn't_ require X forwarding when a `~/.allinea/system.config` file is present already, but does require it to (re)generate one. Maybe putting a dummy file there would work?
