### PR TITLE
Fix quotes when using $ORIGIN in the RPATH

### DIFF
--- a/easybuild/easyblocks/d/dolfin.py
+++ b/easybuild/easyblocks/d/dolfin.py
@@ -299,7 +299,7 @@ class EB_DOLFIN(CMakePythonPackage):
                 for lib in libs:
                     out, _ = run_cmd("patchelf --print-rpath %s" % lib, simple=False, log_all=True)
                     curr_rpath = out.strip()
-                    cmd = "patchelf --set-rpath %s:%s %s" % (curr_rpath, dolfin_libdir, lib)
+                    cmd = "patchelf --set-rpath '%s:%s' %s" % (curr_rpath, dolfin_libdir, lib)
                     run_cmd(cmd, log_all=True)
 
     def make_module_extra(self):


### PR DESCRIPTION
When compiling DOLFIN with RPATH support, the use of `$ORIGIN` in the RPATH should be preserved. However, the lack of quotes now causes expansion of `$ORIGIN`, which is basically empty when `patchelf` is called in the dolfin easyblock. Quotes are added to fix the RPATH support for DOLFIN. 