### PR TITLE
6.5 doesnt include all 32-bit libs... disable sanity check for them

### DIFF
--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -81,7 +81,7 @@ class EB_CUDA(Binary):
 
         custom_paths = {
             'files': ["bin/%s" % x for x in ["fatbinary", "nvcc", "nvlink", "ptxas"]] +
-                     ["%s/lib%s.so" % (x, y) for x in ["lib", "lib64"] for y in ["cublas", "cudart", "cufft",
+                     ["%s/lib%s.so" % (x, y) for x in ["lib64"] for y in ["cublas", "cudart", "cufft",
                                                                                  "curand", "cusparse"]] +
                      ["open64/bin/nvopencc"],
             'dirs': ["include"],


### PR DESCRIPTION
Neither cuda_6.5.11_rc_linux_64.run  (release candidate) or cuda_6.5.1_rc_linux_64.run (released today) populate the /lib directory with all the files listed in the sanity test.  Disable check for 32-bit libs.
