### PR TITLE
{chem} GAMESS-US: fix build hangs on mathlib selection.

### DIFF
--- a/easybuild/easyblocks/g/gamess_us.py
+++ b/easybuild/easyblocks/g/gamess_us.py
@@ -182,7 +182,7 @@ class EB_GAMESS_minus_US(EasyBlock):
             r"GAMESS build directory\? \[.*\] ": self.installdir,  # building in install directory
             r"Enter only the main version number, such as .*\nVersion\? ": fortran_ver,
             r".+gfortran version.\n( \n)?Please enter only the first decimal place, such as .*:": fortran_ver,
-            "Enter your choice of 'mkl' or .* 'none': ": mathlib,
+            r"Enter your choice of 'mkl' or .* 'none': ": mathlib,
         }
         run_cmd_qa(cmd, qa=qa, std_qa=stdqa, log_all=True, simple=True)
 


### PR DESCRIPTION
@boegel found and issue that without MKL the build hangs at:

> Enter your choice of 'mkl' or 'atlas' or 'acml' or 'pgiblas' or 'none':

See:
 https://github.com/easybuilders/easybuild-easyconfigs/pull/4912#issuecomment-327832302