### PR TITLE
fix extension filter for Perl modules (WIP)

### DIFF
--- a/easybuild/easyblocks/p/perl.py
+++ b/easybuild/easyblocks/p/perl.py
@@ -37,7 +37,7 @@ from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.run import run_cmd
 
 # perldoc -lm seems to be the safest way to test if a module is available, based on exit code
-EXTS_FILTER_PERL_MODULES = ("perldoc -lm %(ext_name)s ", "")
+EXTS_FILTER_PERL_MODULES = ("perl -e 'require %(ext_name)s'", '')
 
 
 class EB_Perl(ConfigureMake):


### PR DESCRIPTION
Current approach of checking whether Perl modules are installed fails to catch missing dependencies, cfr.:

```
$ perldoc -lm 'GD::Graph'
/prefix/software/Perl/5.26.1-GCCcore-6.4.0/lib/perl5/site_perl/5.26.1/GD/Graph.pm
$ echo $?
0
```

vs

```
$ perl -e 'require GD::Graph'
Can't locate GD.pm in @INC (you may need to install the GD module) (@INC contains: /prefix/software/Perl/5.26.1-GCCcore-6.4.0/lib/perl5/site_perl/5.26.1/x86_64-linux-thread-multi /prefix/software/Perl/5.26.1-GCCcore-6.4.0/lib/perl5/site_perl/5.26.1 /prefix/software/Perl/5.26.1-GCCcore-6.4.0/lib/perl5/5.26.1/x86_64-linux-thread-multi /prefix/software/Perl/5.26.1-GCCcore-6.4.0/lib/perl5/5.26.1) at /prefix/software/Perl/5.26.1-GCCcore-6.4.0/lib/perl5/site_perl/5.26.1/GD/Graph.pm line 38.
BEGIN failed--compilation aborted at /prefix/software/Perl/5.26.1-GCCcore-6.4.0/lib/perl5/site_perl/5.26.1/GD/Graph.pm line 38.
Compilation failed in require at -e line 1.
$ echo $?
2
```

I made this WIP for now because fixing this impacts all `Perl` easyconfigs, and maybe other easyconfigs in which Perl extensions are involved, since the extension filter is also used during the sanity check...

Accompanying fixes will be required in these easyconfigs to avoid installations suddenly failing to complete.