### PR TITLE
R ld library path

### DIFF
--- a/easybuild/easyblocks/r/r.py
+++ b/easybuild/easyblocks/r/r.py
@@ -66,7 +66,7 @@ class EB_R(ConfigureMake):
         guesses.update({
             'LD_LIBRARY_PATH': ['lib64', 'lib', 'lib64/R/lib', 'lib/R/lib'],
             'LIBRARY_PATH': ['lib64', 'lib', 'lib64/R/lib', 'lib/R/lib'],
-            'PKG_CONFIG_PATH': ['lib/pkgconfig', 'lib64/pkgconfig'],
+            'PKG_CONFIG_PATH': ['lib64/pkgconfig', 'lib/pkgconfig'],
         })
 
         return guesses


### PR DESCRIPTION
added extra paths for LD_LIBRARY_PATH, LIBRARY_PATH and PKG_CONFIG_PATH

I think if this PR is accepted this one can be closed: https://github.com/hpcugent/easybuild-easyconfigs/pull/1150

@boegel what do you think?
