### PR TITLE
use 'wcleanPlatform -all' rather than 'wcleanAll' for recent OpenFOAM versions

### DIFF
--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -257,7 +257,10 @@ class EB_OpenFOAM(EasyBlock):
         """Build OpenFOAM using make after sourcing script to set environment."""
 
         precmd = "source %s" % os.path.join(self.builddir, self.openfoamdir, "etc", "bashrc")
-        cleancmd = "wcleanAll"
+        if 'extend' not in self.name.lower() and LooseVersion(self.version) >= LooseVersion('4.0'):
+            cleancmd = "cd $WM_PROJECT_DIR && wcleanPlatform -all && cd -"
+        else:
+            cleancmd = "wcleanAll"
 
         # make directly in install directory
         cmd_tmpl = "%(precmd)s && %(cleancmd)s && %(prebuildopts)s %(makecmd)s" % {


### PR DESCRIPTION
For OpenFOAM 4.x, `wcleanAll` is no longer available and `wcleanPlatform -all` must be used (and it *must* be run in `$WM_PROJECT_DIR`).

For OpenFOAM-Extend 4.0, it still is (and `wcleanPlatform` is not).