### PR TITLE
extend noqa in configure step of Qt easyblock

### DIFF
--- a/easybuild/easyblocks/q/qt.py
+++ b/easybuild/easyblocks/q/qt.py
@@ -95,6 +95,7 @@ class EB_Qt(ConfigureMake):
             "Project MESSAGE:.*",
             "rm -f .*",
             'Creating qmake...',
+            'Checking for .*...',
         ]
         run_cmd_qa(cmd, qa, no_qa=no_qa, log_all=True, simple=True, maxhits=120)
 


### PR DESCRIPTION
The configure step of Qt5 occasionally fails now, because it 'hangs' for a while, making `run_cmd_qa` think it's asking a question it doesn't know the answer to.

It seems like this happens when the last bit of output produced is `Checking for <foo> ...`, so we can make the Qt easyblock more robust by registering that in `noqa` to indicate it's not a question and more output is expected to come.