### PR TITLE
GROMACS: build for target architecture based on optarch

### DIFF
--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -89,7 +89,9 @@ class EB_GROMACS(CMakeMake):
             comp_fam = self.toolchain.comp_family()
             optarch = optarch.get(comp_fam, '').upper()
 
-        if 'AVX2' in optarch and LooseVersion(self.version) >= LooseVersion('5.0'):
+        if 'AVX512' in optarch and LooseVersion(self.version) >= LooseVersion('2016'):
+            res = 'AVX_512'
+        elif 'AVX2' in optarch and LooseVersion(self.version) >= LooseVersion('5.0'):
             res = 'AVX2_256'
         elif 'AVX' in optarch:
             res = 'AVX_256'

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -44,6 +44,7 @@ from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.config import build_option
 from easybuild.tools.filetools import download_file, extract_file, which
 from easybuild.tools.modules import get_software_libdir, get_software_root
 from easybuild.tools.run import run_cmd
@@ -122,6 +123,13 @@ class EB_GROMACS(CMakeMake):
 
             # disable GUI tools
             self.cfg.update('configopts', "-DGMX_X11=OFF")
+
+            # convince to build for an older architecture then present on the build node by setting GMX_SIMD CMake flag.
+            if build_option('optarch', default=None) and self.toolchain.comp_family() in build_option('optarch'):
+                build_arch = build_option('optarch')[self.toolchain.comp_family()]
+                gmx_simd = self.get_gromacs_arch(build_arch)
+                if gmx_simd:
+                    self.cfg.update('configopts', "-DGMX_SIMD=%s" % gmx_simd)
 
             # set regression test path
             prefix = 'regressiontests'
@@ -357,3 +365,26 @@ class EB_GROMACS(CMakeMake):
             'dirs': dirs,
         }
         super(EB_GROMACS, self).sanity_check_step(custom_paths=custom_paths)
+
+    @staticmethod
+    def get_gromacs_arch(build_arch):
+        """Determine value of GMX_SIMD CMake flag based on optarch string.
+
+        Refs:
+        [0] http://manual.gromacs.org/documentation/2016.3/install-guide/index.html#typical-installation
+        [1] http://manual.gromacs.org/documentation/2016.3/install-guide/index.html#simd-support
+        [2] http://www.gromacs.org/Documentation/Acceleration_and_parallelization
+        """
+        build_arch = build_arch.upper()
+        if build_arch.endswith(("AVX2")):
+            return "AVX2_256"
+        elif build_arch.endswith(("AVX")):
+            return "AVX_256"
+        elif build_arch.endswith(("SSE3" ,"SSE2") or build_arch.contains("MARCH=NOCONA")):
+            # Gromacs doesn't have any GMX_SIMD=SSE3 but only SSE2 and SSE4.1 [1].
+            # According to [2] the performance difference between SSE2 and SSE4.1 is minor on x86
+            # and SSE4.1 is not supported by AMD Magny-Cours[1].
+            return "SSE2"
+        else:
+            # fall back on autodetection
+            return None

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -129,7 +129,10 @@ class EB_GROMACS(CMakeMake):
                 build_arch = build_option('optarch')[self.toolchain.comp_family()]
                 gmx_simd = self.get_gromacs_arch(build_arch)
                 if gmx_simd:
-                    self.cfg.update('configopts', "-DGMX_SIMD=%s" % gmx_simd)
+                    if LooseVersion(self.version) < LooseVersion('5.0'):
+                        self.cfg.update('configopts', "-DGMX_CPU_ACCELERATION=%s" % gmx_simd)
+                    else:
+                        self.cfg.update('configopts', "-DGMX_SIMD=%s" % gmx_simd)
 
             # set regression test path
             prefix = 'regressiontests'
@@ -366,8 +369,7 @@ class EB_GROMACS(CMakeMake):
         }
         super(EB_GROMACS, self).sanity_check_step(custom_paths=custom_paths)
 
-    @staticmethod
-    def get_gromacs_arch(build_arch):
+    def get_gromacs_arch(self, build_arch):
         """Determine value of GMX_SIMD CMake flag based on optarch string.
 
         Refs:
@@ -376,7 +378,7 @@ class EB_GROMACS(CMakeMake):
         [2] http://www.gromacs.org/Documentation/Acceleration_and_parallelization
         """
         build_arch = build_arch.upper()
-        if build_arch.endswith(("AVX2")):
+        if build_arch.endswith(("AVX2")) and not LooseVersion(self.version) < LooseVersion('5.0'):
             return "AVX2_256"
         elif build_arch.endswith(("AVX")):
             return "AVX_256"


### PR DESCRIPTION
Gromac's CMake tries persistently to detect the CPU capabilities on the build node, which makes
problems if the target platform is older than that of the build node.

This patch therefore selects appopriate GMX_SIMD cmake flags based on flags present in the optarch
string (originating from `EASYBUILD_OPTARCH`).  If no known flags are found, it falls back to cmake's auto detection of capabilities on the build node.