### PR TITLE
avoid always including /usr/include to $CPATH in icc module

### DIFF
--- a/easybuild/easyblocks/i/icc.py
+++ b/easybuild/easyblocks/i/icc.py
@@ -228,8 +228,9 @@ class EB_icc(IntelBase):
 
         # on Debian/Ubuntu, /usr/include/x86_64-linux-gnu needs to be included in $CPATH for icc
         out, ec = run_cmd("gcc -print-multiarch", simple=False)
-        if ec == 0 and out:
-            multiarch_inc_dir = os.path.join('/usr', 'include', out.strip())
+        multiarch_inc_subdir = out.strip()
+        if ec == 0 and multiarch_inc_subdir:
+            multiarch_inc_dir = os.path.join('/usr', 'include', multiarch_inc_subdir)
             self.log.info("Adding multiarch include path %s to $CPATH in generated module file", multiarch_inc_dir)
             # system location must be appended at the end, so use append_paths
             txt += self.module_generator.append_paths('CPATH', [multiarch_inc_dir], allow_abs=True)


### PR DESCRIPTION
`gcc -multiarch` always prints a newline even if on a non-multiarch system, so we need to `.strip()` the output before checking it's non-empty, otherwise we always add `/usr/include` to `$CPATH` in the `icc` and `ifort` modules, which leads to compilation problems like:

```
/prefix/software/GCCcore/6.3.0/bin/../include/c++/6.3.0/cstdlib(75): catastrophic error: cannot open      source file "stdlib.h"
2604   #include_next <stdlib.h>
```

This slipped in with #1237.