### PR TITLE
fix symlink check in NWChem easyblock + use change_dir/remove_file/symlink functions

### DIFF
--- a/easybuild/easyblocks/n/nwchem.py
+++ b/easybuild/easyblocks/n/nwchem.py
@@ -40,7 +40,7 @@ from distutils.version import LooseVersion
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import adjust_permissions, mkdir, write_file
+from easybuild.tools.filetools import adjust_permissions, change_dir, mkdir, remove_file, symlink, write_file
 from easybuild.tools.modules import get_software_libdir, get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
 
@@ -56,9 +56,13 @@ class EB_NWChem(ConfigureMake):
         # path for symlink to local copy of default .nwchemrc, required by NWChem at runtime
         # this path is hardcoded by NWChem, and there's no way to make it use a config file at another path...
         self.home_nwchemrc = os.path.join(os.getenv('HOME'), '.nwchemrc')
+        # temporary directory that is common across multiple nodes in a cluster;
+        # we can't rely on tempfile.gettempdir() since that follows $TMPDIR,
+        # which is typically set to a unique directory in jobs;
+        # use /tmp as default, allow customisation via $EB_NWCHEM_TMPDIR environment variable
+        common_tmp_dir = os.getenv('EB_NWCHEM_TMPDIR', '/tmp')
         # local NWChem .nwchemrc config file, to which symlink will point
         # using this approach, multiple parallel builds (on different nodes) can use the same symlink
-        common_tmp_dir = os.path.dirname(tempfile.gettempdir())  # common tmp directory, same across nodes
         self.local_nwchemrc = os.path.join(common_tmp_dir, os.getenv('USER'), 'easybuild_nwchem', '.nwchemrc')
 
     @staticmethod
@@ -98,12 +102,14 @@ class EB_NWChem(ConfigureMake):
                 self.log.debug("Contents of %s: %s", os.path.dirname(self.local_nwchemrc),
                                os.listdir(os.path.dirname(self.local_nwchemrc)))
 
-                if os.path.islink(self.home_nwchemrc) and not os.path.samefile(self.home_nwchemrc, self.local_nwchemrc):
-                    raise EasyBuildError("Found %s, but it's not a symlink to %s. "
-                                         "Please (re)move %s while installing NWChem; it can be restored later",
-                                         self.home_nwchemrc, self.local_nwchemrc, self.home_nwchemrc)
+                if os.path.islink(self.home_nwchemrc):
+                    home_nwchemrc_target = os.readlink(self.home_nwchemrc)
+                    if home_nwchemrc_target != self.local_nwchemrc:
+                        raise EasyBuildError("Found %s, but it's not a symlink to %s. "
+                                             "Please (re)move %s while installing NWChem; it can be restored later",
+                                             self.home_nwchemrc, self.local_nwchemrc, self.home_nwchemrc)
                 # ok to remove, we'll recreate it anyway
-                os.remove(self.local_nwchemrc)
+                remove_file(self.local_nwchemrc)
         except (IOError, OSError), err:
             raise EasyBuildError("Failed to validate %s symlink: %s", self.home_nwchemrc, err)
 
@@ -116,17 +122,14 @@ class EB_NWChem(ConfigureMake):
             # avoid having '['/']' characters in build dir name, NWChem doesn't like that
             start_dir = tmpdir.replace('[', '_').replace(']', '_')
             mkdir(os.path.dirname(start_dir), parents=True)
-            os.symlink(self.cfg['start_dir'], start_dir)
-            os.chdir(start_dir)
+            symlink(self.cfg['start_dir'], start_dir)
+            change_dir(start_dir)
             self.cfg['start_dir'] = start_dir
         except OSError, err:
             raise EasyBuildError("Failed to symlink build dir to a shorter path name: %s", err)
 
         # change to actual build dir
-        try:
-            os.chdir('src')
-        except OSError, err:
-            raise EasyBuildError("Failed to change to build dir: %s", err)
+        change_dir('src')
 
         nwchem_modules = self.cfg['modules']
 
