### PR TITLE
correctly configure R for BLAS/LAPACK & check configure output

### DIFF
--- a/easybuild/easyblocks/r/r.py
+++ b/easybuild/easyblocks/r/r.py
@@ -71,7 +71,7 @@ class EB_R(ConfigureMake):
             root = get_software_root(dep)
             if root:
                 dep_config = os.path.join(root, 'lib', '%sConfig.sh' % dep.lower())
-                self.cfg.update('configopts', '-with-%s-config=%s' % (dep.lower(), dep_config))
+                self.cfg.update('configopts', '--with-%s-config=%s' % (dep.lower(), dep_config))
 
         out = ConfigureMake.configure_step(self)
 


### PR DESCRIPTION
R is currently not being configured correctly, see https://github.com/easybuilders/easybuild-easyconfigs/issues/1435 and also https://github.com/easybuilders/easybuild-easyconfigs/issues/4773.

If `LAPACK_LIBS` is defined in `preconfigopts`, R reports that LAPACK is being built `generic`, which seems wrong (although it *may* be OK for LAPACK, since there are no tuned LAPACK libraries, all the tuning is done in the BLAS library afaik).

This change only defines `$BLAS_LIBS` in the environment, and checks the output of the configure command to make sure that BLAS/LAPACK is i) used, ii) correctly configured (i.e. no `generic`).

The R easyconfigs (in particular the recent https://github.com/easybuilders/easybuild-easyconfigs/pull/5090 and https://github.com/easybuilders/easybuild-easyconfigs/pull/5360)  will need to be modified as well, since they now hard set `LAPACK_LIBS` via `preconfigopts`, which leads to `LAPACK(generic)` being reported.

That's a bit of a catch-22 situation though, since removing `preconfigpts` part and not including `--with-blas --with-lapack` in the easyconfig files requires that this updated easyblock is used, otherwise R gets (sliently) built without BLAS/LAPACK...