### PR TITLE
don't use PERL_MM_OPT and PERL_MB_OPT

### DIFF
--- a/easybuild/easyblocks/generic/perlmodule.py
+++ b/easybuild/easyblocks/generic/perlmodule.py
@@ -58,9 +58,8 @@ class PerlModule(ExtensionEasyBlock, ConfigureMake):
         """Install procedure for Perl modules: using either Makefile.Pl or Build.PL."""
         # Perl modules have two possible installation procedures: using Makefile.PL and Build.PL
         # configure, build, test, install
-        unset_cmd = "unset PERL_MM_OPT PERL_MB_OPT"
         if os.path.exists('Makefile.PL'):
-            run_cmd('%s %s perl Makefile.PL PREFIX=%s %s' % (unset_cmd, self.cfg['preconfigopts'], self.installdir, self.cfg['configopts']))
+            run_cmd('%s perl Makefile.PL PREFIX=%s %s' % (self.cfg['preconfigopts'], self.installdir, self.cfg['configopts']))
             ConfigureMake.build_step(self)
             ConfigureMake.test_step(self)
             ConfigureMake.install_step(self)
@@ -68,7 +67,7 @@ class PerlModule(ExtensionEasyBlock, ConfigureMake):
             run_cmd('%s perl Build.PL --prefix %s %s' % (self.cfg['preconfigopts'], self.installdir, self.cfg['configopts']))
             run_cmd('%s perl Build build %s' % (self.cfg['prebuildopts'], self.cfg['buildopts']))
             run_cmd('perl Build test')
-            run_cmd('%s %s perl Build install %s' % (unset_cmd, self.cfg['preinstallopts'], self.cfg['installopts']))
+            run_cmd('%s perl Build install %s' % (self.cfg['preinstallopts'], self.cfg['installopts']))
 
     def run(self):
         """Perform the actual Perl module build/installation procedure"""

--- a/easybuild/easyblocks/generic/perlmodule.py
+++ b/easybuild/easyblocks/generic/perlmodule.py
@@ -36,7 +36,7 @@ from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd
-
+from easybuild.tools.environment import unset_env_vars
 
 class PerlModule(ExtensionEasyBlock, ConfigureMake):
     """Builds and installs a Perl module, and can provide a dedicated module file."""
@@ -53,6 +53,10 @@ class PerlModule(ExtensionEasyBlock, ConfigureMake):
         """Initialize custom class variables."""
         super(PerlModule, self).__init__(*args, **kwargs)
         self.testcmd = None
+        # Environment variables PERL_MM_OPT and PERL_MB_OPT cause installations to fail. 
+        # Therefore it is better to unset these variables.
+        unset_env_vars(['PERL_MM_OPT', 'PERL_MB_OPT'])
+
 
     def install_perl_module(self):
         """Install procedure for Perl modules: using either Makefile.Pl or Build.PL."""

--- a/easybuild/easyblocks/generic/perlmodule.py
+++ b/easybuild/easyblocks/generic/perlmodule.py
@@ -53,10 +53,10 @@ class PerlModule(ExtensionEasyBlock, ConfigureMake):
         """Initialize custom class variables."""
         super(PerlModule, self).__init__(*args, **kwargs)
         self.testcmd = None
+
         # Environment variables PERL_MM_OPT and PERL_MB_OPT cause installations to fail. 
         # Therefore it is better to unset these variables.
         unset_env_vars(['PERL_MM_OPT', 'PERL_MB_OPT'])
-
 
     def install_perl_module(self):
         """Install procedure for Perl modules: using either Makefile.Pl or Build.PL."""

--- a/easybuild/easyblocks/generic/perlmodule.py
+++ b/easybuild/easyblocks/generic/perlmodule.py
@@ -58,8 +58,9 @@ class PerlModule(ExtensionEasyBlock, ConfigureMake):
         """Install procedure for Perl modules: using either Makefile.Pl or Build.PL."""
         # Perl modules have two possible installation procedures: using Makefile.PL and Build.PL
         # configure, build, test, install
+        unset_cmd = "unset PERL_MM_OPT PERL_MB_OPT"
         if os.path.exists('Makefile.PL'):
-            run_cmd('%s perl Makefile.PL PREFIX=%s %s' % (self.cfg['preconfigopts'], self.installdir, self.cfg['configopts']))
+            run_cmd('%s %s perl Makefile.PL PREFIX=%s %s' % (unset_cmd, self.cfg['preconfigopts'], self.installdir, self.cfg['configopts']))
             ConfigureMake.build_step(self)
             ConfigureMake.test_step(self)
             ConfigureMake.install_step(self)
@@ -67,7 +68,7 @@ class PerlModule(ExtensionEasyBlock, ConfigureMake):
             run_cmd('%s perl Build.PL --prefix %s %s' % (self.cfg['preconfigopts'], self.installdir, self.cfg['configopts']))
             run_cmd('%s perl Build build %s' % (self.cfg['prebuildopts'], self.cfg['buildopts']))
             run_cmd('perl Build test')
-            run_cmd('%s perl Build install %s' % (self.cfg['preinstallopts'], self.cfg['installopts']))
+            run_cmd('%s %s perl Build install %s' % (unset_cmd, self.cfg['preinstallopts'], self.cfg['installopts']))
 
     def run(self):
         """Perform the actual Perl module build/installation procedure"""


### PR DESCRIPTION
Something like this should do the trick, however I was not able to test anything. Using e.g. `eb ~/Perl-5.26.1-test-foss-2018a.eb --include-easyblocks=./perlmodule.py,../p/perl.py ` did not use my custom `perlmodule.py`. It would be helpful to know how I can use a custom easyblock such as perlmodule.py for testing.