### PR TITLE
add missing %(loc)s template for install_target = 'easy_install' in PythonPackage

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -249,6 +249,7 @@ class PythonPackage(ExtensionEasyBlock):
                 self.install_cmd = SETUP_PY_INSTALL_CMD
 
             if self.cfg['install_target'] == EASY_INSTALL_TARGET:
+                self.install_cmd += " %(loc)s"
                 self.cfg.update('installopts', '--no-deps')
             if self.cfg.get('zipped_egg', False):
                 if self.cfg['install_target'] == EASY_INSTALL_TARGET:


### PR DESCRIPTION
@SethosII We overlooked this in #1341, without this the (crucial) `.` is missing at the end of the `python setup.py easy_install .` command, which leads to an error like:

```
== 2018-01-12 22:52:26,479 run.py:183 INFO running cmd:  /usr/bin/python setup.py easy_install --prefix=/user/home/gent/vsc400/vsc40023/eb_phanpyscratch/CO7/sandybridge/software    /vsc-base/2.5.1  --no-deps  --zip-ok
...
error: No urls, filenames, or requirements specified (see --help)
```