### PR TITLE
set default java encoding to utf8 for Trinity

### DIFF
--- a/easybuild/easyblocks/t/trinity.py
+++ b/easybuild/easyblocks/t/trinity.py
@@ -73,7 +73,7 @@ class EB_Trinity(EasyBlock):
 
         self.log.info("Begin Butterfly")
 
-        setvar("-Dfile.encoding", "UTF8")
+        setvar("JAVA_TOOL_OPTIONS", "-Dfile.encoding=UTF8")
 
         dst = os.path.join(self.cfg['start_dir'], 'Butterfly', 'src')
         try:

--- a/easybuild/easyblocks/t/trinity.py
+++ b/easybuild/easyblocks/t/trinity.py
@@ -43,6 +43,7 @@ import easybuild.tools.toolchain as toolchain
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.environment import setvar
 from easybuild.tools.filetools import apply_regex_substitutions
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
@@ -71,6 +72,8 @@ class EB_Trinity(EasyBlock):
         """Install procedure for Butterfly."""
 
         self.log.info("Begin Butterfly")
+
+        setvar("-Dfile.encoding", "UTF8")
 
         dst = os.path.join(self.cfg['start_dir'], 'Butterfly', 'src')
         try:


### PR DESCRIPTION
This is needed to avoid compilation failure due to non-standard characters in java comments (see the Butterfly module).