### PR TITLE
enhance Octave extension filter to avoid false positives

### DIFF
--- a/easybuild/easyblocks/o/octave.py
+++ b/easybuild/easyblocks/o/octave.py
@@ -38,7 +38,7 @@ from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
 
 
-EXTS_FILTER_OCTAVE_PACKAGES = ("octave --eval 'pkg list' | grep %(ext_name)s", '')
+EXTS_FILTER_OCTAVE_PACKAGES = ("octave --eval 'pkg list' | grep packages/%(ext_name)s-%(ext_version)s", '')
 
 
 class EB_Octave(ConfigureMake):


### PR DESCRIPTION
This is required to correctly detect whether the `io` package is installed, since some other output is produced by `octave --eval 'pkg list'` that includes `io` as a substring as well...