### PR TITLE
support install_target in PythonPackage + deprecate use_easy_install & use_setup_py_develop

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -247,8 +247,13 @@ class PythonPackage(ExtensionEasyBlock):
             else:
                 self.install_cmd = SETUP_PY_INSTALL_CMD
 
+            if self.cfg['install_target'] == 'easy_install':
+                self.cfg.update('installopts', '--no-deps')
             if self.cfg.get('zipped_egg', False):
-                raise EasyBuildError("Installing zipped eggs requires using easy_install or pip")
+                if self.cfg['install_target'] == 'easy_install':
+                    self.cfg.update('installopts', '--zip-ok')
+                else:
+                    raise EasyBuildError("Installing zipped eggs requires using easy_install or pip")
 
         self.log.debug("Using '%s' as install command", self.install_cmd)
 

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -51,7 +51,8 @@ from easybuild.tools.run import run_cmd
 
 # not 'easy_install' deliberately, to avoid that pkg installations listed in easy-install.pth get preference
 # '.' is required at the end when using easy_install/pip in unpacked source dir
-EASY_INSTALL_INSTALL_CMD = "%(python)s setup.py easy_install --prefix=%(prefix)s %(installopts)s %(loc)s"
+EASY_INSTALL_TARGET = "easy_install"
+EASY_INSTALL_INSTALL_CMD = "%(python)s setup.py " + EASY_INSTALL_TARGET + " --prefix=%(prefix)s %(installopts)s %(loc)s"
 PIP_INSTALL_CMD = "pip install --prefix=%(prefix)s %(installopts)s %(loc)s"
 SETUP_PY_INSTALL_CMD = "%(python)s setup.py %(install_target)s --prefix=%(prefix)s %(installopts)s"
 SETUP_PY_DEVELOP_CMD = "%(python)s setup.py develop --prefix=%(prefix)s %(installopts)s"
@@ -181,9 +182,9 @@ class PythonPackage(ExtensionEasyBlock):
             'req_py_majver': [2, "Required major Python version (only relevant when using system Python)", CUSTOM],
             'req_py_minver': [6, "Required minor Python version (only relevant when using system Python)", CUSTOM],
             'runtest': [True, "Run unit tests.", CUSTOM],  # overrides default
-            'use_easy_install': [False, "Install using '%s'" % EASY_INSTALL_INSTALL_CMD, CUSTOM],
+            'use_easy_install': [False, "Install using '%s' (deprecated)" % EASY_INSTALL_INSTALL_CMD, CUSTOM],
             'use_pip': [False, "Install using '%s'" % PIP_INSTALL_CMD, CUSTOM],
-            'use_setup_py_develop': [False, "Install using '%s'" % SETUP_PY_DEVELOP_CMD, CUSTOM],
+            'use_setup_py_develop': [False, "Install using '%s' (deprecated)" % SETUP_PY_DEVELOP_CMD, CUSTOM],
             'zipped_egg': [False, "Install as a zipped eggs (requires use_easy_install)", CUSTOM],
             'buildcmd': ['build', "Command to pass to setup.py to build the extension", CUSTOM],
             'install_target': ['install', "Option to pass to setup.py", CUSTOM],
@@ -247,10 +248,10 @@ class PythonPackage(ExtensionEasyBlock):
             else:
                 self.install_cmd = SETUP_PY_INSTALL_CMD
 
-            if self.cfg['install_target'] == 'easy_install':
+            if self.cfg['install_target'] == EASY_INSTALL_TARGET:
                 self.cfg.update('installopts', '--no-deps')
             if self.cfg.get('zipped_egg', False):
-                if self.cfg['install_target'] == 'easy_install':
+                if self.cfg['install_target'] == EASY_INSTALL_TARGET:
                     self.cfg.update('installopts', '--zip-ok')
                 else:
                     raise EasyBuildError("Installing zipped eggs requires using easy_install or pip")

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -217,6 +217,7 @@ class PythonPackage(ExtensionEasyBlock):
         # determine install command
         self.use_setup_py = False
         if self.cfg.get('use_easy_install', False):
+            self.log.deprecated("Use 'install_target' rather than 'use_easy_install'.", '4.0')
             self.install_cmd = EASY_INSTALL_INSTALL_CMD
 
             # don't auto-install dependencies
@@ -241,6 +242,7 @@ class PythonPackage(ExtensionEasyBlock):
             self.use_setup_py = True
 
             if self.cfg.get('use_setup_py_develop', False):
+                self.log.deprecated("Use 'install_target' rather than 'use_setup_py_develop'.", '4.0')
                 self.install_cmd = SETUP_PY_DEVELOP_CMD
             else:
                 self.install_cmd = SETUP_PY_INSTALL_CMD

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -53,7 +53,7 @@ from easybuild.tools.run import run_cmd
 # '.' is required at the end when using easy_install/pip in unpacked source dir
 EASY_INSTALL_INSTALL_CMD = "%(python)s setup.py easy_install --prefix=%(prefix)s %(installopts)s %(loc)s"
 PIP_INSTALL_CMD = "pip install --prefix=%(prefix)s %(installopts)s %(loc)s"
-SETUP_PY_INSTALL_CMD = "%(python)s setup.py install --prefix=%(prefix)s %(installopts)s"
+SETUP_PY_INSTALL_CMD = "%(python)s setup.py %(install_target)s --prefix=%(prefix)s %(installopts)s"
 SETUP_PY_DEVELOP_CMD = "%(python)s setup.py develop --prefix=%(prefix)s %(installopts)s"
 UNKNOWN = 'UNKNOWN'
 
@@ -186,6 +186,7 @@ class PythonPackage(ExtensionEasyBlock):
             'use_setup_py_develop': [False, "Install using '%s'" % SETUP_PY_DEVELOP_CMD, CUSTOM],
             'zipped_egg': [False, "Install as a zipped eggs (requires use_easy_install)", CUSTOM],
             'buildcmd': ['build', "Command to pass to setup.py to build the extension", CUSTOM],
+            'install_target': ['install', "Option to pass to setup.py", CUSTOM],
         })
         return ExtensionEasyBlock.extra_options(extra_vars=extra_vars)
 
@@ -342,6 +343,7 @@ class PythonPackage(ExtensionEasyBlock):
             self.cfg['preinstallopts'],
             self.install_cmd % {
                 'installopts': installopts,
+                'install_target': self.cfg['install_target'],
                 'loc': loc,
                 'prefix': prefix,
                 'python': self.python_cmd,


### PR DESCRIPTION
This makes the option passed to `setup.py` configurable. Therefore `use_setup_py_develop` and `use_easy_install` are obsolete. `install_target = 'develop'` and `install_target = 'easy_install'` can be used instead.

See also https://github.com/easybuilders/easybuild-easyconfigs/pull/5610#issuecomment-356604042.