### PR TITLE
always include -w flag for preprocessor to supress warnings that may break configure

### DIFF
--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -92,9 +92,9 @@ class EB_QuantumESPRESSO(ConfigureMake):
         dflags = []
 
         comp_fam_dflags = {
-                           toolchain.INTELCOMP: '-D__INTEL',
-                           toolchain.GCC: '-D__GFORTRAN -D__STD_F95',
-                          }
+            toolchain.INTELCOMP: '-D__INTEL',
+            toolchain.GCC: '-D__GFORTRAN -D__STD_F95',
+        }
         dflags.append(comp_fam_dflags[self.toolchain.comp_family()])
 
         libfft = os.getenv('LIBFFT')
@@ -116,6 +116,9 @@ class EB_QuantumESPRESSO(ConfigureMake):
 
         if self.cfg['with_scalapack']:
             dflags.append(" -D__SCALAPACK")
+
+        # always include -w to supress warnings
+        dflags.append('-w')
 
         repls.append(('DFLAGS', ' '.join(dflags), False))
 
@@ -311,7 +314,6 @@ class EB_QuantumESPRESSO(ConfigureMake):
         yambo_bins = []
         if 'yambo' in self.cfg['makeopts']:
             yambo_bins = ["a2y", "p2y", "yambo", "ypp"]
-
 
         pref = self.install_subdir
 


### PR DESCRIPTION
required for https://github.com/hpcugent/easybuild-easyconfigs/pull/573 because of https://github.com/hpcugent/easybuild-framework/pull/771
