### PR TITLE
correctly ignore failure in attempt at parallel build in ScaLAPACK easyblock

### DIFF
--- a/easybuild/easyblocks/s/scalapack.py
+++ b/easybuild/easyblocks/s/scalapack.py
@@ -207,7 +207,7 @@ class EB_ScaLAPACK(ConfigureMake):
         cmd = "%s make %s %s" % (self.cfg['prebuildopts'], paracmd, self.cfg['buildopts'])
 
         # Ignore exit code for parallel run
-        (out, _) = run_cmd(cmd, log_ok=False, log_all=True, simple=False)
+        (out, _) = run_cmd(cmd, log_ok=False, log_all=False, simple=False)
 
         # Now remake libscalapack.a serially and the tests.
         self.cfg['buildopts'] = saved_buildopts


### PR DESCRIPTION
To actually ignore the exit code of a failing command, `log_all` needs to be set to `False` too, this was missing in #1288.