### PR TITLE
pick up per-component checksums in Bundle generic easyblock

### DIFF
--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -99,6 +99,10 @@ class Bundle(EasyBlock):
                 # add per-component source_urls to list of bundle source_urls, expanding templates
                 self.cfg.update('source_urls', cfg['source_urls'])
 
+            if 'checksums' in comp_specs:
+                # add per-component checksums for checksums
+                self.cfg.update('checksums', cfg['checksums'])
+
             self.comp_cfgs.append(cfg)
 
         self.cfg.enable_templating = True


### PR DESCRIPTION
The per-component `sources` specs are injected into the 'parent' to handle unpacking, so we should do the same for `checksums`.

Required for https://github.com/easybuilders/easybuild-easyconfigs/pull/5265 when checksums are included for the different components.

cc @vanzod 