### PR TITLE
maintain backward compatibility in R easyblock by hard linking with $LIBBLAS (for now)

### DIFF
--- a/easybuild/easyblocks/r/r.py
+++ b/easybuild/easyblocks/r/r.py
@@ -63,7 +63,7 @@ class EB_R(ConfigureMake):
         # define $BLAS_LIBS to build R correctly against BLAS/LAPACK library
         # $LAPACK_LIBS should *not* be specified since that may lead to using generic LAPACK
         # see https://github.com/easybuilders/easybuild-easyconfigs/issues/1435
-        env.setvar('BLAS_LIBS', os.getenv('LIBBLAS_MT'))
+        env.setvar('BLAS_LIBS', os.getenv('LIBBLAS'))
         self.cfg.update('configopts', "--with-blas --with-lapack")
 
         # make sure correct config script is used for Tcl/Tk


### PR DESCRIPTION
The hardcoded use of `$LIBBLAS` was replaced with using `$LIBBLAS_MT` instead in #1292, which is a backward incompatible change.

The idea is to allow tweaking this via a new toolchain option `mt_blas_lapack` (or equivalent approach), see discussion in https://github.com/easybuilders/easybuild-framework/issues/2350.
(see also https://github.com/easybuilders/easybuild-easyblocks/issues/202)

Until that is in place, we should stick to using `$LIBBLAS` to maintain backward compatibility.