### PR TITLE
define $LDSHARED when installing Python packages when Python's value doesn't use toolchain compiler ($CC)

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -453,7 +453,10 @@ class PythonPackage(ExtensionEasyBlock):
             curr_cc = os.getenv('CC')
             python_ldshared = get_config_vars('LDSHARED')[0]
             if python_ldshared:
-                if python_ldshared.split(' ')[0] != curr_cc:
+                if python_ldshared.split(' ')[0] == curr_cc:
+                    self.log.info("Python's value for $LDSHARED ('%s') uses current $CCi value ('%s'), so not touching it",
+                                  python_ldshared, curr_cc)
+                else:
                     self.log.info("Python's value for $LDSHARED ('%s') doesn't use current $CC value ('%s'), fixing",
                                   python_ldshared, curr_cc)
                     env.setvar("LDSHARED", curr_cc + " -shared")

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -452,7 +452,8 @@ class PythonPackage(ExtensionEasyBlock):
             curr_cc = os.getenv('CC')
             python_ldshared = get_config_vars('LDSHARED')[0].split(' ')
             if python_ldshared[0] != curr_cc:
-                self.log.info("Python's value for $LDSHARED ('%s') doesn't use current $CC value ('%s'), fixing that...", python_ldshared, curr_cc)
+                self.log.info("Python's value for $LDSHARED ('%s') doesn't use current $CC value ('%s'), fixing",
+                              python_ldshared, curr_cc)
                 env.setvar("LDSHARED", curr_cc + " -shared")
 
             cmd = ' '.join([self.cfg['prebuildopts'], self.python_cmd, 'setup.py', self.cfg['buildcmd'],

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -454,7 +454,7 @@ class PythonPackage(ExtensionEasyBlock):
             python_ldshared = get_config_vars('LDSHARED')[0]
             if python_ldshared:
                 if python_ldshared.split(' ')[0] == curr_cc:
-                    self.log.info("Python's value for $LDSHARED ('%s') uses current $CCi value ('%s'), so not touching it",
+                    self.log.info("Python's value for $LDSHARED ('%s') uses current $CC value ('%s'), not touching it",
                                   python_ldshared, curr_cc)
                 else:
                     self.log.info("Python's value for $LDSHARED ('%s') doesn't use current $CC value ('%s'), fixing",

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -449,7 +449,11 @@ class PythonPackage(ExtensionEasyBlock):
                 env.setvar("CMAKE_INCLUDE_PATH", include_paths)
                 env.setvar("CMAKE_LIBRARY_PATH", library_paths)
 
-            env.setvar("LDSHARED", "%s -shared" % self.toolchain.get_variable("CC", str))
+            curr_cc = os.getenv('CC')
+            python_ldshared = get_config_vars('LDSHARED')[0].split(' ')
+            if python_ldshared[0] != curr_cc:
+                self.log.info("Python's value for $LDSHARED ('%s') doesn't use current $CC value ('%s'), fixing that...", python_ldshared, curr_cc)
+                env.setvar("LDSHARED", curr_cc + " -shared")
 
             cmd = ' '.join([self.cfg['prebuildopts'], self.python_cmd, 'setup.py', self.cfg['buildcmd'],
                             self.cfg['buildopts']])

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -449,6 +449,8 @@ class PythonPackage(ExtensionEasyBlock):
                 env.setvar("CMAKE_INCLUDE_PATH", include_paths)
                 env.setvar("CMAKE_LIBRARY_PATH", library_paths)
 
+            env.setvar("LDSHARED", "%s -shared" % self.toolchain.get_variable("CC", str))
+
             cmd = ' '.join([self.cfg['prebuildopts'], self.python_cmd, 'setup.py', self.cfg['buildcmd'],
                             self.cfg['buildopts']])
             run_cmd(cmd, log_all=True, simple=True)


### PR DESCRIPTION
Fix for setuptools at GCCcore level for easybuilders/easybuild-easyconfigs#6537