### PR TITLE
Add make-makeinstall easyblock without configure

### DIFF
--- a/easybuild/easyblocks/generic/makeinstall.py
+++ b/easybuild/easyblocks/generic/makeinstall.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+##
+# Copyright 2009-2018 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+"""
+EasyBuild support for software that uses the GNU installation procedure,
+i.e. configure/make/make install, implemented as an easyblock.
+
+@author: Stijn De Weirdt (Ghent University)
+@author: Dries Verdegem (Ghent University)
+@author: Kenneth Hoste (Ghent University)
+@author: Pieter De Baets (Ghent University)
+@author: Jens Timmerman (Ghent University)
+@author: Toon Willems (Ghent University)
+"""
+
+
+from easybuild.easyblocks.generic.configuremake import ConfigureMake
+
+
+class MakeInstall(ConfigureMake):
+    """
+    Support for building and installing applications with make/make install
+    without configure step
+    """
+
+    def configure_step(self, cmd_prefix=''):
+        pass


### PR DESCRIPTION
Did not find a better way without modifying `ConfigureMake`. Maybe adding a `bool` option to make the configure step optional?

(This module needed for Lua install. Check new PR for `Lua`)