@@ -284,15 +287,15 @@ class EB_NWChem(ConfigureMake):
             self.log.info("Building version info...")
 
             cwd = os.getcwd()
-            os.chdir(os.path.join(self.cfg['start_dir'], 'src', 'util'))
+            change_dir(os.path.join(self.cfg['start_dir'], 'src', 'util'))
 
             run_cmd("make version", simple=True, log_all=True, log_ok=True, log_output=True)
             run_cmd("make", simple=True, log_all=True, log_ok=True, log_output=True)
 
-            os.chdir(os.path.join(self.cfg['start_dir'], 'src'))
+            change_dir(os.path.join(self.cfg['start_dir'], 'src'))
             run_cmd("make link", simple=True, log_all=True, log_ok=True, log_output=True)
 
-            os.chdir(cwd)
+            change_dir(cwd)
 
         except OSError, err:
             raise EasyBuildError("Failed to build version info: %s", err)
@@ -301,12 +304,9 @@ class EB_NWChem(ConfigureMake):
         # this is an alternative to specifying -DDFLT_TOT_MEM via LIB_DEFINES
         # this recompiles the appropriate files and relinks
         if not 'DDFLT_TOT_MEM' in self.cfg['lib_defines']:
-            try:
-                os.chdir(os.path.join(self.cfg['start_dir'], 'contrib'))
-                run_cmd("./getmem.nwchem", simple=True, log_all=True, log_ok=True, log_output=True)
-                os.chdir(self.cfg['start_dir'])
-            except OSError, err:
-                raise EasyBuildError("Failed to run getmem.nwchem script: %s", err)
+            change_dir(os.path.join(self.cfg['start_dir'], 'contrib'))
+            run_cmd("./getmem.nwchem", simple=True, log_all=True, log_ok=True, log_output=True)
+            change_dir(self.cfg['start_dir'])
 
     def install_step(self):
         """Custom install procedure for NWChem."""
@@ -436,8 +436,8 @@ class EB_NWChem(ConfigureMake):
 
                 # only try to create symlink if it's not there yet
                 # we've verified earlier that the symlink is what we expect it to be if it's there
-                if not os.path.exists(self.home_nwchemrc):
-                    os.symlink(self.local_nwchemrc, self.home_nwchemrc)
+                if not os.path.islink(self.home_nwchemrc):
+                    symlink(self.local_nwchemrc, self.home_nwchemrc)
             except OSError, err:
                 raise EasyBuildError("Failed to symlink %s to %s: %s", self.home_nwchemrc, self.local_nwchemrc, err)
 
@@ -456,7 +456,7 @@ class EB_NWChem(ConfigureMake):
 
                 # run test in a temporary dir
                 tmpdir = tempfile.mkdtemp(prefix='nwchem_test_')
-                os.chdir(tmpdir)
+                change_dir(tmpdir)
 
                 # copy all files in test case dir
                 for item in os.listdir(testdir):
@@ -495,7 +495,7 @@ class EB_NWChem(ConfigureMake):
                     tot += 1
 
                 # go back
-                os.chdir(cwd)
+                change_dir(cwd)
                 shutil.rmtree(tmpdir)
 
             fail_ratio = fail / tot


### PR DESCRIPTION
This is basically two fixes combined:

* i) Don't use `tempfile.gettempdir()` to determine location for temporary directory that is local to the system but can be a common target for the `$HOME/.nwchemrc` symlink across workernodes on a cluster. Since `tempfile.gettempdir()` follows `$TMPDIR` which is set to a job-unique directory by resource managers like Torque, the location obtained that way isn't common at all...

* ii) Fix the check to see whether an existing `$HOME/.nwchemrc` points to the right location. We can't just use `os.path.samefile`, since the symlink may be broken (in fact, it usually is). Resolving the symlink and directly comparing the locations fixes that.

(WIP since it still requires thorough testing)