### PR TITLE
boost.py - upgrade to reflect name change of python 3 related lib files in Boost 1.67.0

### DIFF
--- a/easybuild/easyblocks/b/boost.py
+++ b/easybuild/easyblocks/b/boost.py
@@ -252,7 +252,10 @@ class EB_Boost(EasyBlock):
             pymajorver = get_software_version('Python').split('.')[0]
             pyminorver = get_software_version('Python').split('.')[1]
             if int(pymajorver) >= 3:
-                suffix = pymajorver
+                if LooseVersion(self.version) >= LooseVersion("1.68.0"):
+                    suffix = '%s%s' % (pymajorver, pyminorver)
+                else:
+                    suffix = pymajorver
             elif LooseVersion(self.version) >= LooseVersion("1.67.0"):
                 suffix = '%s%s' % (pymajorver, pyminorver)
             else:

--- a/easybuild/easyblocks/b/boost.py
+++ b/easybuild/easyblocks/b/boost.py
@@ -251,13 +251,10 @@ class EB_Boost(EasyBlock):
         if get_software_root('Python'):
             pymajorver = get_software_version('Python').split('.')[0]
             pyminorver = get_software_version('Python').split('.')[1]
-            if int(pymajorver) >= 3:
-                if LooseVersion(self.version) >= LooseVersion("1.68.0"):
-                    suffix = '%s%s' % (pymajorver, pyminorver)
-                else:
-                    suffix = pymajorver
-            elif LooseVersion(self.version) >= LooseVersion("1.67.0"):
+            if LooseVersion(self.version) >= LooseVersion("1.67.0"):
                 suffix = '%s%s' % (pymajorver, pyminorver)
+            elif int(pymajorver) >= 3:
+                suffix = pymajorver
             else:
                 suffix = ''
             custom_paths["files"].append('lib/libboost_python%s.%s' % (suffix, shlib_ext))


### PR DESCRIPTION
With this block, I could build Boost 1.68.0 for

foss/2018b, Python 3.7.0
intel/2018b, Python 2.7.15
intel/2018b, Python 3.7.0

configurations to follow as a PR in the easyconfigs
