### PR TITLE
Cmake env

### DIFF
--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -62,7 +62,8 @@ class CMakeMake(ConfigureMake):
         # Set the search paths for CMake
         include_paths = os.pathsep.join(self.toolchain.get_variable("CPPFLAGS", list))
         library_paths = os.pathsep.join(self.toolchain.get_variable("LDFLAGS", list))
-        prefix_paths = os.pathsep.join([env_val for env_name, env_val in os.environ.items() if env_name.startswith(ROOT_ENV_VAR_NAME_PREFIX)])
+        prefix_paths = os.pathsep.join([env_val for env_name, env_val in os.environ.items()
+                                        if env_name.startswith(ROOT_ENV_VAR_NAME_PREFIX)])
         setvar("CMAKE_INCLUDE_PATH", include_paths)
         setvar("CMAKE_LIBRARY_PATH", library_paths)
         setvar("CMAKE_PREFIX_PATH", prefix_paths)


### PR DESCRIPTION
Set CMake environment vars so that it actually finds the headers and the libraries.

Follow-up of hpcugent/easybuild-framework#812
