### PR TITLE
remove 'provides' line from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,6 @@ setup(
         "Topic :: Software Development :: Build Tools",
     ],
     platforms = "Linux",
-    provides = ["easybuild", "easybuild.easyblocks", "easybuild.easyblocks.generic"],
     install_requires = [
         'setuptools >= 0.6',
         "easybuild-framework >= %s" % API_VERSION,


### PR DESCRIPTION
I had to remove the `provides` line from `setup.py` in order to be able to release EasyBuild v3.3.1 with a recent version of `setuptools`, to work around this problem:

```
Upload failed (400): provides: Must be a valid Python identifier.
error: Upload failed (400): provides: Must be a valid Python identifier.
```

As far as I can tell, no information is lost by dropping this line.