### PR TITLE
Three no_qa added to make it through the configuration.

### DIFF
--- a/easybuild/easyblocks/q/qt.py
+++ b/easybuild/easyblocks/q/qt.py
@@ -59,7 +59,10 @@ class EB_Qt(ConfigureMake):
         }
         no_qa = [
             "for .*pro",
-            r"%s.*" % os.getenv('CXX').replace('+', '\\+'),  # need to escape + in 'g++'
+            r"%s.*" % os.getenv('CXX').replace('+', '\\+'),# need to escape + in 'g++'
+			"Reading .*",
+			"WARNING .*",
+			"Project MESSAGE:.*",
         ]
         run_cmd_qa(cmd, qa, no_qa=no_qa, log_all=True, simple=True)
 


### PR DESCRIPTION
For slow servers, some no_qa have to be added to make it through the installation.
Not sure if all no_qa's should be in it for everybody, Project Message e.g. can give useful information, but if you want to ignore it, it has to be added in the no_qa....
