### PR TITLE
Update sanity tests for OpenFOAM, add logging

### DIFF
--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -329,12 +329,12 @@ class EB_OpenFOAM(EasyBlock):
 
         # some randomly selected binaries
         # if one of these is missing, it's very likely something went wrong
-        bins = [os.path.join(self.openfoamdir, "bin", x) for x in ["foamExec", "paraFoam"]] + \
+        bins = [os.path.join(self.openfoamdir, "bin", x) for x in ["paraFoam"]] + \
                [os.path.join(toolsdir, "buoyant%sSimpleFoam" % x) for x in ["", "Boussinesq"]] + \
                [os.path.join(toolsdir, "%sFoam" % x) for x in ["boundary", "engine", "sonic"]] + \
                [os.path.join(toolsdir, "surface%s" % x) for x in ["Add", "Find", "Smooth"]] + \
-               [os.path.join(toolsdir, x) for x in ["deformedGeom", "engineSwirl", "modifyMesh",
-                                                    "refineMesh", "wdot"]]
+               [os.path.join(toolsdir, x) for x in ["checkMesh", "deformedGeom", "engineSwirl",
+                                                    "modifyMesh", "refineMesh"]]
         # check for the Pstream and scotchDecomp libraries, there must be a dummy one and an mpi one
         if 'extend' in self.name.lower():
             libs = [os.path.join(libsdir, "libscotchDecomp.%s" % shlib_ext),

--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -281,6 +281,9 @@ class EB_OpenFOAM(EasyBlock):
                 "Cleaning .*",
             ]
             run_cmd_qa(cmd_tmpl % 'Allwmake.firstInstall', qa, no_qa=noqa, log_all=True, simple=True)
+        elif LooseVersion(self.version) >= LooseVersion('1600'):
+            # Use Allwmake -log option if possible since this can be useful during builds, but also afterwards
+            run_cmd(cmd_tmpl % 'Allwmake -log', log_all=True, simple=True, log_output=True)
         else:
             run_cmd(cmd_tmpl % 'Allwmake', log_all=True, simple=True, log_output=True)
 


### PR DESCRIPTION
- this allows redirection of the Allwmake output to a log file so that
  it is possible to debug any errors with the build process and have a
  record of the configured build options.