### PR TITLE
Trinity 2.8 sanity check

### DIFF
--- a/easybuild/easyblocks/t/trinity.py
+++ b/easybuild/easyblocks/t/trinity.py
@@ -319,11 +319,16 @@ class EB_Trinity(EasyBlock):
         else:
             sep = '_r'
 
+        if version >= LooseVersion('2.8'):
+            chrysalis_bin = 'Chrysalis/bin/Chrysalis'
+        else:
+            chrysalis_bin = 'Chrysalis/Chrysalis'
+
         path = 'trinityrnaseq%s%s' % (sep, self.version)
 
         # these lists are definitely non-exhaustive, but better than nothing
         custom_paths = {
-            'files': [os.path.join(path, x) for x in ['Inchworm/bin/inchworm', 'Chrysalis/Chrysalis']],
+            'files': [os.path.join(path, x) for x in ['Inchworm/bin/inchworm', chrysalis_bin]],
             'dirs': [os.path.join(path, x) for x in ['Butterfly/src/bin', 'util']]
         }
 


### PR DESCRIPTION
Trinity 2.8 uses CMake for Chrysalis build, resultin in bin/ subdirectory.
see https://github.com/trinityrnaseq/trinityrnaseq/blob/484b3c9668b79b402df3da04117157c0ef5fea25/Changelog.txt#L2

When this is ok, I can bring in a PR for Trinity 2.8