### PR TITLE
added regex to fix WM_PROJECT_VERSION correctly

### DIFF
--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -155,7 +155,12 @@ class EB_OpenFOAM(EasyBlock):
             self.log.debug("Patching out hardcoded $WM_* env vars in %s", script)
             # disable any third party stuff, we use EB controlled builds
             regex_subs = [(r"^(setenv|export) WM_THIRD_PARTY_USE_.*[ =].*$", r"# \g<0>")]
-            regex_subs += [(r"^(setenv|export) WM_PROJECT_VERSION=.*$", r"export WM_PROJECT_VERSION=%s #\g<0>" % self.version)]
+
+            # replacement dictionary of key-values
+            replacement_dict = {"WM_PROJECT_VERSION": self.version}
+            for key,val in replacement_dict.items():
+                regex_subs += [(r"^(setenv|export) %s=.*$" % key, r"export %s=%s #\g<0>" % (key, val))]
+
             WM_env_var = ['WM_COMPILER', 'WM_MPLIB', 'WM_THIRD_PARTY_DIR']
             # OpenFOAM >= 3.0.0 can use 64 bit integers
             if 'extend' not in self.name.lower() and LooseVersion(self.version) >= LooseVersion('3.0'):

--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -156,10 +156,12 @@ class EB_OpenFOAM(EasyBlock):
             # disable any third party stuff, we use EB controlled builds
             regex_subs = [(r"^(setenv|export) WM_THIRD_PARTY_USE_.*[ =].*$", r"# \g<0>")]
 
-            # replacement dictionary of key-values
-            replacement_dict = {"WM_PROJECT_VERSION": self.version}
-            for key, val in replacement_dict.items():
-                regex_subs += [(r"^(setenv|export) %s=.*$" % key, r"export %s=%s #\g<0>" % (key, val))]
+            # this does not work for OpenFOAM Extend lower than 2.0
+            if 'extend' not in self.name.lower() or LooseVersion(self.version) >= LooseVersion('2.0'):
+                # replacement dictionary of key-values
+                replacement_dict = {"WM_PROJECT_VERSION": self.version}
+                for key, val in replacement_dict.items():
+                    regex_subs += [(r"^(setenv|export) %s=.*$" % key, r"export %s=%s #\g<0>" % (key, val))]
 
             WM_env_var = ['WM_COMPILER', 'WM_MPLIB', 'WM_THIRD_PARTY_DIR']
             # OpenFOAM >= 3.0.0 can use 64 bit integers

--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -158,10 +158,8 @@ class EB_OpenFOAM(EasyBlock):
 
             # this does not work for OpenFOAM Extend lower than 2.0
             if 'extend' not in self.name.lower() or LooseVersion(self.version) >= LooseVersion('2.0'):
-                # replacement dictionary of key-values
-                replacement_dict = {"WM_PROJECT_VERSION": self.version}
-                for key, val in replacement_dict.items():
-                    regex_subs += [(r"^(setenv|export) %s=.*$" % key, r"export %s=%s #\g<0>" % (key, val))]
+                key = "WM_PROJECT_VERSION"
+                regex_subs += [(r"^(setenv|export) %s=.*$" % key, r"export %s=%s #\g<0>" % (key, self.version))]
 
             WM_env_var = ['WM_COMPILER', 'WM_MPLIB', 'WM_THIRD_PARTY_DIR']
             # OpenFOAM >= 3.0.0 can use 64 bit integers

--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -155,6 +155,7 @@ class EB_OpenFOAM(EasyBlock):
             self.log.debug("Patching out hardcoded $WM_* env vars in %s", script)
             # disable any third party stuff, we use EB controlled builds
             regex_subs = [(r"^(setenv|export) WM_THIRD_PARTY_USE_.*[ =].*$", r"# \g<0>")]
+            regex_subs += [(r"^(setenv|export) WM_PROJECT_VERSION=.*$", r"export WM_PROJECT_VERSION=%s #\g<0>" % self.version)]
             WM_env_var = ['WM_COMPILER', 'WM_MPLIB', 'WM_THIRD_PARTY_DIR']
             # OpenFOAM >= 3.0.0 can use 64 bit integers
             if 'extend' not in self.name.lower() and LooseVersion(self.version) >= LooseVersion('3.0'):
@@ -162,7 +163,6 @@ class EB_OpenFOAM(EasyBlock):
             for env_var in WM_env_var:
                 regex_subs.append((r"^(setenv|export) (?P<var>%s)[ =](?P<val>.*)$" % env_var,
                                    r": ${\g<var>:=\g<val>}; export \g<var>"))
-
             apply_regex_substitutions(script, regex_subs)
 
         # inject compiler variables into wmake/rules files

--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -158,7 +158,7 @@ class EB_OpenFOAM(EasyBlock):
 
             # replacement dictionary of key-values
             replacement_dict = {"WM_PROJECT_VERSION": self.version}
-            for key,val in replacement_dict.items():
+            for key, val in replacement_dict.items():
                 regex_subs += [(r"^(setenv|export) %s=.*$" % key, r"export %s=%s #\g<0>" % (key, val))]
 
             WM_env_var = ['WM_COMPILER', 'WM_MPLIB', 'WM_THIRD_PARTY_DIR']


### PR DESCRIPTION
This fixes WM_PROJECT_VERSION in OpenFOAM's bashrc files to use whatever is used by the easyconfig. It allows to use custom version numbers since OpenFOAM is so bad at versioning their software. . 