### PR TITLE
disable extra source dirs requirement for GCC versions older than 4.5

### DIFF
--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -93,9 +93,7 @@ class EB_GCC(ConfigureMake):
         """
         Prepare extra (optional) source directories, so GCC will build these as well.
         """
-
         if LooseVersion(self.version) >= LooseVersion('4.5'):
-
             known_stages = ["stage1", "stage2", "stage3"]
             if not stage in known_stages:
                 self.log.error("Incorrect argument for prep_extra_src_dirs, should be one of: %s" % known_stages)


### PR DESCRIPTION
although the diff is big, only a couple of lines of code are added (the version check on 4.5 on top, and the else part at the bottom), the remainder is indentation

this is required for GCC versions prior to 4.5 (PR with easyconfigs coming up)
