### PR TITLE
Use configParser to manage site.cfg. Handle OpenBLAS accordingly to documentation

### DIFF
--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -161,7 +161,6 @@ class EB_numpy(FortranPythonPackage):
                 self.sitecfg.set('mkl', 'lapack_libs', lapack)
                 self.sitecfg.set('mkl', 'mk_libs', blas)
 
-
         else:
             lapack_root_dir = get_software_root("OpenBLAS")
             if lapack_root_dir:
@@ -221,7 +220,6 @@ class EB_numpy(FortranPythonPackage):
                 self.sitecfg.set('umfpack', 'Include_dirs',
                                  os.path.join(umfpackdir, 'Include'))
                 self.sitecfg.set('umfpack', 'umfpack_Libs', 'umfpack')
-
 
         # I need to dump the configfile to a string
         sitecfg_fh = StringIO.StringIO()


### PR DESCRIPTION
I reversed the order the things that are done because I needed to compute the various `blas`, `lapack` etc variables before putting them into the `site.cfg` since the `site.cfg` of numpy does not allow interpolation