### PR TITLE
fix function signature for fetch_extension_sources in OCaml easyblock

### DIFF
--- a/easybuild/easyblocks/o/ocaml.py
+++ b/easybuild/easyblocks/o/ocaml.py
@@ -98,7 +98,7 @@ class EB_OCaml(ConfigureMake):
         self.cfg['exts_filter'] = EXTS_FILTER_OCAML_PACKAGES
         super(EB_OCaml, self).prepare_for_extensions()
 
-    def fetch_extension_sources(self):
+    def fetch_extension_sources(self, *args, **kwargs):
         """Don't fetch extension sources, OPAM takes care of that (and archiving too)."""
         return [{'name': ext_name, 'version': ext_version} for ext_name, ext_version in self.cfg['exts_list']]
 


### PR DESCRIPTION
The function signature of `fetch_extension_sources` slightly changed by adding the optional argument `skip_checksums` to it in https://github.com/easybuilders/easybuild-framework/pull/2286.

Because the OCaml easyblock doesn't accept optional argument in its definition of the `fetch_extension_sources`, EasyBuild crashes when trying to download the sources for OCaml:

```
Traceback (most recent call last):
  File "/usr/lib64/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib64/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/prefix/lib/python2.6/site-packages/easybuild_framework-3.4.0.dev0-py2.7.egg/easybuild/main.py", line 484, in <module>
    main()
  File "/prefix/lib/python2.6/site-packages/easybuild_framework-3.4.0.dev0-py2.7.egg/easybuild/main.py", line 347, in main
    regtest_ok = regtest([path[0] for path in paths] or easyconfigs_pkg_paths, modtool)
  File "/prefix/lib/python2.7/site-packages/easybuild_framework-3.4.0.dev0-py2.7.egg/easybuild/tools/testing.py", line 125, in regtest
    build_easyconfigs_in_parallel(command, resolved, output_dir=output_dir)
  File "/prefix/lib/python2.7/site-packages/easybuild_framework-3.4.0.dev0-py2.7.egg/easybuild/tools/parallelbuild.py", line 94, in build_easyconfigs_in_parallel
    prepare_easyconfig(easyconfig)
  File "/prefix/lib/python2.7/site-packages/easybuild_framework-3.4.0.dev0-py2.7.egg/easybuild/tools/parallelbuild.py", line 211, in prepare_easyconfig
    easyblock_instance.fetch_step(skip_checksums=True)
  File "/prefix/lib/python2.7/site-packages/easybuild_framework-3.4.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 1612, in fetch_step
    self.exts = self.fetch_extension_sources(skip_checksums=skip_checksums)
TypeError: fetch_extension_sources() got an unexpected keyword argument 'skip_checksums'
```