### PR TITLE
add support for staged CPLEX installation

### DIFF
--- a/easybuild/easyblocks/c/cplex.py
+++ b/easybuild/easyblocks/c/cplex.py
@@ -56,6 +56,7 @@ class EB_CPLEX(Binary):
     @staticmethod
     def extra_options():
         extra_vars = [
+            # staged install via a tmp dir can help with the hard (potentially faulty) check on available disk space
             ('staged_install', [False, "Should the installation should be staged via a temporary dir?", CUSTOM]),
         ]
         return Binary.extra_options(extra_vars)


### PR DESCRIPTION
This may be required because CPLEX checked for available disk space (via a Java program, so it's hard to fool it), which may fail on NFS-mounted system (on our systems, CPLEX only sees 0.5MB of available space).
