### PR TITLE
Install Chimera in a subdirectory to avoid its dependencies being added to the environment

### DIFF
--- a/easybuild/easyblocks/c/chimera.py
+++ b/easybuild/easyblocks/c/chimera.py
@@ -10,6 +10,7 @@ import os
 
 from easybuild.easyblocks.generic.packedbinary import PackedBinary
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.filetools import mkdir, symlink
 from easybuild.tools.run import run_cmd
 
 
@@ -31,6 +32,20 @@ class EB_Chimera(PackedBinary):
         except OSError, err:
             raise EasyBuildError("Failed to change to %s: %s", self.cfg['start_dir'], err)
 
-        cmd = "./chimera.bin -q -d %s" % self.installdir
-
+        # Chimera comes bundled with its dependencies, and follows a
+        # UNIX file system layout with 'bin', 'include', 'lib', etc.  To
+        # avoid conflicts with other modules, the Chimera module must
+        # not add the 'bin', 'include', 'lib', etc. directories to PATH,
+        # CPATH, LD_LIBRARY_PATH, etc.  We achieve this by installing
+        # Chimera in a subdirectory (called 'chimera') instead of the
+        # root directory.
+        cmd = "./chimera.bin -q -d %s" % os.path.join(self.installdir,
+                                                      'chimera')
         run_cmd(cmd, log_all=True, simple=True)
+
+        # Create a symlink to the Chimera startup script; this symlink
+        # will end up in PATH.  The startup script sets up the
+        # environment, so that Chimera finds its dependencies.
+        mkdir(os.path.join(self.installdir, 'bin'))
+        symlink(os.path.join(self.installdir, 'chimera', 'bin', 'chimera'),
+                os.path.join(self.installdir, 'bin', 'chimera'))


### PR DESCRIPTION
I noticed that when loading Chimera after loading Python, Python starts picking up the Tcl/Tk version that comes bundled with Chimera instead of the correct one. This PR fixes that by installing Chimera in a subdirectory so that the bundled dependencies are not added to PATH, LD_LIBRARY_PATH, etc. A symlink is added from 'bin/chimera' in the root directory to 'bin/chimera' in subdirectory, so that a 'chimera' command will exist in PATH. Chimera will still find its bundled dependencies, because it uses a wrapper startup script that adds them to the environment.

This method is similar to what they describe in the installation instructions at <http://www.cgl.ucsf.edu/chimera/data/downloads/1.11.2/linux.html>.