### PR TITLE
Added CCOLAMD and CAMD to Trilinos

### DIFF
--- a/easybuild/easyblocks/t/trilinos.py
+++ b/easybuild/easyblocks/t/trilinos.py
@@ -125,7 +125,7 @@ class EB_Trilinos(CMakeMake):
         if suitesparse:
             self.cfg.update('configopts', "-DTPL_ENABLE_UMFPACK:BOOL=ON")
             incdirs, libdirs, libnames = [], [], []
-            for lib in ["UMFPACK", "CHOLMOD", "COLAMD", "AMD"]:
+            for lib in ["UMFPACK", "CHOLMOD", "COLAMD", "AMD", "CCOLAMD", "CAMD"]:
                 incdirs.append(os.path.join(suitesparse, lib, "Include"))
                 libdirs.append(os.path.join(suitesparse, lib, "Lib"))
                 libnames.append(lib.lower())


### PR DESCRIPTION
For `Trilinos-12.12.1` the paths for `SuiteSparse` `CCOLAMD` and `CAMD` libraries must be added to the linker paths.