### PR TITLE
allow that 'gcc -print-multiarch' fails in icc easyblock

### DIFF
--- a/easybuild/easyblocks/i/icc.py
+++ b/easybuild/easyblocks/i/icc.py
@@ -227,7 +227,7 @@ class EB_icc(IntelBase):
                 txt += self.module_generator.set_environment('INTEL_PYTHONHOME', intel_pythonhome)
 
         # on Debian/Ubuntu, /usr/include/x86_64-linux-gnu needs to be included in $CPATH for icc
-        out, ec = run_cmd("gcc -print-multiarch", simple=False)
+        out, ec = run_cmd("gcc -print-multiarch", simple=False, log_all=False, log_ok=False)
         multiarch_inc_subdir = out.strip()
         if ec == 0 and multiarch_inc_subdir:
             multiarch_inc_dir = os.path.join('/usr', 'include', multiarch_inc_subdir)


### PR DESCRIPTION
bugfix for #1237, `gcc -print-multiarch` may fail for old versions of (system) GCC