### PR TITLE
Updated VTune easyblock to behave like sourcing the amplxe-vars.sh script

### DIFF
--- a/easybuild/easyblocks/a/advisor.py
+++ b/easybuild/easyblocks/a/advisor.py
@@ -42,16 +42,16 @@ class EB_Advisor(IntelBase):
         """Constructor, initialize class variables."""
         super(EB_Advisor, self).__init__(*args, **kwargs)
         if LooseVersion(self.version) < LooseVersion('2017'):
-            self.base_path = 'advisor_xe'
+            self.subdir = 'advisor_xe'
         else:
-            self.base_path = 'advisor'
+            self.subdir = 'advisor'
 
     def make_module_req_guess(self):
         """Find reasonable paths for Advisor"""
-        return _make_module_req_guess_tools(self)
+        return self.get_guesses_tools()
 
     def sanity_check_step(self):
         """Custom sanity check paths for Advisor"""
         binaries = ['advixe-cl', 'advixe-feedback', 'advixe-gui', 'advixe-runss', 'advixe-runtrc', 'advixe-runtc']
-        custom_paths = _get_custom_paths_tools(self,binaries)
+        custom_paths = self.get_custom_paths_tools(binaries)
         super(EB_Advisor, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/a/advisor.py
+++ b/easybuild/easyblocks/a/advisor.py
@@ -48,29 +48,12 @@ class EB_Advisor(IntelBase):
         else:
             self.base_path = 'advisor'
 
+    def make_module_req_guess(self):
+        """Find reasonable paths for Advisor"""
+        return _make_module_req_guess_tools(self)
+
     def sanity_check_step(self):
         """Custom sanity check paths for Advisor"""
-
-        custom_paths = {
-            'files': [],
-            'dirs': ['%s/bin64' % self.base_path, '%s/lib64' % self.base_path]
-        }
-
+        binaries = ['advixe-cl', 'advixe-feedback', 'advixe-gui', 'advixe-runss', 'advixe-runtrc', 'advixe-runtc']
+        custom_paths = _get_custom_paths_tools(self,binaries)
         super(EB_Advisor, self).sanity_check_step(custom_paths=custom_paths)
-
-    def make_module_req_guess(self):
-        """
-        A dictionary of possible directories to look for
-        """
-        guesses = super(EB_Advisor, self).make_module_req_guess()
-
-        guesses['PATH'] = [os.path.join(self.subdir, 'bin64')]
-
-        # make sure $CPATH, $LD_LIBRARY_PATH and $LIBRARY_PATH are not updated in generated module file,
-        # because that leads to problem when the libraries included with Advisor are being picked up
-        for key in ['CPATH', 'LD_LIBRARY_PATH', 'LIBRARY_PATH']:
-            if key in guesses:
-                self.log.debug("Purposely not updating $%s in Advisor module file", key)
-                del guesses[key]
-
-        return guesses

--- a/easybuild/easyblocks/a/advisor.py
+++ b/easybuild/easyblocks/a/advisor.py
@@ -29,8 +29,6 @@ EasyBuild support for installing the Intel Advisor XE, implemented as an easyblo
 @author: Damian Alvarez (Forschungszentrum Juelich GmbH)
 """
 
-import os
-
 from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.intelbase import IntelBase

--- a/easybuild/easyblocks/a/advisor.py
+++ b/easybuild/easyblocks/a/advisor.py
@@ -61,16 +61,18 @@ class EB_Advisor(IntelBase):
         A dictionary of possible directories to look for
         """
         guesses = super(EB_Advisor, self).make_module_req_guess()
+        # List of environment variables that the module shouldn't set
+        do_not_set = ['CPATH', 'LD_LIBRARY_PATH', 'LIBRARY_PATH']
 
         lib_path = '%s/lib64' % self.base_path
         include_path = '%s/include' % self.base_path
  
         guesses.update({
-            'CPATH': [include_path],
-            'INCLUDE': [include_path],
-            'LD_LIBRARY_PATH': [lib_path],
-            'LIBRARY_PATH': [lib_path],
             'PATH': ['%s/bin64' % self.base_path],
         })
+
+        for ev in do_not_set:
+            if ev in guesses:
+                del guesses[ev]
 
         return guesses

--- a/easybuild/easyblocks/a/advisor.py
+++ b/easybuild/easyblocks/a/advisor.py
@@ -29,6 +29,8 @@ EasyBuild support for installing the Intel Advisor XE, implemented as an easyblo
 @author: Damian Alvarez (Forschungszentrum Juelich GmbH)
 """
 
+import os
+
 from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.intelbase import IntelBase

--- a/easybuild/easyblocks/a/advisor.py
+++ b/easybuild/easyblocks/a/advisor.py
@@ -61,18 +61,14 @@ class EB_Advisor(IntelBase):
         A dictionary of possible directories to look for
         """
         guesses = super(EB_Advisor, self).make_module_req_guess()
-        # List of environment variables that the module shouldn't set
-        do_not_set = ['CPATH', 'LD_LIBRARY_PATH', 'LIBRARY_PATH']
 
-        lib_path = '%s/lib64' % self.base_path
-        include_path = '%s/include' % self.base_path
- 
-        guesses.update({
-            'PATH': ['%s/bin64' % self.base_path],
-        })
+        guesses['PATH'] = [os.path.join(self.subdir, 'bin64')]
 
-        for ev in do_not_set:
-            if ev in guesses:
-                del guesses[ev]
+        # make sure $CPATH, $LD_LIBRARY_PATH and $LIBRARY_PATH are not updated in generated module file,
+        # because that leads to problem when the libraries included with Advisor are being picked up
+        for key in ['CPATH', 'LD_LIBRARY_PATH', 'LIBRARY_PATH']:
+            if key in guesses:
+                self.log.debug("Purposely not updating $%s in Advisor module file", key)
+                del guesses[key]
 
         return guesses

--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -32,6 +32,7 @@ Generic EasyBuild support for installing Intel tools, implemented as an easybloc
 @author: Jens Timmerman (Ghent University)
 @author: Ward Poelmans (Ghent University)
 @author: Lumir Jasiok (IT4Innovations)
+@author: Damian Alvarez (Forschungszentrum Juelich GmbH)
 """
 
 import os
@@ -110,6 +111,42 @@ class IntelBase(EasyBlock):
         self.home_subdir_local = os.path.join(common_tmp_dir, os.getenv('USER'), 'easybuild_intel')
 
         self.install_components = None
+
+    def _get_guesses_tools(self):
+        """Find reasonable paths for a subset of Intel tools, ignoring CPATH, LD_LIBRARY_PATH and LIBRARY_PATH"""
+
+        guesses = super(IntelBase, self).make_module_req_guess()
+
+        if self.cfg['m32']:
+            guesses['PATH'] = [os.path.join(self.subdir, 'bin32')]
+        else:
+            guesses['PATH'] = [os.path.join(self.subdir, 'bin64')]
+
+        guesses['MANPATH'] = [os.path.join(self.subdir, 'man')]
+
+        # make sure $CPATH, $LD_LIBRARY_PATH and $LIBRARY_PATH are not updated in generated module file,
+        # because that leads to problem when the libraries included with VTune/Advisor/Inspector are being picked up
+        for key in ['CPATH', 'LD_LIBRARY_PATH', 'LIBRARY_PATH']:
+            if key in guesses:
+                self.log.debug("Purposely not updating $%s in %s module file", key, self.name)
+                del guesses[key]
+
+        return guesses
+
+    def _get_custom_paths_tools(self, binaries):
+        """Custom sanity check paths for certain Intel tools."""
+        if self.cfg['m32']:
+            files = [os.path.join('bin32', b) for b in binaries]
+            dirs = ['lib32', 'include']
+        else:
+            files = [os.path.join('bin64', b) for b in binaries]
+            dirs = ['lib64', 'include']
+
+        custom_paths = {
+            'files': [os.path.join(self.subdir, f) for f in files],
+            'dirs': [os.path.join(self.subdir, d) for d in dirs],
+        }
+        return custom_paths
 
     @staticmethod
     def extra_options(extra_vars=None):

--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -112,7 +112,7 @@ class IntelBase(EasyBlock):
 
         self.install_components = None
 
-    def _get_guesses_tools(self):
+    def get_guesses_tools(self):
         """Find reasonable paths for a subset of Intel tools, ignoring CPATH, LD_LIBRARY_PATH and LIBRARY_PATH"""
 
         guesses = super(IntelBase, self).make_module_req_guess()
@@ -133,7 +133,7 @@ class IntelBase(EasyBlock):
 
         return guesses
 
-    def _get_custom_paths_tools(self, binaries):
+    def get_custom_paths_tools(self, binaries):
         """Custom sanity check paths for certain Intel tools."""
         if self.cfg['m32']:
             files = [os.path.join('bin32', b) for b in binaries]
@@ -420,7 +420,7 @@ class IntelBase(EasyBlock):
             shutil.rmtree(os.path.join(self.installdir, self.name))
         except OSError, err:
             raise EasyBuildError("Failed to move contents of %s to %s: %s", subdir, self.installdir, err)
-    
+
     def sanity_check_rpath(self):
         """Skip the rpath sanity check, this is binary software"""
         self.log.info("RPATH sanity check is skipped when using %s easyblock (derived from IntelBase)",

--- a/easybuild/easyblocks/i/inspector.py
+++ b/easybuild/easyblocks/i/inspector.py
@@ -44,10 +44,10 @@ class EB_Inspector(IntelBase):
 
         # recent versions of Inspector are installed to a subdirectory
         self.subdir = ''
-        if LooseVersion(self.version) >= LooseVersion('2013_update7') and \
-           LooseVersion(self.version) < LooseVersion('2017'):
+        loosever = LooseVersion(self.version)
+        if loosever >= LooseVersion('2013_update7') and loosever < LooseVersion('2017'):
             self.subdir = 'inspector_xe'
-        elif LooseVersion(self.version) >= LooseVersion('2017'):
+        elif loosever >= LooseVersion('2017'):
             self.subdir = 'inspector'
 
     def make_installdir(self):
@@ -72,10 +72,10 @@ class EB_Inspector(IntelBase):
 
     def make_module_req_guess(self):
         """Find reasonable paths for Inspector"""
-        return _get_guesses_tools(self)
+        return self.get_guesses_tools()
 
     def sanity_check_step(self):
         """Custom sanity check paths for Intel Inspector."""
         binaries = ['inspxe-cl', 'inspxe-feedback', 'inspxe-gui', 'inspxe-runmc', 'inspxe-runtc']
-        custom_paths = _get_custom_paths_tools(self, binaries)
+        custom_paths = self.get_custom_paths_tools(binaries)
         super(EB_Inspector, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/i/inspector.py
+++ b/easybuild/easyblocks/i/inspector.py
@@ -28,7 +28,6 @@ EasyBuild support for installing Intel Inspector, implemented as an easyblock
 @author: Kenneth Hoste (Ghent University)
 @author: Damian Alvarez (Forschungzentrum Juelich GmbH)
 """
-import os
 from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.intelbase import IntelBase, ACTIVATION_NAME_2012, LICENSE_FILE_NAME_2012

--- a/easybuild/easyblocks/i/inspector.py
+++ b/easybuild/easyblocks/i/inspector.py
@@ -26,6 +26,7 @@
 EasyBuild support for installing Intel Inspector, implemented as an easyblock
 
 @author: Kenneth Hoste (Ghent University)
+@author: Damian Alvarez (Forschungzentrum Juelich GmbH)
 """
 import os
 from distutils.version import LooseVersion
@@ -75,24 +76,25 @@ class EB_Inspector(IntelBase):
         """
 
         guesses = super(EB_Inspector, self).make_module_req_guess()
+        # List of environment variables that the module shouldn't set
+        do_not_set = ['CPATH', 'LD_LIBRARY_PATH', 'LIBRARY_PATH']
 
         if self.cfg['m32']:
             guesses.update({
                 'PATH': [os.path.join(self.subdir, 'bin32')],
-                'LD_LIBRARY_PATH': [os.path.join(self.subdir, 'lib32')],
-                'LIBRARY_PATH': [os.path.join(self.subdir, 'lib32')],
             })
         else:
             guesses.update({
                 'PATH': [os.path.join(self.subdir, 'bin64')],
-                'LD_LIBRARY_PATH': [os.path.join(self.subdir, 'lib64')],
-                'LIBRARY_PATH': [os.path.join(self.subdir, 'lib64')],
             })
 
         guesses.update({
-            'CPATH': [os.path.join(self.subdir, 'include')],
             'MANPATH': [os.path.join(self.subdir, 'man')],
         })
+
+        for ev in do_not_set:
+            if ev in guesses:
+                del guesses[ev]
 
         return guesses
 

--- a/easybuild/easyblocks/i/inspector.py
+++ b/easybuild/easyblocks/i/inspector.py
@@ -76,25 +76,20 @@ class EB_Inspector(IntelBase):
         """
 
         guesses = super(EB_Inspector, self).make_module_req_guess()
-        # List of environment variables that the module shouldn't set
-        do_not_set = ['CPATH', 'LD_LIBRARY_PATH', 'LIBRARY_PATH']
 
         if self.cfg['m32']:
-            guesses.update({
-                'PATH': [os.path.join(self.subdir, 'bin32')],
-            })
+            guesses['PATH'] = [os.path.join(self.subdir, 'bin32')]
         else:
-            guesses.update({
-                'PATH': [os.path.join(self.subdir, 'bin64')],
-            })
+            guesses['PATH'] = [os.path.join(self.subdir, 'bin64')]
 
-        guesses.update({
-            'MANPATH': [os.path.join(self.subdir, 'man')],
-        })
+        guesses['MANPATH'] = [os.path.join(self.subdir, 'man')]
 
-        for ev in do_not_set:
-            if ev in guesses:
-                del guesses[ev]
+        # make sure $CPATH, $LD_LIBRARY_PATH and $LIBRARY_PATH are not updated in generated module file,
+        # because that leads to problem when the libraries included with Inspector are being picked up
+        for key in ['CPATH', 'LD_LIBRARY_PATH', 'LIBRARY_PATH']:
+            if key in guesses:
+                self.log.debug("Purposely not updating $%s in Inspector module file", key)
+                del guesses[key]
 
         return guesses
 

--- a/easybuild/easyblocks/i/inspector.py
+++ b/easybuild/easyblocks/i/inspector.py
@@ -45,7 +45,8 @@ class EB_Inspector(IntelBase):
 
         # recent versions of Inspector are installed to a subdirectory
         self.subdir = ''
-        if LooseVersion(self.version) >= LooseVersion('2013_update7') and LooseVersion(self.version) < LooseVersion('2017'):
+        if LooseVersion(self.version) >= LooseVersion('2013_update7') and \
+           LooseVersion(self.version) < LooseVersion('2017'):
             self.subdir = 'inspector_xe'
         elif LooseVersion(self.version) >= LooseVersion('2017'):
             self.subdir = 'inspector'
@@ -71,41 +72,11 @@ class EB_Inspector(IntelBase):
         super(EB_Inspector, self).install_step(silent_cfg_names_map=silent_cfg_names_map)
 
     def make_module_req_guess(self):
-        """
-        A dictionary of possible directories to look for
-        """
-
-        guesses = super(EB_Inspector, self).make_module_req_guess()
-
-        if self.cfg['m32']:
-            guesses['PATH'] = [os.path.join(self.subdir, 'bin32')]
-        else:
-            guesses['PATH'] = [os.path.join(self.subdir, 'bin64')]
-
-        guesses['MANPATH'] = [os.path.join(self.subdir, 'man')]
-
-        # make sure $CPATH, $LD_LIBRARY_PATH and $LIBRARY_PATH are not updated in generated module file,
-        # because that leads to problem when the libraries included with Inspector are being picked up
-        for key in ['CPATH', 'LD_LIBRARY_PATH', 'LIBRARY_PATH']:
-            if key in guesses:
-                self.log.debug("Purposely not updating $%s in Inspector module file", key)
-                del guesses[key]
-
-        return guesses
+        """Find reasonable paths for Inspector"""
+        return _get_guesses_tools(self)
 
     def sanity_check_step(self):
         """Custom sanity check paths for Intel Inspector."""
-
         binaries = ['inspxe-cl', 'inspxe-feedback', 'inspxe-gui', 'inspxe-runmc', 'inspxe-runtc']
-        if self.cfg['m32']:
-            files = [os.path.join('bin32', b) for b in binaries]
-            dirs = ['lib32', 'include']
-        else:
-            files = [os.path.join('bin64', b) for b in binaries]
-            dirs = ['lib64', 'include']
-
-        custom_paths = {
-            'files': [os.path.join(self.subdir, f) for f in files],
-            'dirs': [os.path.join(self.subdir, d) for d in dirs],
-        }
+        custom_paths = _get_custom_paths_tools(self, binaries)
         super(EB_Inspector, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/v/vtune.py
+++ b/easybuild/easyblocks/v/vtune.py
@@ -45,7 +45,8 @@ class EB_VTune(IntelBase):
 
         # recent versions of VTune are installed to a subdirectory
         self.subdir = ''
-        if LooseVersion(self.version) >= LooseVersion('2013_update12'):
+        if LooseVersion(self.version) >= LooseVersion('2013_update12') and \
+           LooseVersion(self.version) < LooseVersion('2018'):
             self.subdir = 'vtune_amplifier_xe'
         elif LooseVersion(self.version) >= LooseVersion('2018'):
             self.subdir = 'vtune_amplifier'

--- a/easybuild/easyblocks/v/vtune.py
+++ b/easybuild/easyblocks/v/vtune.py
@@ -44,10 +44,10 @@ class EB_VTune(IntelBase):
 
         # recent versions of VTune are installed to a subdirectory
         self.subdir = ''
-        if LooseVersion(self.version) >= LooseVersion('2013_update12') and \
-           LooseVersion(self.version) < LooseVersion('2018'):
+        loosever = LooseVersion(self.version)
+        if loosever >= LooseVersion('2013_update12') and loosever < LooseVersion('2018'):
             self.subdir = 'vtune_amplifier_xe'
-        elif LooseVersion(self.version) >= LooseVersion('2018'):
+        elif loosever >= LooseVersion('2018'):
             self.subdir = 'vtune_amplifier'
 
     def make_installdir(self):
@@ -72,10 +72,10 @@ class EB_VTune(IntelBase):
 
     def make_module_req_guess(self):
         """Find reasonable paths for VTune"""
-        return _get_guesses_tools(self)
+        return self.get_guesses_tools()
 
     def sanity_check_step(self):
         """Custom sanity check paths for VTune."""
         binaries = ['amplxe-cl', 'amplxe-feedback', 'amplxe-gui', 'amplxe-runss']
-        custom_paths = _get_custom_paths_tools(self, binaries)
+        custom_paths = self.get_custom_paths_tools(binaries)
         super(EB_VTune, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/v/vtune.py
+++ b/easybuild/easyblocks/v/vtune.py
@@ -26,6 +26,7 @@
 EasyBuild support for installing Intel VTune, implemented as an easyblock
 
 @author: Kenneth Hoste (Ghent University)
+@author: Damian Alvarez (Forschungzentrum Juelich GmbH)
 """
 import os
 from distutils.version import LooseVersion
@@ -73,24 +74,25 @@ class EB_VTune(IntelBase):
         """
 
         guesses = super(EB_VTune, self).make_module_req_guess()
+        # List of environment variables that the module shouldn't set
+        do_not_set = ['CPATH', 'LD_LIBRARY_PATH', 'LIBRARY_PATH']
 
         if self.cfg['m32']:
             guesses.update({
                 'PATH': [os.path.join(self.subdir, 'bin32')],
-                'LD_LIBRARY_PATH': [os.path.join(self.subdir, 'lib32')],
-                'LIBRARY_PATH': [os.path.join(self.subdir, 'lib32')],
             })
         else:
             guesses.update({
                 'PATH': [os.path.join(self.subdir, 'bin64')],
-                'LD_LIBRARY_PATH': [os.path.join(self.subdir, 'lib64')],
-                'LIBRARY_PATH': [os.path.join(self.subdir, 'lib64')],
             })
 
         guesses.update({
-            'CPATH': [os.path.join(self.subdir, 'include')],
             'MANPATH': [os.path.join(self.subdir, 'man')],
         })
+
+        for ev in do_not_set:
+            if ev in guesses:
+                del guesses[ev]
 
         return guesses
 

--- a/easybuild/easyblocks/v/vtune.py
+++ b/easybuild/easyblocks/v/vtune.py
@@ -28,7 +28,6 @@ EasyBuild support for installing Intel VTune, implemented as an easyblock
 @author: Kenneth Hoste (Ghent University)
 @author: Damian Alvarez (Forschungzentrum Juelich GmbH)
 """
-import os
 from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.intelbase import IntelBase, ACTIVATION_NAME_2012, LICENSE_FILE_NAME_2012

--- a/easybuild/easyblocks/v/vtune.py
+++ b/easybuild/easyblocks/v/vtune.py
@@ -43,10 +43,12 @@ class EB_VTune(IntelBase):
         """Easyblock constructor; define class variables."""
         super(EB_VTune, self).__init__(*args, **kwargs)
 
-        # recent versions of Inspector are installed to a subdirectory
+        # recent versions of VTune are installed to a subdirectory
         self.subdir = ''
         if LooseVersion(self.version) >= LooseVersion('2013_update12'):
             self.subdir = 'vtune_amplifier_xe'
+        elif LooseVersion(self.version) >= LooseVersion('2018'):
+            self.subdir = 'vtune_amplifier'
 
     def make_installdir(self):
         """Do not create installation directory, install script handles that already."""

--- a/easybuild/easyblocks/v/vtune.py
+++ b/easybuild/easyblocks/v/vtune.py
@@ -72,41 +72,11 @@ class EB_VTune(IntelBase):
         super(EB_VTune, self).install_step(silent_cfg_names_map=silent_cfg_names_map)
 
     def make_module_req_guess(self):
-        """
-        A dictionary of possible directories to look for
-        """
-
-        guesses = super(EB_VTune, self).make_module_req_guess()
-
-        if self.cfg['m32']:
-            guesses['PATH'] = [os.path.join(self.subdir, 'bin32')]
-        else:
-            guesses['PATH'] = [os.path.join(self.subdir, 'bin64')]
-
-        guesses['MANPATH'] = [os.path.join(self.subdir, 'man')]
-
-        # make sure $CPATH, $LD_LIBRARY_PATH and $LIBRARY_PATH are not updated in generated module file,
-        # because that leads to problem when the libraries included with VTune are being picked up
-        for key in ['CPATH', 'LD_LIBRARY_PATH', 'LIBRARY_PATH']:
-            if key in guesses:
-                self.log.debug("Purposely not updating $%s in VTune module file", key)
-                del guesses[key]
-
-        return guesses
+        """Find reasonable paths for VTune"""
+        return _get_guesses_tools(self)
 
     def sanity_check_step(self):
-        """Custom sanity check paths for Intel VTune."""
-
+        """Custom sanity check paths for VTune."""
         binaries = ['amplxe-cl', 'amplxe-feedback', 'amplxe-gui', 'amplxe-runss']
-        if self.cfg['m32']:
-            files = ['bin32/%s' % x for x in binaries]
-            dirs = ['lib32', 'include']
-        else:
-            files = ['bin64/%s' % x for x in binaries]
-            dirs = ['lib64', 'include']
-
-        custom_paths = {
-            'files': [os.path.join(self.subdir, f) for f in files],
-            'dirs': [os.path.join(self.subdir, d) for d in dirs],
-        }
+        custom_paths = _get_custom_paths_tools(self, binaries)
         super(EB_VTune, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/v/vtune.py
+++ b/easybuild/easyblocks/v/vtune.py
@@ -74,25 +74,20 @@ class EB_VTune(IntelBase):
         """
 
         guesses = super(EB_VTune, self).make_module_req_guess()
-        # List of environment variables that the module shouldn't set
-        do_not_set = ['CPATH', 'LD_LIBRARY_PATH', 'LIBRARY_PATH']
 
         if self.cfg['m32']:
-            guesses.update({
-                'PATH': [os.path.join(self.subdir, 'bin32')],
-            })
+            guesses['PATH'] = [os.path.join(self.subdir, 'bin32')]
         else:
-            guesses.update({
-                'PATH': [os.path.join(self.subdir, 'bin64')],
-            })
+            guesses['PATH'] = [os.path.join(self.subdir, 'bin64')]
 
-        guesses.update({
-            'MANPATH': [os.path.join(self.subdir, 'man')],
-        })
+        guesses['MANPATH'] = [os.path.join(self.subdir, 'man')]
 
-        for ev in do_not_set:
-            if ev in guesses:
-                del guesses[ev]
+        # make sure $CPATH, $LD_LIBRARY_PATH and $LIBRARY_PATH are not updated in generated module file,
+        # because that leads to problem when the libraries included with VTune are being picked up
+        for key in ['CPATH', 'LD_LIBRARY_PATH', 'LIBRARY_PATH']:
+            if key in guesses:
+                self.log.debug("Purposely not updating $%s in VTune module file", key)
+                del guesses[key]
 
         return guesses
 


### PR DESCRIPTION
(ie: do not add LD_LIBRARY_PATH, LIBRARY_PATH and CPATH)

Otherwise error like this appear:

``$PREFIX/VTune/2017_update4/vtune_amplifier_xe/lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by XXX)``