### PR TITLE
Ipp

### DIFF
--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -434,12 +434,6 @@ class IntelBase(EasyBlock):
             txt += self.module_generator.prepend_paths(self.license_env_var, [self.license_file],
                                                        allow_abs=True, expand_relpaths=False)
 
-        if self.cfg['m32']:
-            nlspath = os.path.join('idb', '32', 'locale', '%l_%t', '%N')
-        else:
-            nlspath = os.path.join('idb', 'intel64', 'locale', '%l_%t', '%N')
-        txt += self.module_generator.prepend_paths('NLSPATH', nlspath)
-
         return txt
 
     def cleanup_step(self):

--- a/easybuild/easyblocks/i/ipp.py
+++ b/easybuild/easyblocks/i/ipp.py
@@ -112,7 +112,7 @@ class EB_ipp(IntelBase):
         custom_paths = {
             'files': [
                 os.path.join('ipp', 'lib', 'intel64', 'libipp%s') % y for x in ipp_libs
-                    for y in ['%s.a' % x, '%s.%s' % (x, shlib_ext)]
+                for y in ['%s.a' % x, '%s.%s' % (x, shlib_ext)]
             ],
             'dirs': dirs,
         }

--- a/easybuild/easyblocks/i/ipp.py
+++ b/easybuild/easyblocks/i/ipp.py
@@ -109,7 +109,7 @@ class EB_ipp(IntelBase):
         guesses = super(EB_ipp, self).make_module_req_guess()
 
         if LooseVersion(self.version) >= LooseVersion('9.0'):
