### PR TITLE
Make cp fix

### DIFF
--- a/easybuild/easyblocks/generic/makecp.py
+++ b/easybuild/easyblocks/generic/makecp.py
@@ -85,7 +85,7 @@ class MakeCp(ConfigureMake):
 
                 # in this loop we expand expresions like
                 # files_to_copy = [(["scripts/*.sh"], 'bin')]
-		srcs = reduce(list.__add__, [glob.glob(src) for src in src])
+		srcs = reduce(list.__add__, [glob.glob(src) for src in srcs])
 
                 for src in srcs:
 		    # check if the file is in the root folder containing the sources


### PR DESCRIPTION
add support to search for files_to_copy in start_dir o in the root folder so we keep backward compatibility

this is not working. I only "works" when commenting out line 88, so no glob support   :|
