### PR TITLE
Update gcc easyblock to add enable-fat option

### DIFF
--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -380,7 +380,7 @@ class EB_GCC(ConfigureMake):
                         raise EasyBuildError("Failed to change to %s: %s", libdir, err)
                     if lib == "gmp":
                         cmd = "./configure --prefix=%s " % stage2prefix
-                        cmd += "--with-pic --disable-shared --enable-cxx"
+                        cmd += "--with-pic --disable-shared --enable-cxx --enable-fat"
                     elif lib == "ppl":
                         self.pplver = LooseVersion(stage2_info['versions']['ppl'])
 


### PR DESCRIPTION
This change will build gcc so it will run on multiple platforms. During stage2 build that gmp was being optimized for the processor on the build machine. The --enable-fat option to configure enables gmp to run on other platforms. This fix has been tested on our test cluster for building foss 2016b, 2017a, 2017b on AMD and Intel platforms.