### PR TITLE
fix for MXNet easyblock

### DIFF
--- a/easybuild/easyblocks/m/mxnet.py
+++ b/easybuild/easyblocks/m/mxnet.py
@@ -197,6 +197,7 @@ class EB_MXNet(MakeCp):
         if not self.py_ext.sanity_check_step():
             raise EasyBuildError("The sanity check for the Python bindings failed")
 
+        self.r_ext.options['modulename'] = self.name.lower()
         if not self.r_ext.sanity_check_step():
             raise EasyBuildError("The sanity check for the R bindings failed")
 

--- a/easybuild/easyblocks/m/mxnet.py
+++ b/easybuild/easyblocks/m/mxnet.py
@@ -87,14 +87,14 @@ class EB_MXNet(MakeCp):
         # Extract everything into separate directories.
         super(EB_MXNet, self).extract_step()
 
-        mxnet_dirs = glob.glob(os.path.join(self.builddir, 'mxnet-*'))
+        mxnet_dirs = glob.glob(os.path.join(self.builddir, '*mxnet-*'))
         if len(mxnet_dirs) == 1:
             self.mxnet_src_dir = mxnet_dirs[0]
             self.log.debug("MXNet dir is: %s", self.mxnet_src_dir)
         else:
             raise EasyBuildError("Failed to find/isolate MXNet source directory: %s", mxnet_dirs)
 
-        for srcdir in [d for d in os.listdir(self.builddir) if not d.startswith('mxnet-')]:
+        for srcdir in [d for d in os.listdir(self.builddir) if d != os.path.basename(self.mxnet_src_dir)]:
             submodule, _, _ = srcdir.rpartition('-')
             newdir = os.path.join(self.mxnet_src_dir, submodule)
             olddir = os.path.join(self.builddir, srcdir)


### PR DESCRIPTION
* change for `mxnet` unpacked subdir is required because upstream sources changed, see also https://github.com/easybuilders/easybuild-easyconfigs/pull/5162
* change to sanity check is required because of recent bug fix in framework (https://github.com/easybuilders/easybuild-framework/pull/2276)