### PR TITLE
make sure xmlpatterns always gets built with Qt

### DIFF
--- a/easybuild/easyblocks/q/qt.py
+++ b/easybuild/easyblocks/q/qt.py
@@ -81,6 +81,8 @@ class EB_Qt(ConfigureMake):
         else:
             raise EasyBuildError("Don't know which platform to set based on compiler family.")
 
+        self.cfg.update('configopts', '-xmlpatterns')
+
         cmd = "%s ./configure -prefix %s %s" % (self.cfg['preconfigopts'], self.installdir, self.cfg['configopts'])
         qa = {
             "Type 'o' if you want to use the Open Source Edition.": 'o',
@@ -129,8 +131,8 @@ class EB_Qt(ConfigureMake):
             libfile = os.path.join('lib', 'libqt.%s' % shlib_ext)
 
         custom_paths = {
-            'files': [libfile],
-            'dirs': ['bin', 'include', 'plugins'],
+            'files': ['bin/moc', 'bin/qmake', 'bin/xmlpatterns', libfile],
+            'dirs': ['include', 'plugins'],
         }
 
         super(EB_Qt, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/q/qt.py
+++ b/easybuild/easyblocks/q/qt.py
@@ -81,7 +81,9 @@ class EB_Qt(ConfigureMake):
         else:
             raise EasyBuildError("Don't know which platform to set based on compiler family.")
 
-        if LooseVersion(self.version) >= LooseVersion('4'):
+        # configure Qt such that xmlpatterns is also installed
+        # -xmlpatterns is not a known configure option for Qt 5.x, but there xmlpatterns support is enabled by default
+        if LooseVersion(self.version) >= LooseVersion('4') and LooseVersion(self.version) < LooseVersion('5'):
             self.cfg.update('configopts', '-xmlpatterns')
 
         cmd = "%s ./configure -prefix %s %s" % (self.cfg['preconfigopts'], self.installdir, self.cfg['configopts'])

--- a/easybuild/easyblocks/q/qt.py
+++ b/easybuild/easyblocks/q/qt.py
@@ -81,7 +81,8 @@ class EB_Qt(ConfigureMake):
         else:
             raise EasyBuildError("Don't know which platform to set based on compiler family.")
 
-        self.cfg.update('configopts', '-xmlpatterns')
+        if LooseVersion(self.version) >= LooseVersion('4'):
+            self.cfg.update('configopts', '-xmlpatterns')
 
         cmd = "%s ./configure -prefix %s %s" % (self.cfg['preconfigopts'], self.installdir, self.cfg['configopts'])
         qa = {
@@ -131,8 +132,11 @@ class EB_Qt(ConfigureMake):
             libfile = os.path.join('lib', 'libqt.%s' % shlib_ext)
 
         custom_paths = {
-            'files': ['bin/moc', 'bin/qmake', 'bin/xmlpatterns', libfile],
+            'files': ['bin/moc', 'bin/qmake', libfile],
             'dirs': ['include', 'plugins'],
         }
+
+        if LooseVersion(self.version) >= LooseVersion('4'):
+            custom_paths['files'].append('bin/xmlpatterns')
 
         super(EB_Qt, self).sanity_check_step(custom_paths=custom_paths)


### PR DESCRIPTION
fix for https://github.com/easybuilders/easybuild-easyconfigs/issues/6302

For some reason, `xmlpatterns` isn't always installed. Explicitly configuring for it seems to help though... This problem only seems to occur with `Qt` 4.x, the `Qt5` installations I have all include `bin/xmlpatterns`

WIP since all existing `Qt` easyconfigs need to be retested to ensure they all still work...