### PR TITLE
added option use_pip_for_dependencies for pythonpackages

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -234,7 +234,10 @@ class PythonPackage(ExtensionEasyBlock):
             # don't auto-install dependencies with pip unless use_pip_for_dependencies=True
             # the default is use_pip_for_dependencies=False
             if self.cfg.get('use_pip_for_dependencies') == False:
+                self.log.info("Using pip with --no-deps option")
                 self.cfg.update('installopts', '--no-deps')
+            else:
+                self.log.info("Using pip to also install the dependencies")
 
             # don't (try to) uninstall already availale versions of the package being installed
             self.cfg.update('installopts', '--ignore-installed')

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -184,6 +184,7 @@ class PythonPackage(ExtensionEasyBlock):
             'runtest': [True, "Run unit tests.", CUSTOM],  # overrides default
             'use_easy_install': [False, "Install using '%s' (deprecated)" % EASY_INSTALL_INSTALL_CMD, CUSTOM],
             'use_pip': [False, "Install using '%s'" % PIP_INSTALL_CMD, CUSTOM],
+            'use_pip_for_dependencies': [False, "Install dependencies using '%s'" % PIP_INSTALL_CMD, CUSTOM],
             'use_setup_py_develop': [False, "Install using '%s' (deprecated)" % SETUP_PY_DEVELOP_CMD, CUSTOM],
             'zipped_egg': [False, "Install as a zipped eggs (requires use_easy_install)", CUSTOM],
             'buildcmd': ['build', "Command to pass to setup.py to build the extension", CUSTOM],
@@ -230,8 +231,10 @@ class PythonPackage(ExtensionEasyBlock):
         elif self.cfg.get('use_pip', False):
             self.install_cmd = PIP_INSTALL_CMD
 
-            # don't auto-install dependencies
-            self.cfg.update('installopts', '--no-deps')
+            # don't auto-install dependencies with pip unless use_pip_for_dependencies=True
+            # the default is use_pip_for_dependencies=False
+            if self.cfg.get('use_pip_for_dependencies') == False:
+                self.cfg.update('installopts', '--no-deps')
 
             # don't (try to) uninstall already availale versions of the package being installed
             self.cfg.update('installopts', '--ignore-installed')

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -184,7 +184,7 @@ class PythonPackage(ExtensionEasyBlock):
             'runtest': [True, "Run unit tests.", CUSTOM],  # overrides default
             'use_easy_install': [False, "Install using '%s' (deprecated)" % EASY_INSTALL_INSTALL_CMD, CUSTOM],
             'use_pip': [False, "Install using '%s'" % PIP_INSTALL_CMD, CUSTOM],
-            'use_pip_for_dependencies': [False, "Install dependencies using '%s'" % PIP_INSTALL_CMD, CUSTOM],
+            'use_pip_for_deps': [False, "Install dependencies using '%s'" % PIP_INSTALL_CMD, CUSTOM],
             'use_setup_py_develop': [False, "Install using '%s' (deprecated)" % SETUP_PY_DEVELOP_CMD, CUSTOM],
             'zipped_egg': [False, "Install as a zipped eggs (requires use_easy_install)", CUSTOM],
             'buildcmd': ['build', "Command to pass to setup.py to build the extension", CUSTOM],
@@ -231,13 +231,13 @@ class PythonPackage(ExtensionEasyBlock):
         elif self.cfg.get('use_pip', False):
             self.install_cmd = PIP_INSTALL_CMD
 
-            # don't auto-install dependencies with pip unless use_pip_for_dependencies=True
-            # the default is use_pip_for_dependencies=False
-            if self.cfg.get('use_pip_for_dependencies') == False:
+            # don't auto-install dependencies with pip unless use_pip_for_deps=True
+            # the default is use_pip_for_deps=False
+            if self.cfg.get('use_pip_for_deps'):
+                self.log.info("Using pip to also install the dependencies")
+            else:
                 self.log.info("Using pip with --no-deps option")
                 self.cfg.update('installopts', '--no-deps')
-            else:
-                self.log.info("Using pip to also install the dependencies")
 
             # don't (try to) uninstall already availale versions of the package being installed
             self.cfg.update('installopts', '--ignore-installed')


### PR DESCRIPTION
with this option a easyconfig like this one can be installed. The only change is `use_pip_for_dependencies = True`

I know this is not the recommended approach and it doesn't help to reproduce the same installation in the future but in this specific example deeptools requires 41 different python libraries so creating a proper easyconfig with all the required libraries require quite some manual work. And this is a tool that probably only 1 or 2 of my users will need so it's not worth the time IMHO and for me it's ok to take the risk of not writting a fully complete easyconfig with the complete list of deps and rely on pip for the installation but save a lot of time of manual work

```
easyblock = 'PythonPackage'

name = 'deepTools'
version = '3.0.0'
versionsuffix = '-Python-%(pyver)s'

homepage = 'https://github.com/fidelram/deepTools'
description = """Tools to process and analyze deep sequencing data"""

toolchain = {'name': 'goolf', 'version': '1.7.20'}

source_urls = ['https://github.com/fidelram/deepTools/archive/']
sources = ['%(version)s.tar.gz']

dependencies = [
    ('Python', '2.7.11'),
    ('cURL', '7.40.0', '', True),
]

use_pip = True
use_pip_for_dependencies = True
unpack_sources = False

sanity_check_paths = {
    'files': [],
    'dirs': ['lib/python%(pyshortver)s/site-packages/deeptools'],
}

moduleclass = 'bio'
```