### PR TITLE
fix prefix subdirectory for older versions of icc (in particular 2011.3.174)

### DIFF
--- a/easybuild/easyblocks/i/icc.py
+++ b/easybuild/easyblocks/i/icc.py
@@ -176,6 +176,11 @@ class EB_icc(IntelBase):
 
             if LooseVersion(self.version) < LooseVersion('2016'):
                 prefix = 'composer_xe_%s' % self.version
+                # for some older versions, name of subdirectory is slightly different
+                if not os.path.isdir(os.path.join(self.installdir, prefix)):
+                    cand_prefix = 'composerxe-%s' % self.version
+                    if os.path.isdir(os.path.join(self.installdir, cand_prefix)):
+                        prefix = cand_prefix
 
                 # debugger is dependent on $INTEL_PYTHONHOME since version 2015 and newer
                 if LooseVersion(self.version) >= LooseVersion('2015'):


### PR DESCRIPTION
The `which icc` check fails because the subdirectory is slightly different for icc 2011.3.174, i.e. `composerxe-2011.3.174` rather than the usual `composer_xe_%(version)s`.

(test report in https://github.com/easybuilders/easybuild-easyconfigs/pull/5133 failed because this is missing)