### PR TITLE
correctly disable parallel build for ATLAS

### DIFF
--- a/easybuild/easyblocks/a/atlas.py
+++ b/easybuild/easyblocks/a/atlas.py
@@ -157,8 +157,7 @@ Configure failed, not sure why (see output above).""" % out
 
         if self.cfg['parallel'] != 1:
             self.log.warning("Ignoring requested build parallelism, it breaks ATLAS, so setting to 1")
-        self.log.info("Disabling parallel build, makes no sense for ATLAS.")
-        self.cfg['parallel'] = 1
+            self.cfg['parallel'] = 1
 
         # default make is fine
         super(EB_ATLAS, self).build_step(verbose=verbose)


### PR DESCRIPTION
the `set_parallellism` method is moved and renamed as a part of https://github.com/hpcugent/easybuild-framework/pull/953, since it's not considered to be part of the easyblocks API

This patch tweaks the ATLAS easyblock to properly disable a parallel build.
