### PR TITLE
update CP2K easyblock

### DIFF
--- a/easybuild/easyblocks/c/cp2k.py
+++ b/easybuild/easyblocks/c/cp2k.py
@@ -353,7 +353,7 @@ class EB_CP2K(EasyBlock):
             self.log.warning("LibInt module not loaded, so building without LibInt support")
 
             
-        libxc = get_software_root('libxc'):
+        libxc = get_software_root('libxc')
         if libxc:
             cur_libxc_version = get_software_version('libxc')
             if LooseVersion(LIBXC_VERSION) != LooseVersion(cur_libxc_version):


### PR DESCRIPTION
builds on top of @wpoely86's PR #323, fixes bug in definition of `test_core_cnt` (which is not a real constant since it's not defined out of the class) and includes minor style fixes

tested with https://github.com/hpcugent/easybuild-easyconfigs/pull/572 and https://github.com/hpcugent/easybuild-easyconfigs/pull/601
