### PR TITLE
make CUDA easyblock aware of preinstallopts

### DIFF
--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -67,7 +67,6 @@ class EB_CUDA(Binary):
         # script has /usr/bin/perl hardcoded, but we want to have control over which perl is being used
         if LooseVersion(self.version) <= LooseVersion("5"):
             install_script = "install-linux.pl"
-            install_script_path = os.path.join(self.builddir, install_script)
             cmd = "%(preinstallopts)s perl ./%(script)s --prefix=%(installdir)s %(installopts)s" % {
                 'preinstallopts': self.cfg['preinstallopts'],
                 'script': install_script,

--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -67,23 +67,17 @@ class EB_CUDA(Binary):
         # script has /usr/bin/perl hardcoded, but we want to have control over which perl is being used
         if LooseVersion(self.version) <= LooseVersion("5"):
             install_script = "install-linux.pl"
-            cmd = "%(preinstallopts)s perl ./%(script)s --prefix=%(installdir)s %(installopts)s" % {
-                'preinstallopts': self.cfg['preinstallopts'],
-                'script': install_script,
-                'installdir': self.installdir,
-                'installopts': self.cfg['installopts']
-            }
+            self.cfg.update('installopts', '--prefix=%s' % self.installdir)
         else:
-            # the following would require to include "osdependencies = 'libglut'" because of samples
-            # installparams = "-samplespath=%(x)s/samples/ -toolkitpath=%(x)s -samples -toolkit" % {'x': self.installdir}
             install_script = "cuda-installer.pl"
-            installparams = "-toolkitpath=%s -toolkit" % self.installdir
-            cmd = "%(preinstallopts)s perl ./%(script)s -verbose -silent %(installparams)s %(installopts)s" % {
-                'preinstallopts': self.cfg['preinstallopts'],
-                'script': install_script,
-                'installparams': installparams,
-                'installopts': self.cfg['installopts']
-            }
+            # note: also including samples (via "-samplespath=%(installdir)s -samples") would require libglut
+            self.cfg.update('installopts', "-verbose -silent -toolkitpath=%s -toolkit" % self.installdir)
+
+        cmd = "%(preinstallopts)s perl ./%(script)s %(installopts)s" % {
+            'preinstallopts': self.cfg['preinstallopts'],
+            'script': install_script,
+            'installopts': self.cfg['installopts']
+        }
 
         # prepare for running install script autonomously
         qanda = {}

--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -68,13 +68,23 @@ class EB_CUDA(Binary):
         if LooseVersion(self.version) <= LooseVersion("5"):
             install_script = "install-linux.pl"
             install_script_path = os.path.join(self.builddir, install_script)
-            cmd = "perl ./%s --prefix=%s %s" % (install_script, self.installdir, self.cfg['installopts'])
+            cmd = "%(preinstallopts)s perl ./%(script)s --prefix=%(installdir)s %(installopts)s" % {
+                'preinstallopts': self.cfg['preinstallopts'],
+                'script': install_script,
+                'installdir': self.installdir,
+                'installopts': self.cfg['installopts']
+            }
         else:
             # the following would require to include "osdependencies = 'libglut'" because of samples
             # installparams = "-samplespath=%(x)s/samples/ -toolkitpath=%(x)s -samples -toolkit" % {'x': self.installdir}
             install_script = "cuda-installer.pl"
             installparams = "-toolkitpath=%s -toolkit" % self.installdir
-            cmd = "perl ./%s -verbose -silent %s %s" % (install_script, installparams, self.cfg['installopts'])
+            cmd = "%(preinstallopts)s perl ./%(script)s -verbose -silent %(installparams)s %(installopts)s" % {
+                'preinstallopts': self.cfg['preinstallopts'],
+                'script': install_script,
+                'installparams': installparams,
+                'installopts': self.cfg['installopts']
+            }
 
         # prepare for running install script autonomously
         qanda = {}


### PR DESCRIPTION
The `CUDA` easyblock was missing support for `preinstallopts`.
This is necessary to be able to define `PERL5LIB` if needed in order for the installer script to correctly locate `InstallUtils.pm`.