### PR TITLE
take into account that self.debuggerpath may not be set in icc easyblock

### DIFF
--- a/easybuild/easyblocks/i/icc.py
+++ b/easybuild/easyblocks/i/icc.py
@@ -215,12 +215,11 @@ class EB_icc(IntelBase):
             for key, subdirs in guesses.items():
                 guesses[key] = [os.path.join(prefix, subdir) for subdir in subdirs]
 
-        # The for loop above breaks libipt library loading for gdb - this fixes that
-            guesses['LD_LIBRARY_PATH'].extend([
-                os.path.join(self.debuggerpath, 'libipt/intel64/lib'),
-                'daal/lib/intel64_lin',
-            ])
-                
+            # The for loop above breaks libipt library loading for gdb - this fixes that
+            guesses['LD_LIBRARY_PATH'].append('daal/lib/intel64_lin')
+            if self.debuggerpath:
+                guesses['LD_LIBRARY_PATH'].append(os.path.join(self.debuggerpath, 'libipt/intel64/lib'))
+
         # only set $IDB_HOME if idb exists
         idb_home_subdir = 'bin/intel64'
         if os.path.isfile(os.path.join(self.installdir, idb_home_subdir, 'idb')):


### PR DESCRIPTION
fix for regression for old `icc` versions that was introduced with #1224 

fixes this problem:

```
Traceback (most recent call last):
  File "/lib/python2.7/site-packages/easybuild_framework-3.6.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2883, in build_easyconfigs
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/lib/python2.7/site-packages/easybuild_framework-3.6.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2614, in run_all_steps
    self.run_step(step_name, step_methods)
  File "/lib/python2.7/site-packages/easybuild_framework-3.6.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2489, in run_step
    step_method(self)()
  File "/lib/python2.7/site-packages/easybuild_easyblocks-3.6.0-py2.7.egg/easybuild/easyblocks/i/icc.py", line 126, in sanity_check_step
    super(EB_icc, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
  File "/lib/python2.7/site-packages/easybuild_framework-3.6.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 1981, in sanity_check_step
    self._sanity_check_step(*args, **kwargs)
  File "/lib/python2.7/site-packages/easybuild_framework-3.6.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2181, in _sanity_check_step
    fake_mod_data = self.load_fake_module(purge=True)
  File "/lib/python2.7/site-packages/easybuild_framework-3.6.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 1297, in load_fake_module
    fake_mod_path = self.make_module_step(fake=True)
  File "/lib/python2.7/site-packages/easybuild_framework-3.6.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2300, in make_module_step
    txt += self.make_module_req()
  File "/lib/python2.7/site-packages/easybuild_framework-3.6.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 1218, in make_module_req
    requirements = self.make_module_req_guess()
  File "/lib/python2.7/site-packages/easybuild_easyblocks-3.6.0-py2.7.egg/easybuild/easyblocks/i/icc.py", line 220, in make_module_req_guess
    os.path.join(self.debuggerpath, 'libipt/intel64/lib'),
  File "/usr/lib64/python2.7/posixpath.py", line 77, in join
    elif path == '' or path.endswith('/'):
AttributeError: 'NoneType' object has no attribute 'endswith'
```