-            lib_path = os.pathsep.join(os.path.join('ipp/lib', self.arch), os.path.join('lib', self.arch))
+            lib_path = os.pathsep.join([os.path.join('ipp/lib', self.arch), os.path.join('lib', self.arch)])
             include_path = 'ipp/include'
 
             guesses.update({

--- a/easybuild/easyblocks/i/ipp.py
+++ b/easybuild/easyblocks/i/ipp.py
@@ -31,6 +31,7 @@ EasyBuild support for installing the Intel Performance Primitives (IPP) library,
 @author: Pieter De Baets (Ghent University)
 @author: Jens Timmerman (Ghent University)
 @author: Lumir Jasiok (IT4Innovations)
+@author: Damian Alvarez (Forschungszentrum Juelich GmbH)
 """
 
 from distutils.version import LooseVersion
@@ -83,20 +84,36 @@ class EB_ipp(IntelBase):
         shlib_ext = get_shared_lib_ext()
 
         if LooseVersion(self.version) < LooseVersion('8.0'):
-            dirs = ['compiler/lib/intel64', 'ipp/bin', 'ipp/include',
-                    'ipp/interfaces/data-compression', 'ipp/tools/intel64']
+            dirs = [
+                os.path.join('compiler', 'lib', 'intel64'),
+                os.path.join('ipp', 'bin'),
+                os.path.join('ipp', 'include'),
+                os.path.join('ipp', 'interfaces', 'data-compression'),
+                os.path.join('ipp', 'tools', 'intel64')
+            ]
         elif LooseVersion(self.version) >= LooseVersion('9.0'):
-            dirs = ['ipp/bin', 'ipp/include', 'ipp/tools/intel64']
+            dirs = [
+                os.path.join('ipp', 'bin'),
+                os.path.join('ipp', 'include'),
+                os.path.join('ipp', 'tools', 'intel64')
+            ]
         else:
-            dirs = ['composerxe/lib/intel64', 'ipp/bin', 'ipp/include',
-                    'ipp/tools/intel64']
+            dirs = [
+                os.path.join('composerxe', 'lib', 'intel64'),
+                os.path.join('ipp', 'bin'),
+                os.path.join('ipp', 'include'),
+                os.path.join('ipp', 'tools', 'intel64')
+            ]
 
         ipp_libs = ['cc', 'ch', 'core', 'cv', 'dc', 'i', 's', 'vm']
         if LooseVersion(self.version) < LooseVersion('9.0'):
             ipp_libs.extend(['ac', 'di', 'j', 'm', 'r', 'sc', 'vc'])
 
         custom_paths = {
-            'files': ['ipp/lib/intel64/libipp%s' % y for x in ipp_libs for y in ['%s.a' % x, '%s.%s' % (x, shlib_ext)]],
+            'files': [
+                os.path.join('ipp', 'lib', 'intel64', 'libipp%s') % y for x in ipp_libs
+                    for y in ['%s.a' % x, '%s.%s' % (x, shlib_ext)]
+            ],
             'dirs': dirs,
         }
 
@@ -109,8 +126,8 @@ class EB_ipp(IntelBase):
         guesses = super(EB_ipp, self).make_module_req_guess()
 
         if LooseVersion(self.version) >= LooseVersion('9.0'):
-            lib_path = [os.path.join('ipp/lib', self.arch), os.path.join('lib', self.arch)]
-            include_path = 'ipp/include'
+            lib_path = [os.path.join('ipp', 'lib', self.arch), os.path.join('lib', self.arch)]
+            include_path = os.path.join('ipp', 'include')
 
             guesses.update({
                 'LD_LIBRARY_PATH': lib_path,

--- a/easybuild/easyblocks/i/ipp.py
+++ b/easybuild/easyblocks/i/ipp.py
@@ -109,14 +109,15 @@ class EB_ipp(IntelBase):
         guesses = super(EB_ipp, self).make_module_req_guess()
 
         if LooseVersion(self.version) >= LooseVersion('9.0'):
-            lib_path = os.path.join('lib', self.arch)
+            lib_path = [os.path.join('ipp/lib', self.arch), os.path.join('lib', self.arch)]
             include_path = 'ipp/include'
 
             guesses.update({
-                'LD_LIBRARY_PATH': [lib_path],
-                'LIBRARY_PATH': [lib_path],
+                'LD_LIBRARY_PATH': lib_path,
+                'LIBRARY_PATH': lib_path,
                 'CPATH': [include_path],
                 'INCLUDE': [include_path],
             })
+            guesses.pop('NLSPATH')
 
         return guesses

--- a/easybuild/easyblocks/i/ipp.py
+++ b/easybuild/easyblocks/i/ipp.py
@@ -118,6 +118,5 @@ class EB_ipp(IntelBase):
                 'CPATH': [include_path],
                 'INCLUDE': [include_path],
             })
-            guesses.pop('NLSPATH')
 
         return guesses

--- a/easybuild/easyblocks/i/ipp.py
+++ b/easybuild/easyblocks/i/ipp.py
@@ -83,27 +83,16 @@ class EB_ipp(IntelBase):
         """Custom sanity check paths for IPP."""
         shlib_ext = get_shared_lib_ext()
 
+        dirs = [ os.path.join('ipp', x) for x in ['bin', 'include', os.path.join('tools', 'intel64')]]
         if LooseVersion(self.version) < LooseVersion('8.0'):
-            dirs = [
+            dirs.extend([
                 os.path.join('compiler', 'lib', 'intel64'),
-                os.path.join('ipp', 'bin'),
-                os.path.join('ipp', 'include'),
                 os.path.join('ipp', 'interfaces', 'data-compression'),
-                os.path.join('ipp', 'tools', 'intel64')
-            ]
-        elif LooseVersion(self.version) >= LooseVersion('9.0'):
-            dirs = [
-                os.path.join('ipp', 'bin'),
-                os.path.join('ipp', 'include'),
-                os.path.join('ipp', 'tools', 'intel64')
-            ]
-        else:
-            dirs = [
+            ])
+        elif LooseVersion(self.version) < LooseVersion('9.0'):
+            dirs.extend([
                 os.path.join('composerxe', 'lib', 'intel64'),
-                os.path.join('ipp', 'bin'),
-                os.path.join('ipp', 'include'),
-                os.path.join('ipp', 'tools', 'intel64')
-            ]
+            ])
 
         ipp_libs = ['cc', 'ch', 'core', 'cv', 'dc', 'i', 's', 'vm']
         if LooseVersion(self.version) < LooseVersion('9.0'):

--- a/easybuild/easyblocks/i/ipp.py
+++ b/easybuild/easyblocks/i/ipp.py
@@ -83,7 +83,7 @@ class EB_ipp(IntelBase):
         """Custom sanity check paths for IPP."""
         shlib_ext = get_shared_lib_ext()
 
-        dirs = [ os.path.join('ipp', x) for x in ['bin', 'include', os.path.join('tools', 'intel64')]]
+        dirs = [os.path.join('ipp', x) for x in ['bin', 'include', os.path.join('tools', 'intel64')]]
         if LooseVersion(self.version) < LooseVersion('8.0'):
             dirs.extend([
                 os.path.join('compiler', 'lib', 'intel64'),

--- a/easybuild/easyblocks/i/ipp.py
+++ b/easybuild/easyblocks/i/ipp.py
@@ -109,12 +109,12 @@ class EB_ipp(IntelBase):
         guesses = super(EB_ipp, self).make_module_req_guess()
 
         if LooseVersion(self.version) >= LooseVersion('9.0'):
-            lib_path = os.pathsep.join([os.path.join('ipp/lib', self.arch), os.path.join('lib', self.arch)])
+            lib_path = [os.path.join('ipp/lib', self.arch), os.path.join('lib', self.arch)]
             include_path = 'ipp/include'
 
             guesses.update({
-                'LD_LIBRARY_PATH': [lib_path],
-                'LIBRARY_PATH': [lib_path],
+                'LD_LIBRARY_PATH': lib_path,
+                'LIBRARY_PATH': lib_path,
                 'CPATH': [include_path],
                 'INCLUDE': [include_path],
             })

--- a/easybuild/easyblocks/i/ipp.py
+++ b/easybuild/easyblocks/i/ipp.py
@@ -109,12 +109,12 @@ class EB_ipp(IntelBase):
         guesses = super(EB_ipp, self).make_module_req_guess()
 
         if LooseVersion(self.version) >= LooseVersion('9.0'):
-            lib_path = [os.path.join('ipp/lib', self.arch), os.path.join('lib', self.arch)]
+            lib_path = os.pathsep.join(os.path.join('ipp/lib', self.arch), os.path.join('lib', self.arch))
             include_path = 'ipp/include'
 
             guesses.update({
-                'LD_LIBRARY_PATH': lib_path,
-                'LIBRARY_PATH': lib_path,
+                'LD_LIBRARY_PATH': [lib_path],
+                'LIBRARY_PATH': [lib_path],
                 'CPATH': [include_path],
                 'INCLUDE': [include_path],
             })


### PR DESCRIPTION
`NLSPATH` with idb has been an useless variable for a long time. At least since 2015. More importantly, the `ipp` easyblock has never set correctly the library paths, as the ipp libraries are in `ipp/lib/intel64`, not in `lib/intel64` (which also exists and has some extra libraries)