### PR TITLE
verify installation of a dummy Python package before actually installing a Python package

### DIFF
--- a/easybuild/easyblocks/n/neuron.py
+++ b/easybuild/easyblocks/n/neuron.py
@@ -31,13 +31,13 @@ import os
 import re
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
-from easybuild.easyblocks.generic.pythonpackage import det_pylibdir
+from easybuild.easyblocks.generic.pythonpackage import det_pylibdir, PythonPackage
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.filetools import run_cmd, adjust_permissions
 from easybuild.tools.modules import get_software_root
 
 
-class EB_NEURON(ConfigureMake):
+class EB_NEURON(ConfigureMake, PythonPackage):
     """Support for building/installing NEURON."""
 
     def __init__(self, *args, **kwargs):
@@ -103,8 +103,7 @@ class EB_NEURON(ConfigureMake):
             except OSError, err:
                 self.log.error("Failed to change to %s: %s" % (pypath, err))
 
-            cmd = "python setup.py install --prefix=%s" % self.installdir
-            run_cmd(cmd, simple=True, log_all=True, log_ok=True)
+            PythonPackage.python_safe_install(self, preinstallopts='', installopts='')
 
             try:
                 os.chdir(pwd)

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -174,14 +174,12 @@ class EB_numpy(FortranPythonPackage):
 
         # temporarily install numpy, it doesn't alow to be used straight from the source dir
         tmpdir = tempfile.mkdtemp()
-        cmd = "python setup.py install --prefix=%s %s" % (tmpdir, self.installopts)
-        run_cmd(cmd, log_all=True, simple=True)
-
+        self.python_safe_install(prefix=tmpdir, installopts=self.installopts)
         try:
             pwd = os.getcwd()
             os.chdir(tmpdir)
         except OSError, err:
-            self.log.error("Faild to change to %s: %s" % (tmpdir, err))
+            self.log.error("Failed to change to %s: %s" % (tmpdir, err))
 
         # evaluate performance of numpy.dot (3 runs, 3 loops each)
         size = 1000

--- a/easybuild/easyblocks/v/vsc_tools.py
+++ b/easybuild/easyblocks/v/vsc_tools.py
@@ -40,20 +40,13 @@ class EB_VSC_minus_tools(PythonPackage):
 
     def build_step(self):
         """No build procedure for VSC-tools."""
-
         pass
 
     def install_step(self):
         """Custom install procedure for VSC-tools."""
 
-        args = "install --prefix=%(path)s --install-lib=%(path)s/lib" % {'path': self.installdir}
-
-        pylibdir = os.path.join(self.installdir, 'lib')
-        env.setvar('PYTHONPATH', '%s:%s' % (pylibdir, os.getenv('PYTHONPATH')))
-
+        self.pylibdir = 'lib'
         try:
-            os.mkdir(pylibdir)
-
             pwd = os.getcwd()
 
             pkg_list = ['-'.join(src['name'].split('-')[0:-1]) for src in self.src if src['name'].startswith('vsc')]
@@ -64,8 +57,7 @@ class EB_VSC_minus_tools(PythonPackage):
                     self.log.error("Found none or more than one %s dir in %s: %s" % (pkg, self.builddir, sel_dirs))
 
                 os.chdir(os.path.join(self.builddir, sel_dirs[0]))
-                cmd = "python setup.py %s" % args
-                run_cmd(cmd, log_all=True, simple=True, log_output=True)
+                self.python_safe_install(installopts='--install-lib=%s/lib' % self.installdir)
 
             os.chdir(pwd)
 
@@ -74,21 +66,18 @@ class EB_VSC_minus_tools(PythonPackage):
 
     def sanity_check_step(self):
         """Custom sanity check for VSC-tools."""
-
         custom_paths = {
-                        'files': ['bin/%s' % x for x in ['ihmpirun', 'impirun', 'logdaemon', 'm2hmpirun',
-                                                         'm2mpirun', 'mhmpirun', 'mmmpirun', 'mmpirun',
-                                                         'mympirun', 'mympisanity', 'myscoop', 'ompirun',
-                                                         'pbsssh', 'qmpirun', 'sshsleep', 'startlogdaemon',
-                                                         'fake/mpirun']],
-                        'dirs': ['lib'],
-                       }
-
+            'files': ['bin/%s' % x for x in ['ihmpirun', 'impirun', 'logdaemon', 'm2hmpirun',
+                                             'm2mpirun', 'mhmpirun', 'mmmpirun', 'mmpirun',
+                                             'mympirun', 'mympisanity', 'myscoop', 'ompirun',
+                                             'pbsssh', 'qmpirun', 'sshsleep', 'startlogdaemon',
+                                             'fake/mpirun']],
+            'dirs': ['lib'],
+        }
         super(EB_VSC_minus_tools, self).sanity_check_step(custom_paths=custom_paths)
 
     def make_module_extra(self):
         """Add install path to PYTHONPATH"""
-
         txt = super(EB_VSC_minus_tools, self).make_module_extra()
 
         txt += self.moduleGenerator.prepend_paths('PATH', ["bin/fake"])


### PR DESCRIPTION
After spending about 2h on trying to figure out why a particular `setuptools` installation was blatently ignoring `--prefix`, I was sufficiently frustrated to come up with this: a verification of whether whichever `setuptools` is active honors `--prefix` before actually installing a Python package with it.

Up until now, I've run into two different ways of making `setuptools` blatently ignore `--prefix`:
- via the `distutils.cfg` or `$HOME/.pydistutils.cfg` configuration files which effectively override any specified `--prefix` comand line option (cfr. https://docs.python.org/2/install/#distutils-configuration-files)
- by using a `setuptools` installation that was installed with `--user` into `$HOME/.local`, causing it to install everything to `$HOME/.local` regardless of what `--prefix` specifies (yes, you read that right)

Since there's little we can do to prevent the use of a (basically broken) `setuptools` installation (there's no way I'm aware of in which we can install our own and be 100% sure it'll be used), we better have a way of verifying whether the `active` setuptools does the right thing.

related: https://github.com/hpcugent/easybuild/issues/31, https://github.com/hpcugent/easybuild-easyblocks/issues/373 and last nights discussion with @kcgthb on the `#easybuild` IRC channel

@stdweird, @JensTimmerman: thoughts on this?

cc: @kcgthb, @chwilk, @DimitriSteyaert, @pforai, @ocaisa
