### PR TITLE
Fix Tkinter so it works with both Python 2 and 3.

### DIFF
--- a/easybuild/easyblocks/t/tkinter.py
+++ b/easybuild/easyblocks/t/tkinter.py
@@ -31,6 +31,7 @@ module to use Tcl/Tk.
 """
 import os
 import shutil
+import glob
 import tempfile
 from distutils.version import LooseVersion
 
@@ -63,7 +64,16 @@ class EB_Tkinter(EB_Python):
         tmpdir = tempfile.mkdtemp(dir=self.builddir)
 
         pylibdir = os.path.join(self.installdir, os.path.dirname(det_pylibdir()))
-        tkparts = ["lib-tk", "lib-dynload/_tkinter.so"]
+        shlib_ext = get_shared_lib_ext()
+        tkinter_so = os.path.join(pylibdir, 'lib-dynload', '_tkinter*.' + shlib_ext)
+        tkinter_so_hits = glob.glob(tkinter_so)
+        if len(tkinter_so_hits) != 1:
+            raise EasyBuildError("Expected to find exactly one _tkinter*.so: %s", tkinter_so_hits)
+        self.tkinter_so_basename = os.path.basename(tkinter_so_hits[0])
+        if LooseVersion(self.version) >= LooseVersion('3'):
+            tkparts = ["tkinter", os.path.join("lib-dynload", self.tkinter_so_basename)]
+        else:
+            tkparts = ["lib-tk", os.path.join("lib-dynload", self.tkinter_so_basename)]
 
         copy([os.path.join(pylibdir, x) for x in tkparts], tmpdir)
 
@@ -88,7 +98,7 @@ class EB_Tkinter(EB_Python):
         pylibdir = os.path.dirname(det_pylibdir())
 
         custom_paths = {
-            'files': ['%s/_tkinter.%s' % (pylibdir, shlib_ext)],
+            'files': ['%s/%s' % (pylibdir, self.tkinter_so_basename)],
             'dirs': ['lib']
         }
         super(EB_Python, self).sanity_check_step(custom_commands=custom_commands, custom_paths=custom_paths)


### PR DESCRIPTION
The current Tkinter easyblock only works for Python 2, as the names of some of the files that should be installed are different in Python 3.

This module is needed since Tkinter support has been removed from the default Python installations.