### PR TITLE
made configure and make run async

### DIFF
--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -37,7 +37,7 @@ import os
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.environment import setvar
-from easybuild.tools.filetools import run_cmd
+from vsc.utils.run  import run_async_to_log_no_worries as run_cmd
 from easybuild.tools.modules import ROOT_ENV_VAR_NAME_PREFIX
 
 
@@ -99,6 +99,6 @@ class CMakeMake(ConfigureMake):
         options_string = " ".join(options)
 
         command = "%s cmake %s %s %s" % (self.cfg['preconfigopts'], srcdir, options_string, self.cfg['configopts'])
-        (out, _) = run_cmd(command, log_all=True, simple=False)
+        (out, _) = run_cmd(command)
 
         return out

--- a/easybuild/easyblocks/generic/configuremake.py
+++ b/easybuild/easyblocks/generic/configuremake.py
@@ -36,7 +36,7 @@ i.e. configure/make/make install, implemented as an easyblock.
 
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
-from easybuild.tools.filetools import run_cmd
+from vsc.utils.run import run_async_to_log_no_worries as run_cmd
 
 
 class ConfigureMake(EasyBlock):
@@ -87,7 +87,7 @@ class ConfigureMake(EasyBlock):
             'configopts': self.cfg['configopts'],
         }
 
-        (out, _) = run_cmd(cmd, log_all=True, simple=False)
+        (out, _) = run_cmd(cmd)
 
         return out
 
@@ -103,7 +103,7 @@ class ConfigureMake(EasyBlock):
 
         cmd = "%s make %s %s" % (self.cfg['prebuildopts'], paracmd, self.cfg['buildopts'])
 
-        (out, _) = run_cmd(cmd, log_all=True, simple=False, log_output=verbose)
+        (out, _) = run_cmd(cmd)
 
         return out
 
@@ -115,7 +115,7 @@ class ConfigureMake(EasyBlock):
 
         if self.cfg['runtest']:
             cmd = "make %s" % (self.cfg['runtest'])
-            (out, _) = run_cmd(cmd, log_all=True, simple=False)
+            (out, _) = run_cmd(cmd)
 
             return out
 
@@ -127,6 +127,6 @@ class ConfigureMake(EasyBlock):
 
         cmd = "%s make install %s" % (self.cfg['preinstallopts'], self.cfg['installopts'])
 
-        (out, _) = run_cmd(cmd, log_all=True, simple=False)
+        (out, _) = run_cmd(cmd)
 
         return out


### PR DESCRIPTION
- you can now see the output of the configure and make commands scroll by if you're in debug mode
- only in easyblocks derived from configuremake and cmakemake

depends on https://github.com/hpcugent/easybuild-framework/pull/1026
