### PR TITLE
Adding support for --optarch=GENERIC for GROMACS

### DIFF
--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -103,7 +103,7 @@ class EB_GROMACS(CMakeMake):
             # According to [2] the performance difference between SSE2 and SSE4.1 is minor on x86
             # and SSE4.1 is not supported by AMD Magny-Cours[1].
             res = 'SSE2'
-        elif optarch == OPTARCH_GENERIC:
+        elif optarch == OPTARCH_GENERIC and LooseVersion(self.version) >= LooseVersion('5.0'):
             cpu_arch = get_cpu_architecture()
             if cpu_arch == X86_64:
                 res = 'SSE2'

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -112,8 +112,10 @@ class EB_GROMACS(CMakeMake):
             else:
                 res = 'None'
         elif optarch:
-            print_warning("OPTARCH set to %s but not used."
-                          "Compiling GROMACS for the current host architecture", optarch)
+            warn_msg = "--optarch configuration setting set to %s but not taken into account; " % optarch
+            warn_msg += "compiling GROMACS for the current host architecture (i.e. the default behavior)"
+            self.log.warning(warn_msg)
+            print_warning(warn_msg)
 
         if res:
             self.log.info("Target architecture based on optarch configuration option ('%s'): %s", optarch, res)

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -49,8 +49,7 @@ from easybuild.tools.filetools import download_file, extract_file, which
 from easybuild.tools.modules import get_software_libdir, get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
 from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
-from easybuild.tools.systemtools import X86_64
-from easybuild.tools.systemtools import get_cpu_architecture, get_shared_lib_ext
+from easybuild.tools.systemtools import X86_64, get_cpu_architecture, get_shared_lib_ext
 
 
 class EB_GROMACS(CMakeMake):

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -113,7 +113,6 @@ class EB_GROMACS(CMakeMake):
                 res = 'None'
         elif optarch:
             self.log.info("OPTARCH set to %s but not used. Compiling GROMACS for the current host architecture")
-            
 
         if res:
             self.log.info("Target architecture based on optarch configuration option ('%s'): %s", optarch, res)

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -50,7 +50,7 @@ from easybuild.tools.modules import get_software_libdir, get_software_root, get_
 from easybuild.tools.run import run_cmd
 from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
 from easybuild.tools.systemtools import X86_64
-from easybuild.tools.systemtools import get_cpu_architecture, get_platform_name, get_shared_lib_ext
+from easybuild.tools.systemtools import get_cpu_architecture, get_shared_lib_ext
 
 
 class EB_GROMACS(CMakeMake):

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -103,12 +103,15 @@ class EB_GROMACS(CMakeMake):
             # According to [2] the performance difference between SSE2 and SSE4.1 is minor on x86
             # and SSE4.1 is not supported by AMD Magny-Cours[1].
             res = 'SSE2'
-        elif optarch == OPTARCH_GENERIC and LooseVersion(self.version) >= LooseVersion('5.0'):
+        elif optarch == OPTARCH_GENERIC:
             cpu_arch = get_cpu_architecture()
             if cpu_arch == X86_64:
                 res = 'SSE2'
             else:
                 res = 'None'
+        elif optarch:
+            self.log.info("OPTARCH set to %s but not used. Compiling GROMACS for the current host architecture")
+            
 
         if res:
             self.log.info("Target architecture based on optarch configuration option ('%s'): %s", optarch, res)

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -48,7 +48,9 @@ from easybuild.tools.config import build_option
 from easybuild.tools.filetools import download_file, extract_file, which
 from easybuild.tools.modules import get_software_libdir, get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
-from easybuild.tools.systemtools import get_platform_name , get_shared_lib_ext
+from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
+from easybuild.tools.systemtools import X86_64
+from easybuild.tools.systemtools import get_cpu_architecture, get_platform_name, get_shared_lib_ext
 
 
 class EB_GROMACS(CMakeMake):
@@ -102,6 +104,12 @@ class EB_GROMACS(CMakeMake):
             # According to [2] the performance difference between SSE2 and SSE4.1 is minor on x86
             # and SSE4.1 is not supported by AMD Magny-Cours[1].
             res = 'SSE2'
+        elif optarch == OPTARCH_GENERIC:
+            cpu_arch = get_cpu_architecture()
+            if cpu_arch == X86_64:
+                res = 'SSE2'
+            else:
+                res = 'None'
 
         if res:
             self.log.info("Target architecture based on optarch configuration option ('%s'): %s", optarch, res)

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -43,7 +43,7 @@ import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.framework.easyconfig import CUSTOM
-from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.build_log import EasyBuildError, print_warning
 from easybuild.tools.config import build_option
 from easybuild.tools.filetools import download_file, extract_file, which
 from easybuild.tools.modules import get_software_libdir, get_software_root, get_software_version
@@ -112,7 +112,7 @@ class EB_GROMACS(CMakeMake):
             else:
                 res = 'None'
         elif optarch:
-            self.log.info("OPTARCH set to %s but not used. Compiling GROMACS for the current host architecture")
+            print_warning("OPTARCH set to %s but not used. Compiling GROMACS for the current host architecture", optarch)
 
         if res:
             self.log.info("Target architecture based on optarch configuration option ('%s'): %s", optarch, res)

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -90,6 +90,8 @@ class EB_GROMACS(CMakeMake):
             optarch = optarch.get(comp_fam, '')
         optarch = optarch.upper()
 
+        # The list of GMX_SIMD options can be found
+        # http://manual.gromacs.org/documentation/2018/install-guide/index.html#simd-support
         if 'MIC-AVX512' in optarch and LooseVersion(self.version) >= LooseVersion('2016'):
             res = 'AVX_512_KNL'
         elif 'AVX512' in optarch and LooseVersion(self.version) >= LooseVersion('2016'):

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -112,7 +112,8 @@ class EB_GROMACS(CMakeMake):
             else:
                 res = 'None'
         elif optarch:
-            print_warning("OPTARCH set to %s but not used. Compiling GROMACS for the current host architecture", optarch)
+            print_warning("OPTARCH set to %s but not used."
+                          "Compiling GROMACS for the current host architecture", optarch)
 
         if res:
             self.log.info("Target architecture based on optarch configuration option ('%s'): %s", optarch, res)


### PR DESCRIPTION
This PR allows the use of EASYBUILD_OPTARCH=GENERIC for GROMACS. It sets
the GMX_SIMD to 'SSE2' if the underlying software is a X86_64. This is a
good approximation since SSE2 were introduced in 2001 for intel CPUs and
in 2003 for AMD ones. This build would only break if one is compiling
for a >18 year old intel or >15 years old AMD.

For other architectures it sets the GMX_SIMD to 'None'