### PR TITLE
fix undefined variables used when running of parallel make in ScaLAPACK easyblock

### DIFF
--- a/easybuild/easyblocks/s/scalapack.py
+++ b/easybuild/easyblocks/s/scalapack.py
@@ -207,7 +207,7 @@ class EB_ScaLAPACK(ConfigureMake):
         cmd = "%s make %s %s" % (self.cfg['prebuildopts'], paracmd, self.cfg['buildopts'])
 
         # Ignore exit code for parallel run
-        (out, _) = run_cmd(cmd, path=path, log_ok=False, log_all=True, simple=False, log_output=verbose)
+        (out, _) = run_cmd(cmd, log_ok=False, log_all=True, simple=False)
 
         # Now remake libscalapack.a serially and the tests.
         self.cfg['buildopts'] = saved_buildopts


### PR DESCRIPTION
Fix for issue reported by @olesenm in #1319.
This somehow slipped in #1288, despite my testing (I probably accidentally tested with an earlier version of that updated ScaLAPACK easyblock somehow...).