### PR TITLE
fix PYTHONPATH for OpenBabel Python bindings

### DIFF
--- a/easybuild/easyblocks/o/openbabel.py
+++ b/easybuild/easyblocks/o/openbabel.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -30,6 +30,7 @@ EasyBuild support for OpenBabel, implemented as an easyblock
 """
 import os
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
+from easybuild.easyblocks.generic.pythonpackage import det_pylibdir
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.systemtools import get_shared_lib_ext
@@ -41,7 +42,7 @@ class EB_OpenBabel(CMakeMake):
     @staticmethod
     def extra_options():
         extra_vars = {
-            'try_python': [True, "Try to build Open Babel's Python bindings. (-DPYTHON_BINDINGS=ON)", CUSTOM],
+            'with_python_bindings': [True, "Try to build Open Babel's Python bindings. (-DPYTHON_BINDINGS=ON)", CUSTOM],
         }
         return CMakeMake.extra_options(extra_vars)
 
@@ -60,7 +61,7 @@ class EB_OpenBabel(CMakeMake):
         self.cfg['configopts'] += "-DBUILD_GUI=OFF "
 
         root_python = get_software_root('Python')
-        if root_python and self.cfg['try_python']:
+        if root_python and self.cfg['with_python_bindings']:
             self.log.info("Enabling Python bindings")
             self.with_python = True
             shortpyver = '.'.join(get_software_version('Python').split('.')[:2])
@@ -70,7 +71,6 @@ class EB_OpenBabel(CMakeMake):
             self.cfg['configopts'] += "-DPYTHON_INCLUDE_DIR=%s/include/python%s " % (root_python, shortpyver)
         else:
             self.log.info("Not enabling Python bindings")
-            self.with_python = False
 
         root_eigen = get_software_root("Eigen")
         if root_eigen:
@@ -96,8 +96,7 @@ class EB_OpenBabel(CMakeMake):
             if LooseVersion(self.version) >= LooseVersion('2.4'):
                 # since OpenBabel 2.4.0 the Python bindings under 
                 # ${PREFIX}/lib/python2.7/site-packages  rather than ${PREFIX}/lib
-                shortpyver = '.'.join(get_software_version('Python').split('.')[:2])
-                ob_pythonpath = 'lib/python%s/site-packages/' % (shortpyver)
+                ob_pythonpath = det_pylibdir()
             else:
                 ob_pythonpath = 'lib'
             txt += self.module_generator.prepend_paths('PYTHONPATH', [ob_pythonpath])

--- a/easybuild/easyblocks/o/openbabel.py
+++ b/easybuild/easyblocks/o/openbabel.py
@@ -26,12 +26,13 @@
 EasyBuild support for OpenBabel, implemented as an easyblock
 
 @author: Ward Poelmans (Ghent University)
+@author: Oliver Stueker (Compute Canada/ACENET)
 """
 import os
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.systemtools import get_shared_lib_ext
-
+from distutils.version import LooseVersion
 
 class EB_OpenBabel(CMakeMake):
     """Support for installing the OpenBabel package."""
@@ -75,8 +76,15 @@ class EB_OpenBabel(CMakeMake):
 
     def make_module_extra(self):
         """Custom variables for OpenBabel module."""
+        if LooseVersion(self.version) >= LooseVersion('2.4'):
+            # since OpenBabel 2.4.0 the Python bindings under 
+            # ${PREFIX}/lib/python2.7/site-packages  rather than ${PREFIX}/lib
+            shortpyver = '.'.join(get_software_version('Python').split('.')[:2])
+            ob_pythonpath = 'lib/python%s/site-packages/' % (shortpyver)
+        else:
+            ob_pythonpath = 'lib'
         txt = super(EB_OpenBabel, self).make_module_extra()
-        txt += self.module_generator.prepend_paths('PYTHONPATH', ['lib'])
+        txt += self.module_generator.prepend_paths('PYTHONPATH', [ob_pythonpath])
         babel_libdir = os.path.join(self.installdir, 'lib', 'openbabel', self.version)
         txt += self.module_generator.set_environment('BABEL_LIBDIR', babel_libdir)
         babel_datadir = os.path.join(self.installdir, 'share', 'openbabel', self.version)

--- a/easybuild/easyblocks/o/openbabel.py
+++ b/easybuild/easyblocks/o/openbabel.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# https://github.com/easybuilders/easybuild
+# http://github.com/hpcugent/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -44,6 +44,11 @@ class EB_OpenBabel(CMakeMake):
             'try_python': [True, "Try to build Open Babel's Python bindings. (-DPYTHON_BINDINGS=ON)", CUSTOM],
         }
         return CMakeMake.extra_options(extra_vars)
+
+    def __init__(self, *args, **kwargs):
+        """Initialize OpenBabel-specific variables."""
+        super(EB_OpenBabel, self).__init__(*args, **kwargs)
+        self.with_python = False
 
     def configure_step(self):
 


### PR DESCRIPTION
From OpenBabel 2.4.0 on, the Python bindings are no longer installed directly in `${PREFIX}/lib` but rather under `${PREFIX}/lib/python2.7/site-packages` (for 2.7 Python).

This commit sets the correct PYTHONPATH in the generated module.