### PR TITLE
fix issues with installing RPMS when rpmrebuild is required

### DIFF
--- a/easybuild/easyblocks/generic/rpm.py
+++ b/easybuild/easyblocks/generic/rpm.py
@@ -174,7 +174,7 @@ class Rpm(Binary):
 
         if self.rebuildRPM:
             cmd_tpl = "rpm -i --dbpath %(inst)s/rpm %(force)s --relocate /=%(inst)s " \
-                      "%(pre)s %(post)s --nodeps %(rpm)s"
+                      "%(pre)s %(post)s --nodeps --ignorearch %(rpm)s"
         else:
             cmd_tpl = "rpm -i --dbpath /rpm %(force)s --root %(inst)s --relocate /=%(inst)s " \
                       "%(pre)s %(post)s --nodeps %(rpm)s"
@@ -185,12 +185,12 @@ class Rpm(Binary):
 
         for rpm in self.src:
             cmd = cmd_tpl % {
-                             'inst': self.installdir,
-                             'rpm': rpm['path'],
-                             'force': force,
-                             'pre': preinstall,
-                             'post': postinstall
-                            }
+                'inst': self.installdir,
+                'rpm': rpm['path'],
+                'force': force,
+                'pre': preinstall,
+                'post': postinstall,
+            }
             run_cmd(cmd, log_all=True, simple=True)
 
         for path in self.cfg['makesymlinks']:


### PR DESCRIPTION
this is required to be able to install the QLogicMPI RPMs, that are part of the `iqacml` toolchain, on SL6
