### PR TITLE
BamTools 2.5.0 libraries can be located in either 'lib' or 'lib64'

### DIFF
--- a/easybuild/easyblocks/b/bamtools.py
+++ b/easybuild/easyblocks/b/bamtools.py
@@ -87,7 +87,8 @@ class EB_BamTools(MakeCp, CMakeMake):
                                           'lib/libjsoncpp.a'])
             custom_paths['dirs'].extend(['include/api', 'docs'])
         else:
-            custom_paths['files'].extend(['include/bamtools/shared/bamtools_global.h', 'lib64/libbamtools.a'])
-            custom_paths['dirs'].extend(['include/bamtools/api', 'lib64/pkgconfig'])
+            custom_paths['files'].extend(['include/bamtools/shared/bamtools_global.h',
+                                          ('lib/libbamtools.a', 'lib64/libbamtools.a')])
+            custom_paths['dirs'].extend(['include/bamtools/api', ('lib.pkgconfig', 'lib64/pkgconfig')])
 
         super(EB_BamTools, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/b/bamtools.py
+++ b/easybuild/easyblocks/b/bamtools.py
@@ -89,6 +89,6 @@ class EB_BamTools(MakeCp, CMakeMake):
         else:
             custom_paths['files'].extend(['include/bamtools/shared/bamtools_global.h',
                                           ('lib/libbamtools.a', 'lib64/libbamtools.a')])
-            custom_paths['dirs'].extend(['include/bamtools/api', ('lib.pkgconfig', 'lib64/pkgconfig')])
+            custom_paths['dirs'].extend(['include/bamtools/api', ('lib/pkgconfig', 'lib64/pkgconfig')])
 
         super(EB_BamTools, self).sanity_check_step(custom_paths=custom_paths)


### PR DESCRIPTION
follow-up for #1332

cc @SethosII