### PR TITLE
FSL - Improve configuration choice

### DIFF
--- a/easybuild/easyblocks/f/fsl.py
+++ b/easybuild/easyblocks/f/fsl.py
@@ -68,6 +68,7 @@ class EB_FSL(EasyBlock):
         diff_regex = re.compile("^diff.*config\/", re.M)
         
         patched_cfgs = []
+        best_cfg = None
 
         for patch in self.patches:
             try:
@@ -88,9 +89,16 @@ class EB_FSL(EasyBlock):
         else:
             self.log.debug("No config dir found in patch files")
 
-        # prepare config
-        # either using matching config, or copy closest match
+        # If no patched config is found, pick best guess
         cfgdir = os.path.join(self.fsldir, "config")
+        if not best_cfg:
+            cfgs = os.listdir(cfgdir)
+            best_cfg = difflib.get_close_matches(fslmachtype, cfgs)[0]
+
+            self.log.debug("Best matching config dir for %s is %s" % (fslmachtype, best_cfg))
+
+        # Prepare config
+        # Either use patched config or copy closest match
         try:
             if fslmachtype != best_cfg:
                 srcdir = os.path.join(cfgdir, best_cfg)

--- a/easybuild/easyblocks/f/fsl.py
+++ b/easybuild/easyblocks/f/fsl.py
@@ -73,7 +73,7 @@ class EB_FSL(EasyBlock):
 
             patched_cfgs = []
             best_cfg = None
-            
+
             for patch in self.patches:
                 patchfile = read_file(patch['path'])
                 res = systype_regex.findall(patchfile)

--- a/easybuild/easyblocks/f/fsl.py
+++ b/easybuild/easyblocks/f/fsl.py
@@ -66,13 +66,14 @@ class EB_FSL(EasyBlock):
         fslmachtype = out.strip()
         self.log.debug("FSL machine type: %s" % fslmachtype)
 
+        best_cfg = None
+
         # Patch files for ver. < 5.0.10 patch multiple config directories
         if LooseVersion(self.version) >= LooseVersion('5.0.10'):
             # Check if a specific machine type directory is patched
             systype_regex = re.compile("^diff.*config\/(.*(apple|gnu|i686|linux|spark)(?:(?!\/).)*)", re.M)
 
             patched_cfgs = []
-            best_cfg = None
 
             for patch in self.patches:
                 patchfile = read_file(patch['path'])

--- a/easybuild/easyblocks/f/fsl.py
+++ b/easybuild/easyblocks/f/fsl.py
@@ -72,7 +72,8 @@ class EB_FSL(EasyBlock):
             systype_regex = re.compile("^diff.*config\/(.*(apple|gnu|i686|linux|spark)(?:(?!\/).)*)", re.M)
 
             patched_cfgs = []
-
+            best_cfg = None
+            
             for patch in self.patches:
                 patchfile = read_file(patch['path'])
                 res = systype_regex.findall(patchfile)


### PR DESCRIPTION
`FSL` build relies on an internal check and a script to identify the appropriate configuration to use. Since the available configurations are for relatively old compilers, the current easyblock uses `difflib.get_close_matches` to identify the closest configuration and copies the directory containing it into a new one named after the configuration targeted by `FSL`. In certain cases the guessed closest configuration is not the same as the one at which required patches are applied, resulting in a build failure.
This easyblock change uses the patch files as first source of information to guess the target directory and rolls back to `difflib.get_close_matches` only if no target configuration is found in the patches.