### PR TITLE
fix linking to FFTW for Doris: should be -lfftw3f

### DIFF
--- a/easybuild/easyblocks/d/doris.py
+++ b/easybuild/easyblocks/d/doris.py
@@ -81,7 +81,7 @@ class EB_Doris(ConfigureMake):
         change_dir(os.path.join(self.cfg['start_dir'], 'src'))
 
         # override some of the settings via options to 'make'
-        lflags = "-L%s -lfftw3 " % os.path.join(get_software_root('FFTW'), 'lib')
+        lflags = "-L%s -lfftw3f " % os.path.join(get_software_root('FFTW'), 'lib')
         lflags += "-L%s %s" % (os.getenv('LAPACK_LIB_DIR'), os.getenv('LIBLAPACK_MT'))
         self.cfg.update('buildopts', 'LFLAGS="%s"' % lflags)
         self.cfg.update('buildopts', 'CFLAGSOPT="%s \$(DEFS)"' % os.getenv('CXXFLAGS'))


### PR DESCRIPTION
Fix for link issues like `undefined reference to fftwf_version` when building `Doris` with `foss` toolchain.

There's no problem when using an `intel` toolchain because the symbols probably get resolved via `imkl`...