### PR TITLE
make PythonPackage generic easyblock aware of 'unpack_options' easyconfig parameter

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -203,7 +203,7 @@ class PythonPackage(ExtensionEasyBlock):
         self.sitecfgincdir = None
         self.testinstall = False
         self.testcmd = None
-        self.unpack_options = ''
+        self.unpack_options = self.cfg['unpack_options']
 
         self.python_cmd = None
         self.pylibdir = UNKNOWN


### PR DESCRIPTION
default value for (general) `unpack_options` easyconfig parameter is `''`, so trivial change...