### PR TITLE
Used os.path.join in cuda.py, and added ldconfig to post_install_step

### DIFF
--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -132,11 +132,10 @@ class EB_CUDA(Binary):
         if LooseVersion(self.version) < LooseVersion("6"):
             chk_libdir += ["lib"]
 
+        culibs = ["cublas", "cudart", "cufft", "curand", "cusparse"]
         custom_paths = {
-            'files': [os.path.join("bin", "%s") % x for x in ["fatbinary", "nvcc", "nvlink", "ptxas"]] +
-                     [os.path.join("%s", "lib%s.%s") % (x, y, shlib_ext) for x in chk_libdir for y in ["cublas",
-                                                                                      "cudart", "cufft", "curand",
-                                                                                      "cusparse"]],
+            'files': [os.path.join("bin", x) for x in ["fatbinary", "nvcc", "nvlink", "ptxas"]] +
+            [os.path.join("%s", "lib%s.%s") % (x, y, shlib_ext) for x in chk_libdir for y in culibs],
             'dirs': ["include"],
         }
 

--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -73,7 +73,7 @@ class EB_CUDA(Binary):
             # note: also including samples (via "-samplespath=%(installdir)s -samples") would require libglut
             self.cfg.update('installopts', "-verbose -silent -toolkitpath=%s -toolkit" % self.installdir)
 
-        cmd = "%(preinstallopts)s perl ./%(script)s %(installopts)s" % {
+        cmd = "%(preinstallopts)s perl %(script)s %(installopts)s" % {
             'preinstallopts': self.cfg['preinstallopts'],
             'script': install_script,
             'installopts': self.cfg['installopts']
@@ -101,11 +101,12 @@ class EB_CUDA(Binary):
         if 'DISPLAY' in os.environ:
             os.environ.pop('DISPLAY')
 
-        #overriding maxhits default value to 300 (300s wait for nothing to change in the output without seeing a known question)
+        # overriding maxhits default value to 300 (300s wait for nothing to change in the output without seeing a known
+        # question)
         run_cmd_qa(cmd, qanda, std_qa=stdqa, no_qa=noqanda, log_all=True, simple=True, maxhits=300)
 
     def post_install_step(self):
-        """Create wrappers for the specified host compilers"""
+        """Create wrappers for the specified host compilers and generate the appropriate stub symlinks"""
         def create_wrapper(wrapper_name, wrapper_comp):
             """Create for a particular compiler, with a particular name"""
             wrapper_f = os.path.join(self.installdir, 'bin', wrapper_name)
@@ -115,6 +116,9 @@ class EB_CUDA(Binary):
         # Prepare wrappers to handle a default host compiler other than g++
         for comp in (self.cfg['host_compilers'] or []):
             create_wrapper('nvcc_%s' % comp, comp)
+
+        # Run ldconfig to create missing symlinks in the stubs directory (libcuda.so.1, etc)
+        run_cmd("ldconfig -N " + os.path.join(self.installdir, 'lib64', 'stubs'))
 
         super(EB_CUDA, self).post_install_step()
 
@@ -129,17 +133,18 @@ class EB_CUDA(Binary):
             chk_libdir += ["lib"]
 
         custom_paths = {
-            'files': ["bin/%s" % x for x in ["fatbinary", "nvcc", "nvlink", "ptxas"]] +
-                     ["%s/lib%s.%s" % (x, y, shlib_ext) for x in chk_libdir for y in ["cublas", "cudart", "cufft",
-                                                                                      "curand", "cusparse"]],
+            'files': [os.path.join("bin", "%s") % x for x in ["fatbinary", "nvcc", "nvlink", "ptxas"]] +
+                     [os.path.join("%s", "lib%s.%s") % (x, y, shlib_ext) for x in chk_libdir for y in ["cublas",
+                                                                                      "cudart", "cufft", "curand",
+                                                                                      "cusparse"]],
             'dirs': ["include"],
         }
 
         if LooseVersion(self.version) < LooseVersion('7'):
-            custom_paths['files'].append('open64/bin/nvopencc')
+            custom_paths['files'].append(os.path.join('open64', 'bin', 'nvopencc'))
         if LooseVersion(self.version) >= LooseVersion('7'):
-            custom_paths['files'].append("extras/CUPTI/lib64/libcupti.%s" % shlib_ext)
-            custom_paths['dirs'].append("extras/CUPTI/include")
+            custom_paths['files'].append(os.path.join("extras", "CUPTI", "lib64", "libcupti.%s") % shlib_ext)
+            custom_paths['dirs'].append(os.path.join("extras", "CUPTI", "include"))
 
 
         super(EB_CUDA, self).sanity_check_step(custom_paths=custom_paths)
@@ -152,22 +157,22 @@ class EB_CUDA(Binary):
         # The dirs should be in the order ['open64/bin', 'bin']
         bin_path = []
         if LooseVersion(self.version) < LooseVersion('7'):
-            bin_path.append('open64/bin')
+            bin_path.append(os.path.join('open64', 'bin'))
         bin_path.append('bin')
 
         lib_path = ['lib64']
         inc_path = ['include']
         if LooseVersion(self.version) >= LooseVersion('7'):
-            lib_path.append('extras/CUPTI/lib64')
-            inc_path.append('extras/CUPTI/include')
-            bin_path.append('nvvm/bin')
-            lib_path.append('nvvm/lib64')
-            inc_path.append('nvvm/include')
+            lib_path.append(os.path.join('extras', 'CUPTI', 'lib64'))
+            inc_path.append(os.path.join('extras', 'CUPTI', 'include'))
+            bin_path.append(os.path.join('nvvm', 'bin'))
+            lib_path.append(os.path.join('nvvm', 'lib64'))
+            inc_path.append(os.path.join('nvvm', 'include'))
 
         guesses.update({
             'PATH': bin_path,
             'LD_LIBRARY_PATH': lib_path,
-            'LIBRARY_PATH': ['lib64', 'lib64/stubs'],
+            'LIBRARY_PATH': ['lib64', os.path.join('lib64', 'stubs')],
             'CPATH': inc_path,
             'CUDA_HOME': [''],
             'CUDA_ROOT': [''],


### PR DESCRIPTION
This PR makes the easyblock use `os.path.join` instead of `/`, but more importantly, runs `ldconfig -N` in the stubs directory, to create the proper symlinks. This is necessary to deal with binaries created outside of EB, which might be linked against `libcuda.so.1` instead of `libcuda.so`, like, for instance, `MVAPICH2-GDR`