### PR TITLE
Changed HPCG configure syntax for v3.0 support 

### DIFF
--- a/easybuild/easyblocks/h/hpcg.py
+++ b/easybuild/easyblocks/h/hpcg.py
@@ -50,10 +50,10 @@ class EB_HPCG(ConfigureMake):
         # configure with most generic configuration available, i.e. hybrid
         # this is not specific to GCC or OpenMP, we take full control over that via $CXX and $CXXFLAGS
         if LooseVersion(self.version) >= LooseVersion('3.0'):
-            cmd = "../configure MPI_GCC_OMP"
+            arg = "MPI_GCC_OMP"
         else:
-            cmd = "../configure ../setup/Make.MPI_GCC_OMP"
-        run_cmd(cmd, log_all=True, simple=True, log_ok=True, path='obj')
+            arg = "../setup/Make.MPI_GCC_OMP"
+        run_cmd("../configure %s" % arg, log_all=True, simple=True, log_ok=True, path='obj')
 
     def build_step(self):
         """Run build in build subdirectory."""

--- a/easybuild/easyblocks/h/hpcg.py
+++ b/easybuild/easyblocks/h/hpcg.py
@@ -37,6 +37,7 @@ from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option
 from easybuild.tools.filetools import mkdir
 from easybuild.tools.run import run_cmd
+from distutils.version import LooseVersion
 
 
 class EB_HPCG(ConfigureMake):
@@ -48,7 +49,10 @@ class EB_HPCG(ConfigureMake):
         mkdir("obj")
         # configure with most generic configuration available, i.e. hybrid
         # this is not specific to GCC or OpenMP, we take full control over that via $CXX and $CXXFLAGS
-        cmd = "../configure ../setup/Make.MPI_GCC_OMP" 
+        if LooseVersion(self.version) >= LooseVersion('3.0'):
+            cmd = "../configure MPI_GCC_OMP"
+        else:
+            cmd = "../configure ../setup/Make.MPI_GCC_OMP"
         run_cmd(cmd, log_all=True, simple=True, log_ok=True, path='obj')
 
     def build_step(self):


### PR DESCRIPTION
In `HPCG-3.0` the configure command syntax is different from the one implemented for previous versions. This solves the issue and keeps compatibility with older versions. 