### PR TITLE
Enabled filtering of paths in the CPATH variable generated for the wrapper

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -110,7 +110,7 @@ class EB_TensorFlow(PythonPackage):
                 self.log.info("$%s old value was %s" % (var, path))
                 filtered_path = os.pathsep.join([p for fil in path_filter for p in path if fil not in p])
                 self.log.info("$%s new value is %s" % (var, filtered_path))
-                setvar(var, filtered_path)
+                env.setvar(var, filtered_path)
 
         # put wrapper for Intel C compiler in place (required to make sure license server is found)
         # cfr. https://github.com/bazelbuild/bazel/issues/663
@@ -125,7 +125,7 @@ class EB_TensorFlow(PythonPackage):
             }
             icc_wrapper = os.path.join(wrapper_dir, 'icc')
             write_file(icc_wrapper, icc_wrapper_txt)
-            env.setvar('PATH', ':'.join([os.path.dirname(icc_wrapper), os.getenv('PATH')]))
+            env.setvar('PATH', os.pathsep.join([os.path.dirname(icc_wrapper), os.getenv('PATH')]))
             if self.dry_run:
                 self.dry_run_msg("Wrapper for 'icc' was put in place: %s", icc_wrapper)
             else:

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -103,13 +103,12 @@ class EB_TensorFlow(PythonPackage):
         # filter out paths from CPATH and LIBRARY_PATH. This is needed since bazel will pull some dependencies that
         # might conflict with dependencies on the system and/or installed with EB. For example: protobuf
         path_filter = self.cfg['path_filter']
-        if len(path_filter > 0):
-            self.log.info("Filtering $CPATH and $LIBRARY_PATH")
+        if path_filter:
+            self.log.info("Filtering $CPATH and $LIBRARY_PATH with path filter %s", path_filter)
             for var in ['CPATH', 'LIBRARY_PATH']:
-                path = os.getenv(var).split(':')
+                path = os.getenv(var).split(os.pathsep)
                 self.log.info("$%s old value was %s" % (var, path))
                 filtered_path = os.pathsep.join([p for fil in path_filter for p in path if fil not in p])
-                self.log.info("$%s new value is %s" % (var, filtered_path))
                 env.setvar(var, filtered_path)
 
         # put wrapper for Intel C compiler in place (required to make sure license server is found)

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -114,7 +114,7 @@ class EB_TensorFlow(PythonPackage):
 
             icc_wrapper_txt = INTEL_COMPILER_WRAPPER % {
                 'compiler_path': which('icc'),
-                'cpath': cpath,
+                'cpath': os.getenv('CPATH'),
                 'intel_license_file': os.getenv('INTEL_LICENSE_FILE', os.getenv('LM_LICENSE_FILE')),
                 'wrapper_dir': wrapper_dir,
             }

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -104,7 +104,7 @@ class EB_TensorFlow(PythonPackage):
         package_filter = self.cfg['package_filter']
         for var in ['CPATH', 'LIBRARY_PATH']:
             path = os.getenv(var).split(':')
-            filtered_path = [path for fil in package_filter for p in path if fil not in p]
+            filtered_path = [p for fil in package_filter for p in path if fil not in p]
             os.environ[var] = ':'.join(filtered_path)
 
         # put wrapper for Intel C compiler in place (required to make sure license server is found)


### PR DESCRIPTION
As we know, bazel pulls a lot of stuff on its own. In the existing setup, these versions might conflict with packages already installed and included in the CPATH variable generated for the `icc` wrapper. This PR enables package filtering there. What this does not do is filtering CPATH when using `gcc`-based toolchains. Input? Should we extend the filter to work also under other toolchains where a wrapper is not generated?