### PR TITLE
Qscintilla no python

### DIFF
--- a/easybuild/easyblocks/q/qscintilla.py
+++ b/easybuild/easyblocks/q/qscintilla.py
@@ -138,7 +138,8 @@ class EB_QScintilla(ConfigureMake):
         python = get_software_root('Python')
         custom_commands = []
         if python:
-            custom_paths['dirs'] += [os.path.join(det_pylibdir(), 'PyQt4'), os.path.join('qsci', 'api', 'python'), os.path.join('share', 'sip', 'PyQt4')]
+            custom_paths['dirs'] += [os.path.join(det_pylibdir(), 'PyQt4'), os.path.join('qsci', 'api', 'python'),
+                                     os.path.join('share', 'sip', 'PyQt4')]
             custom_commands = ["python -c 'import PyQt4.Qsci'"]
 
         super(EB_QScintilla, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)

--- a/easybuild/easyblocks/q/qscintilla.py
+++ b/easybuild/easyblocks/q/qscintilla.py
@@ -147,5 +147,7 @@ class EB_QScintilla(ConfigureMake):
     def make_module_extra(self):
         """Custom extra module file entries for QScintilla."""
         txt = super(EB_QScintilla, self).make_module_extra()
-        txt += self.module_generator.prepend_paths('PYTHONPATH', [det_pylibdir()])
+        python = get_software_root('Python')
+        if python:
+            txt += self.module_generator.prepend_paths('PYTHONPATH', [det_pylibdir()])
         return txt

--- a/easybuild/easyblocks/q/qscintilla.py
+++ b/easybuild/easyblocks/q/qscintilla.py
@@ -131,10 +131,14 @@ class EB_QScintilla(ConfigureMake):
 
         custom_paths = {
             'files': [os.path.join('lib', qsci_lib + '.' + get_shared_lib_ext())],
-            'dirs': ['data', os.path.join('include', 'Qsci'), os.path.join(det_pylibdir(), 'PyQt4'),
-                     os.path.join('qsci', 'api', 'python'), os.path.join('share', 'sip', 'PyQt4'), 'trans'],
+            'dirs': ['data', os.path.join('include', 'Qsci'), 'trans'],
         }
-        custom_commands = ["python -c 'import PyQt4.Qsci'"]
+        # also install Python bindings if Python is included as a dependency
+        python = get_software_root('Python')
+        custom_commands = []
+        if python:
+            custom_paths['dirs'] += [os.path.join(det_pylibdir(), 'PyQt4'), os.path.join('qsci', 'api', 'python'), os.path.join('share', 'sip', 'PyQt4')]
+            custom_commands = ["python -c 'import PyQt4.Qsci'"]
 
         super(EB_QScintilla, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
 

--- a/easybuild/easyblocks/q/qscintilla.py
+++ b/easybuild/easyblocks/q/qscintilla.py
@@ -26,6 +26,7 @@
 EasyBuild support for building and installing QScintilla, implemented as an easyblock
 
 author: Kenneth Hoste (HPC-UGent)
+author: Maxime Boissonneault (Compute Canada)
 """
 import os
 from distutils.version import LooseVersion


### PR DESCRIPTION
Fixes sanity_check when python is not being used as a dependency. 