### PR TITLE
add generic easyblock for installing software via Spack

### DIFF
--- a/easybuild/easyblocks/generic/spack.py
+++ b/easybuild/easyblocks/generic/spack.py
@@ -1,0 +1,136 @@
+##
+# Copyright 2018-2018 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for installing software using Spack, implemented as an easyblock.
+
+@author: Kenneth Hoste (Ghent University)
+"""
+import os
+
+import easybuild.tools.environment as env
+from easybuild.framework.easyblock import EasyBlock
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.filetools import copy_dir, mkdir, symlink, which, write_file
+from easybuild.tools.modules import get_software_root, get_software_version
+from easybuild.tools.run import run_cmd
+from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME
+
+
+class Spack(EasyBlock):
+    """
+    Support for installing software with Spack
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Constructor for Spack easyblock."""
+        super(Spack, self).__init__(*args, **kwargs)
+
+        self.spack_dir = None
+
+    def prepare_step(self):
+        """Prepare build environment & Spack"""
+        super(Spack, self).prepare_step()
+
+        # copy Spack to build directory
+        # this is required to configure it for the software installation(s) that will be performed
+        spack_root = get_software_root('Spack')
+        if spack_root is None:
+            spack = which('spack')
+            if spack:
+                spack_root = os.path.dirname(os.path.dirname(spack))
+            else:
+                raise EasyBuildError("Failed to find Spack!")
+
+        self.spack_dir = os.path.join(self.builddir, 'spack')
+        copy_dir(spack_root, self.spack_dir)
+
+        # make sure right 'spack' command is picked up
+        env.setvar('PATH', '%s:%s' % (os.path.join(self.spack_dir, 'bin'), os.getenv('PATH')))
+
+        # make Spack aware of available compilers (incl. toolchain compiler)
+        run_cmd("spack compiler add --scope site")
+
+    def configure_step(self, cmd_prefix=''):
+        """
+        Configure step: ...
+        """
+        # instruct Spack where to install software
+        spack_cfg_txt = '\n'.join([
+            'config:',
+            '  install_tree: %s' % os.path.join(self.installdir, 'spack'),
+        ])
+        write_file(os.path.join(self.spack_dir, 'etc', 'spack', 'config.yaml'), spack_cfg_txt)
+
+    def build_step(self, verbose=False, path=None):
+        """
+        Build step: ...
+        """
+        pass
+
+    def install_step(self):
+        """
+        Install step: ...
+        """
+        cmd = [
+            'spack',
+            'install',
+            self.name.lower() + '@' + self.version,
+        ]
+
+        # instruct Spack to use right compiler when a non-dummy toolchain is used
+        if self.toolchain.name != DUMMY_TOOLCHAIN_NAME:
+            comp_name = self.toolchain.COMPILER_MODULE_NAME[0]
+            comp_version = get_software_version(comp_name)
+            if comp_name == 'GCCcore':
+                comp_name = 'gcc'
+            else:
+                comp_name = comp_name.lower()
+            cmd.append('%' + comp_name + '@' + comp_version)
+
+        run_cmd(' '.join(cmd))
+
+    def post_install_step(self):
+        """
+        Symlink installed software into top-level installation prefix
+        """
+        topdir = os.path.join(self.installdir, 'spack')
+        for dirpath, dirnames, filenames in os.walk(topdir):
+            for fn in filenames:
+                # Spack installs into <platform>/<compiler>/<software> subdirectory, so strip those off for symlinks
+                subdirs = dirpath.replace(topdir + '/', '').split(os.path.sep)[3:]
+                if subdirs:
+                    subdirs = os.path.join(*subdirs)
+                    target_path = os.path.join(self.installdir, subdirs, fn)
+                else:
+                    target_path = os.path.join(self.installdir, fn)
+
+                mkdir(os.path.dirname(target_path), parents=True)
+                if os.path.exists(target_path):
+                    raise EasyBuildError("%s already exists" % target_path)
+                else:
+                    symlink(os.path.join(dirpath, fn), target_path)
+
+            # ignore .spack subdirectory
+            dirnames[:] = [d for d in dirnames if d not in ['.spack']]


### PR DESCRIPTION
Example usage:

* easyconfig file for installing `bzip2` with Spack:
```python
easyblock = 'Spack'

name = 'bzip2'
version = '1.0.6'

homepage = 'http://www.bzip.org/'
description = "bzip2 is a freely available, patent free, high-quality data compressor."

toolchain = {'name': 'GCCcore', 'version': '6.4.0'}

sanity_check_paths = {
    'files': ['bin/bunzip2', 'bin/bzip2'],
    'dirs': ['include', 'lib'],
}

moduleclass = 'tools'
```

* example output under `--trace`:
```
$ eb bzip2-Spack.eb --include-easyblocks spack.py -df
== temporary log file in case of crash /tmp/eb-ZLvqAp/easybuild-5QR8wz.log
== processing EasyBuild easyconfig /tmp/bzip2-Spack.eb
== building and installing bzip2/1.0.6-GCCcore-6.4.0...
  >> installation prefix: /tmp/software/bzip2/1.0.6-GCCcore-6.4.0
== fetching files...
== creating build dir, resetting environment...
  >> build dir: /tmp/build/bzip2/1.0.6/GCCcore-6.4.0
== unpacking...
== patching...
== preparing...
  >> loading toolchain module: GCCcore/6.4.0
  >> defining build environment for GCCcore/6.4.0 toolchain
  >> running command:
	[started at: 2018-04-01 18:25:41]
	[output logged in /tmp/eb-ZLvqAp/easybuild-run_cmd-dgq8JQ.log]
	spack compiler add --scope site
  >> command completed: exit 0, ran in 00h00m01s
== configuring...
== building...
== testing...
== installing...
  >> running command:
	[started at: 2018-04-01 18:25:43]
	[output logged in /tmp/eb-ZLvqAp/easybuild-run_cmd-gXakZP.log]
	spack install bzip2@1.0.6 %gcc@6.4.0
  >> command completed: exit 0, ran in 00h00m17s
== taking care of extensions...
== postprocessing...
== sanity checking...
  >> file 'bin/bunzip2' found: OK
  >> file 'bin/bzip2' found: OK
  >> (non-empty) directory 'include' found: OK
  >> (non-empty) directory 'lib' found: OK
== cleaning up...
== creating module...
  >> generating module file @ /tmp/modules/all/bzip2/1.0.6-GCCcore-6.4.0.lua
== permissions...
== packaging...
== COMPLETED: Installation ended successfully
== Results of the build can be found in the log file(s) /tmp/software/bzip2/1.0.6-GCCcore-6.4.0/easybuild/easybuild-bzip2-1.0.6-20180401.182611.log
== Build succeeded for 1 out of 1
== Temporary log file(s) /tmp/eb-ZLvqAp/easybuild-5QR8wz.log* have been removed.
== Temporary directory /tmp/eb-ZLvqAp has been removed.
```

@tgamblin: up for reviewing this?