### PR TITLE
Make cdft lib compilation optional for Intel MKL, by detecting MPI availability

### DIFF
--- a/easybuild/easyblocks/i/imkl.py
+++ b/easybuild/easyblocks/i/imkl.py
@@ -87,7 +87,7 @@ class EB_imkl(IntelBase):
                 }
                 mpi_fam = self.toolchain.mpi_family()
                 self.mpi_spec = mpi_spec_by_fam.get(mpi_fam)
-                self.log.debug("Determined MPI specification based on MPI toolchain component: %s", self.mpi_spec)
+                debugstr = "MPI toolchain component"
             else:
                 # can't use toolchain.mpi_family, because of dummy toolchain
                 if get_software_root('MPICH2') or get_software_root('MVAPICH2'):
@@ -97,7 +97,11 @@ class EB_imkl(IntelBase):
                 elif not get_software_root('impi'):
                     # no compatible MPI found: do not build cdft
                     self.cdftlibs = []
-                self.log.debug("Determined MPI specification based on loaded MPI module: %s", self.mpi_spec)
+                debugstr = "loaded MPI module"
+            if self.mpi_spec:
+                self.log.debug("Determined MPI specification based on %s: %s", debugstr, self.mpi_spec)
+            else:
+                self.log.debug("No MPI or no compatible MPI found: do not build CDFT")
 
     def prepare_step(self, *args, **kwargs):
         if LooseVersion(self.version) >= LooseVersion('2017.2.174'):

--- a/easybuild/easyblocks/i/imkl.py
+++ b/easybuild/easyblocks/i/imkl.py
@@ -70,13 +70,21 @@ class EB_imkl(IntelBase):
         super(EB_imkl, self).__init__(*args, **kwargs)
         # make sure $MKLROOT isn't set, it's known to cause problems with the installation
         self.cfg.update('unwanted_env_vars', ['MKLROOT'])
+        self.cdftlibs = []
+        self.mpi_spec = None
+
+    def prepare_step(self, *args, **kwargs):
+        if LooseVersion(self.version) >= LooseVersion('2017.2.174'):
+            kwargs['requires_runtime_license'] = False
+            super(EB_imkl, self).prepare_step(*args, **kwargs)
+        else:
+            super(EB_imkl, self).prepare_step(*args, **kwargs)
 
         # build the mkl interfaces, if desired
         if self.cfg['interfaces']:
             self.cdftlibs = ['fftw2x_cdft']
             if LooseVersion(self.version) >= LooseVersion('10.3'):
                 self.cdftlibs.append('fftw3x_cdft')
-            self.mpi_spec = None
             # check whether MPI_FAMILY constant is defined, so mpi_family() can be used
             if hasattr(self.toolchain, 'MPI_FAMILY') and self.toolchain.MPI_FAMILY is not None:
                 mpi_spec_by_fam = {
@@ -102,13 +110,6 @@ class EB_imkl(IntelBase):
                 self.log.debug("Determined MPI specification based on %s: %s", debugstr, self.mpi_spec)
             else:
                 self.log.debug("No MPI or no compatible MPI found: do not build CDFT")
-
-    def prepare_step(self, *args, **kwargs):
-        if LooseVersion(self.version) >= LooseVersion('2017.2.174'):
-            kwargs['requires_runtime_license'] = False
-            super(EB_imkl, self).prepare_step(*args, **kwargs)
-        else:
-            super(EB_imkl, self).prepare_step(*args, **kwargs)
 
     def install_step(self):
         """


### PR DESCRIPTION
This allows installing MKL using a compiler-only toolchain with interfaces enabled.