### PR TITLE
Make perlmodule take into account (pre){config,build,install}opts

### DIFF
--- a/easybuild/easyblocks/generic/perlmodule.py
+++ b/easybuild/easyblocks/generic/perlmodule.py
@@ -58,15 +58,15 @@ class PerlModule(ExtensionEasyBlock, ConfigureMake):
         # Perl modules have two possible installation procedures: using Makefile.PL and Build.PL
         # configure, build, test, install
         if os.path.exists('Makefile.PL'):
-            run_cmd('perl Makefile.PL PREFIX=%s' % self.installdir)
+            run_cmd('%s perl Makefile.PL PREFIX=%s %s' % (self.cfg['preconfigopts'], self.installdir, self.cfg['configopts']))
             ConfigureMake.build_step(self)
             ConfigureMake.test_step(self)
             ConfigureMake.install_step(self)
         elif os.path.exists('Build.PL'):
-            run_cmd('perl Build.PL --prefix %s' % self.installdir)
-            run_cmd('perl Build build')
+            run_cmd('%s perl Build.PL --prefix %s %s' % (self.cfg['preconfigopts'], self.installdir, self.cfg['configopts']))
+            run_cmd('%s perl Build build %s' % (self.cfg['prebuildopts'], self.cfg['buildopts']))
             run_cmd('perl Build test')
-            run_cmd('perl Build install')
+            run_cmd('%s perl Build install %s' % (self.cfg['preinstallopts'], self.cfg['installopts']))
 
     def run(self):
         """Perform the actual Perl module build/installation procedure"""


### PR DESCRIPTION
I not sure this is the right way. Maybe we have to define separate (pre)module{config,build,install}opts keywords not to mix with perl (pre){config,build,install}opts. For separate perl module installation it will work, but it might break old perl easyconfig files (where perl is installed with modules)
