### PR TITLE
Added support for SPM. Still needs work.

### DIFF
--- a/easybuild/easyblocks/s/spm.py
+++ b/easybuild/easyblocks/s/spm.py
@@ -13,19 +13,13 @@ EasyBuild support for SPM, implemented as an easyblock
 import os
 import shutil
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.framework.easyconfig import CUSTOM, MANDATORY
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.filetools import run_cmd,which
 
 class EB_SPM(ConfigureMake):
     """Support for building and installing SPM."""
     
-    source_files = [
-        'spm_add', 'spm_bias_mex', 'spm_brainwarp', 'spm_bsplinc', 'spm_bsplins',
-        'spm_bwlabel', 'spm_conv_vol', 'spm_dilate_erode', 'spm_existfile', 'spm_gamrnd',
-        'spm_get_lm', 'spm_global', 'spm_hist2', 'spm_hist', 'spm_invdef', 'spm_krutil',
-        'spm_project', 'spm_render_vol', 'spm_resels_vol', 'spm_sample_vol', 'spm_slice_vol',
-        'spm_unlink', 'spm_voronoi', '@file_array/private/file2mat', '@file_array/private/mat2file',
-    ]  # these should be moved to the easyconfig, because they probably change between versions
     all_mex_suffixes = [ 'mexa64', 'mexglx', 'mexw32', 'mexw64', 'mexmaci64', 'mexmaci' ]
     compiled_mex_suffix = 'mexa64'
 
@@ -33,19 +27,17 @@ class EB_SPM(ConfigureMake):
         """Specify building in install dir, initialize custom variables."""
         super(EB_SPM, self).__init__(*args, **kwargs)
         self.build_in_installdir = True
-    
-        # MATLAB (mcc) warns if GCC version is not 4.4.x, but it still seems to work
-        deps = [ 'GCC', 'MATLAB' ]
-        for dep in deps:
-            if not get_software_root(dep):
-                self.log.error("%s module not loaded" % dep)
-       
-        matlab_compilers = [ 'mcc', 'mex' ] 
-        for compiler in matlab_compilers:
-            if which(compiler) is None:
-                self.log.error('%s not found' % compiler)
+
+    @staticmethod
+    def extra_options():
+        extra_vars = [
+                      ('mexfiles', [None, "Specify the mex files that get compiled in the install step (without file extension)." \
+                                          "This is used for cleaning out obsolete files and sanity checking.", MANDATORY])
+                     ]
+        return ConfigureMake.extra_options(extra_vars)
 
     def extract_step(self):
+        """Extract SPM and move it one level up"""
         super(EB_SPM, self).extract_step()
         
         # there is no --strip-components for unzip...
@@ -56,14 +48,25 @@ class EB_SPM(ConfigureMake):
         self.cfg['start_dir'] = os.path.join(self.builddir, "src")
 
     def prepare_step(self):
-        super(EB_SPM, self).prepare_step() 
-        for source_file in self.source_files:
+        """Clean out the shipped mex files."""
+        super(EB_SPM, self).prepare_step()
+        source_files = self.cfg['mexfiles'] 
+        for source_file in source_files:
             for suffix in self.all_mex_suffixes:
                 os.remove(os.path.join(self.builddir, source_file + '.' + suffix))
 
     def configure_step(self):
-        """No configure step for SPM."""
-        pass
+        """Check for loaded dependencies"""
+        # MATLAB (mcc) warns if GCC version is not 4.4.x, but it still works
+        deps = [ 'GCC', 'MATLAB' ]
+        for dep in deps:
+            if not get_software_root(dep):
+                self.log.error("%s module not loaded" % dep)
+
+        matlab_compilers = [ 'mcc', 'mex' ]
+        for compiler in matlab_compilers:
+            if which(compiler) is None:
+                self.log.error('%s not found' % compiler)
 
     def build_step(self):
         """Build is done in install step"""
@@ -74,14 +77,16 @@ class EB_SPM(ConfigureMake):
         super(EB_SPM, self).install_step()
 
     def cleanup_step(self):
+        """Remove (now obsolete) src dir"""
         super(EB_SPM, self).cleanup_step()
         shutil.rmtree(os.path.join(self.builddir, 'src'))
 
     def sanity_check_step(self):
         """Custom sanity check for SPM."""
-
+        
+        source_files = self.cfg['mexfiles']
         custom_paths = {
-            'files': [ source_file + '.' + self.compiled_mex_suffix for source_file in self.source_files ],
+            'files': [ source_file + '.' + self.compiled_mex_suffix for source_file in source_files ],
             'dirs': [],
         }
         super(EB_SPM, self).sanity_check_step(custom_paths=custom_paths)


### PR DESCRIPTION
A problem I ran into with this easyblock is that the zip-file when extracted has a name like 'spm8', which I think is quite ugly, so I tried to flatten it (equivalent of --strip-components=1 in tar). I am not sure why deleting the original directory after moving breaks the prepare step. Would be nice if someone could comment on this.

Also I am not sure if there is a better way to check if the MATLAB module is loaded.

Stuff that needs to be done before a merge:
- Clean out the compiled MATLAB files before building (there are precompiled versions included).
- Check if the MATLAB compiler takes some kind of compiler optimization flags.
- Probably update the license.
