### PR TITLE
switch to using CMake install procedure for Eigen 3.3.4 & newer

### DIFF
--- a/easybuild/easyblocks/e/eigen.py
+++ b/easybuild/easyblocks/e/eigen.py
@@ -33,6 +33,9 @@ class EB_Eigen(CMakeMake):
 
     def configure_step(self):
         """Custom configuration procedure for Eigen."""
+        # start using CMake for Eigen 3.3.4 and newer versions
+        # not done for older versions, since this implies using (a dummy-built) CMake as a build dependency,
+        # which is a bit strange for a header-only library like Eigen...
         if LooseVersion(self.version) >= LooseVersion('3.3.4'):
             self.cfg['separate_build_dir'] = True
             # avoid that include files are installed into include/eigen3/Eigen, should be include/Eigen

--- a/easybuild/easyblocks/e/eigen.py
+++ b/easybuild/easyblocks/e/eigen.py
@@ -21,36 +21,46 @@ import os
 import shutil
 from distutils.version import LooseVersion
 
-from easybuild.easyblocks.generic.tarball import Tarball
+from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import mkdir
+from easybuild.tools.filetools import copy_dir, copy_file, mkdir
 
 
-class EB_Eigen(Tarball):
+class EB_Eigen(CMakeMake):
     """
     Support for building Eigen.
     """
+
+    def configure_step(self):
+        """Custom configuration procedure for Eigen."""
+        if LooseVersion(self.version) >= LooseVersion('3.3.4'):
+            self.cfg['separate_build_dir'] = True
+            # avoid that include files are installed into include/eigen3/Eigen, should be include/Eigen
+            self.cfg.update('configopts', "-DINCLUDE_INSTALL_DIR=%s" % os.path.join(self.installdir, 'include'))
+            CMakeMake.configure_step(self)
+
+    def build_step(self):
+        """Custom build procedure for Eigen."""
+        if LooseVersion(self.version) >= LooseVersion('3.3.4'):
+            CMakeMake.build_step(self)
 
     def install_step(self):
         """
         Install by copying files to install dir
         """
-        mkdir(os.path.join(self.installdir, 'include'), parents=True)
-        for subdir in ['Eigen', 'unsupported']:
-            srcdir = os.path.join(self.cfg['start_dir'], subdir)
-            destdir = os.path.join(self.installdir, os.path.join('include', subdir))
-            try:
-                shutil.copytree(srcdir, destdir, ignore=shutil.ignore_patterns('CMakeLists.txt'))
-            except OSError, err:
-                raise EasyBuildError("Copying %s to installation dir %s failed: %s", srcdir, destdir, err)
+        if LooseVersion(self.version) >= LooseVersion('3.3.4'):
+            CMakeMake.install_step(self)
+        else:
+            mkdir(os.path.join(self.installdir, 'include'), parents=True)
+            for subdir in ['Eigen', 'unsupported']:
+                srcdir = os.path.join(self.cfg['start_dir'], subdir)
+                destdir = os.path.join(self.installdir, os.path.join('include', subdir))
+                copy_dir(srcdir, destdir, ignore=shutil.ignore_patterns('CMakeLists.txt'))
 
-        if LooseVersion(self.version) >= LooseVersion('3.0'):
-            srcfile = os.path.join(self.cfg['start_dir'], 'signature_of_eigen3_matrix_library')
-            destfile = os.path.join(self.installdir, 'include/signature_of_eigen3_matrix_library')
-            try:
-                shutil.copy2(srcfile, destfile)
-            except OSError, err:
-                raise EasyBuildError("Copying %s to installation dir %s failed: %s", srcfile, destfile, err)
+            if LooseVersion(self.version) >= LooseVersion('3.0'):
+                srcfile = os.path.join(self.cfg['start_dir'], 'signature_of_eigen3_matrix_library')
+                destfile = os.path.join(self.installdir, 'include/signature_of_eigen3_matrix_library')
+                copy_file(srcfile, destfile)
 
     def sanity_check_step(self):
         """Custom sanity check for Eigen."""
@@ -72,6 +82,9 @@ class EB_Eigen(Tarball):
 
         if LooseVersion(self.version) >= LooseVersion('3.0'):
             custom_paths['files'].append('include/signature_of_eigen3_matrix_library')
+
+        if LooseVersion(self.version) >= LooseVersion('3.3.4'):
+            custom_paths['files'].append('share/pkgconfig/eigen3.pc')
 
         super(EB_Eigen, self).sanity_check_step(custom_paths=custom_paths)
 


### PR DESCRIPTION
If the CMake-based installation procedure is not using, the `eigen3.pc` file for `pkg-config` does not get generated & installed...