### PR TITLE
Set CMake patch when it's loaded in PythonPackage

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -420,6 +420,13 @@ class PythonPackage(ExtensionEasyBlock):
     def build_step(self):
         """Build Python package using setup.py"""
         if self.use_setup_py:
+
+            if get_software_root('CMake'):
+                include_paths = os.pathsep.join(self.toolchain.get_variable("CPPFLAGS", list))
+                library_paths = os.pathsep.join(self.toolchain.get_variable("LDFLAGS", list))
+                env.setvar("CMAKE_INCLUDE_PATH", include_paths)
+                env.setvar("CMAKE_LIBRARY_PATH", library_paths)
+
             cmd = ' '.join([self.cfg['prebuildopts'], self.python_cmd, 'setup.py', self.cfg['buildcmd'],
                             self.cfg['buildopts']])
             run_cmd(cmd, log_all=True, simple=True)


### PR DESCRIPTION
It's is not a great nor a final solution but it already helps.

We should think how to handle this in the generic case? Wrapper for CMake in the PythonPackage block?