### PR TITLE
always use $CPP for preprocessing Fortran code in QuantumESPRESSO

### DIFF
--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -150,12 +150,11 @@ class EB_QuantumESPRESSO(ConfigureMake):
                     else:
                         line = re.sub(r"^(%s\s*=[ \t]*).*$" % k, r"\1%s" % v, line)
 
-                    # fix preprocessing directives for .f90 files in make.sys if required
-                if self.toolchain.comp_family() in [toolchain.GCC]:
-                    line = re.sub("\$\(MPIF90\) \$\(F90FLAGS\) -c \$<",
-                                  "$(CPP) -C $(CPPFLAGS) $< -o $*.F90\n" +
-                                  "\t$(MPIF90) $(F90FLAGS) -c $*.F90 -o $*.o",
-                                  line)
+                # fix preprocessing directives for .f90 files in make.sys
+                line = re.sub("\$\(MPIF90\) \$\(F90FLAGS\) -c \$<",
+                              "$(CPP) -C $(CPPFLAGS) $< -o $*.F90\n" +
+                              "\t$(MPIF90) $(F90FLAGS) -c $*.F90 -o $*.o",
+                              line)
 
                 sys.stdout.write(line)
         except IOError, err:


### PR DESCRIPTION
Using `$CPP` for preprocessing Fortran code is sometimes also needed with Intel compilers, and always using it doesn't hurt (?).
