### PR TITLE
explicitly set --with-x=no if X11 is not included as dependency in R easyblock

### DIFF
--- a/easybuild/easyblocks/r/r.py
+++ b/easybuild/easyblocks/r/r.py
@@ -75,6 +75,8 @@ class EB_R(ConfigureMake):
 
         if get_software_root('X11'):
             self.cfg.update('configopts', '--with-x=yes')
+        else:
+            self.cfg.update('configopts', '--with-x=no')
 
         # enable graphic capabilities for plotting, based on available dependencies
         for dep in ['Cairo', 'libjpeg-turbo', 'libpng', 'libtiff']:


### PR DESCRIPTION
R easyconfig that don't include X11 as dependency now explicitly use `--with-x=no` (to avoid relying on the X11 provided by the OS), the easyblock should do so too.