### PR TITLE
Fix bugs in the HDF5 easyblocks

### DIFF
--- a/easybuild/easyblocks/h/hdf5.py
+++ b/easybuild/easyblocks/h/hdf5.py
@@ -45,14 +45,19 @@ class EB_HDF5(ConfigureMake):
     def configure_step(self):
         """Configure build: set require config and make options, and run configure script."""
 
-        # configure options
-        deps = ["Szip", "zlib"]
-        for dep in deps:
-            root = get_software_root(dep)
-            if root:
-                self.cfg.update('configopts', '--with-%s=%s' % (dep.lower(), root))
-            else:
-                self.log.error("Dependency module %s not loaded." % dep)
+        # Szip configure option -> --with-szlib
+        szip_root = get_software_root("Szip")
+        if szip_root:
+            self.cfg.update('configopts', '--with-szlib=%s' % (szip_root))
+        else:
+            self.log.error("Dependency module Szip not loaded.")
+
+        # zlib configure option -> --with-zlib
+        zlib_root = get_software_root("zlib")
+        if zlib_root:
+            self.cfg.update('configopts', '--with-zlib=%s' % (zlib_root))
+        else:
+            self.log.error("Dependency module zlib not loaded.")
 
         fcomp = 'FC="%s"' % os.getenv('F90')
 


### PR DESCRIPTION
The configure option of HDF5 for Szip is actually --with-szlib and not --with-szip.
This is documented in http://www.hdfgroup.org/ftp/HDF5/current/src/unpacked/release_docs/INSTALL
I verified that this option is valid for HDF5 1.8.7, 1.8.9, 1.8.10 and 1.8.11.
