### PR TITLE
Fixed wrong use of build_type in self.cfg that resulted in an exception raised

### DIFF
--- a/easybuild/easyblocks/w/wrf.py
+++ b/easybuild/easyblocks/w/wrf.py
@@ -238,7 +238,7 @@ class EB_WRF(EasyBlock):
 
             if self.cfg['buildtype'] in self.parallel_build_types and not build_option('mpi_tests'):
                 self.log.info("Skipping testing of WRF with build type '%s' since MPI testing is disabled",
-                              self.cfg['build_type'])
+                              self.cfg['buildtype'])
                 return
 
             # get list of WRF test cases


### PR DESCRIPTION
The correct easyconfig parameter is `buildtype` not `build_type`