### PR TITLE
add generic ModulesRC easyblock

### DIFF
--- a/easybuild/easyblocks/generic/modulealias.py
+++ b/easybuild/easyblocks/generic/modulealias.py
@@ -83,7 +83,10 @@ class ModuleAlias(EasyBlock):
         ])
         write_file(modulerc, modulerc_txt)
 
-        return self.module_generator.get_modules_path(fake=fake)
+        modpath = self.module_generator.get_modules_path(fake=fake)
+        self.invalidate_module_caches(modpath)
+
+        return modpath
 
     def sanity_check_step(self, *args, **kwargs):
         """

--- a/easybuild/easyblocks/generic/modulealias.py
+++ b/easybuild/easyblocks/generic/modulealias.py
@@ -1,0 +1,94 @@
+##
+# Copyright 2018-2018 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for installing a software-specific .modulerc file
+
+@author: Kenneth Hoste (Ghent University)
+"""
+import os
+
+from easybuild.framework.easyblock import EasyBlock
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.config import build_option
+from easybuild.tools.filetools import write_file
+from easybuild.tools.module_generator import ModuleGeneratorTcl
+
+
+class ModuleAlias(EasyBlock):
+    """
+    Generic easyblock to create a software-specific .modulerc file
+    """
+
+    def configure_step(self):
+        """Do nothing."""
+        pass
+
+    def build_step(self):
+        """Do nothing."""
+        pass
+
+    def install_step(self):
+        """Do nothing."""
+        pass
+
+    def make_module_step(self, fake=False):
+        """Install .modulerc file."""
+        modfile_path = self.module_generator.get_module_filepath(fake=fake)
+        modulerc = os.path.join(os.path.dirname(modfile_path), '.modulerc')
+
+        if os.path.exists(modulerc) and not build_option('force'):
+            raise EasyBuildError("Found existing .modulerc at %s, not overwriting without --force", modulerc)
+
+        deps = self.cfg['dependencies']
+        if len(deps) != 1:
+            raise EasyBuildError("There should be only one single dependency specified, found %d", len(deps))
+
+        # names should match
+        if self.name != deps[0]['name']:
+            raise EasyBuildError("Name does not match dependency name: %s vs %s", self.name, deps[0]['name'])
+
+        # version to prefix of version to alias to
+        if not deps[0]['version'].startswith(self.version):
+            raise EasyBuildError("Version is not a prefix of dependency version: %s vs %s",
+                                 self.version, deps[0]['version'])
+
+        alias_modname = deps[0]['full_mod_name']
+        self.log.info("Adding module version alias for %s to %s", alias_modname, modulerc)
+
+        modulerc_txt = '\n'.join([
+            ModuleGeneratorTcl.MODULE_SHEBANG,
+            "module-version %s %s" % (alias_modname, self.version),
+        ])
+        write_file(modulerc, modulerc_txt)
+
+        return self.module_generator.get_modules_path(fake=fake)
+
+    def sanity_check_step(self, *args, **kwargs):
+        """
+        Custom sanity check: just try to load the module version alias
+        """
+        # test loading of (fake) module by means of sanity check
+        fake_mod_data = self.load_fake_module(purge=True)
+        self.clean_up_fake_module(fake_mod_data)

--- a/easybuild/easyblocks/generic/modulerc.py
+++ b/easybuild/easyblocks/generic/modulerc.py
@@ -68,7 +68,7 @@ class ModuleRC(EasyBlock):
         if self.name != deps[0]['name']:
             raise EasyBuildError("Name does not match dependency name: %s vs %s", self.name, deps[0]['name'])
 
-        # version to prefix of version to alias to
+        # ensure version to alias to is a prefix of the version of the dependency
         if not deps[0]['version'].startswith(self.version):
             raise EasyBuildError("Version is not a prefix of dependency version: %s vs %s",
                                  self.version, deps[0]['version'])

--- a/easybuild/easyblocks/generic/modulerc.py
+++ b/easybuild/easyblocks/generic/modulerc.py
@@ -36,7 +36,7 @@ from easybuild.tools.filetools import write_file
 from easybuild.tools.module_generator import ModuleGeneratorTcl
 
 
-class ModuleAlias(EasyBlock):
+class ModuleRC(EasyBlock):
     """
     Generic easyblock to create a software-specific .modulerc file
     """
@@ -77,10 +77,8 @@ class ModuleAlias(EasyBlock):
         alias_modname = deps[0]['full_mod_name']
         self.log.info("Adding module version alias for %s to %s", alias_modname, modulerc)
 
-        modulerc_txt = '\n'.join([
-            ModuleGeneratorTcl.MODULE_SHEBANG,
-            "module-version %s %s" % (alias_modname, self.version),
-        ])
+        module_version_specs = {'modname': alias_modname, 'sym_version': self.version, 'version': deps[0]['version']}
+        modulerc_txt = self.module_generator.modulerc(module_version=module_version_specs)
         write_file(modulerc, modulerc_txt)
 
         modpath = self.module_generator.get_modules_path(fake=fake)

--- a/easybuild/easyblocks/generic/modulerc.py
+++ b/easybuild/easyblocks/generic/modulerc.py
@@ -62,7 +62,7 @@ class ModuleRC(EasyBlock):
 
         deps = self.cfg['dependencies']
         if len(deps) != 1:
-            raise EasyBuildError("There should be only one single dependency specified, found %d", len(deps))
+            raise EasyBuildError("There should be exactly one dependency specified, found %d", len(deps))
 
         # names should match
         if self.name != deps[0]['name']:

--- a/easybuild/easyblocks/generic/modulerc.py
+++ b/easybuild/easyblocks/generic/modulerc.py
@@ -33,7 +33,6 @@ from easybuild.framework.easyblock import EasyBlock
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option
 from easybuild.tools.filetools import write_file
-from easybuild.tools.module_generator import ModuleGeneratorTcl
 
 
 class ModuleRC(EasyBlock):

--- a/test/easyblocks/module.py
+++ b/test/easyblocks/module.py
@@ -258,18 +258,19 @@ def template_module_only_test(self, easyblock, name='foo', version='1.3.2', extr
         finally:
             os.chdir(orig_workdir)
 
-        modfile = os.path.join(TMPDIR, 'modules', 'all', name, version)
-        luamodfile = '%s.lua' % modfile
-        self.assertTrue(os.path.exists(modfile) or os.path.exists(luamodfile),
-                        "Module file %s or %s was generated" % (modfile, luamodfile))
+        if os.path.basename(easyblock) not in ['modulealias.py']:
+            modfile = os.path.join(TMPDIR, 'modules', 'all', name, version)
+            luamodfile = '%s.lua' % modfile
+            self.assertTrue(os.path.exists(modfile) or os.path.exists(luamodfile),
+                            "Module file %s or %s was generated" % (modfile, luamodfile))
 
-        if os.path.exists(modfile):
-            modtxt = read_file(modfile)
-        else:
-            modtxt = read_file(luamodfile)
+            if os.path.exists(modfile):
+                modtxt = read_file(modfile)
+            else:
+                modtxt = read_file(luamodfile)
 
-        none_regex = re.compile('None')
-        self.assertFalse(none_regex.search(modtxt), "None not found in module file: %s" % modtxt)
+            none_regex = re.compile('None')
+            self.assertFalse(none_regex.search(modtxt), "None not found in module file: %s" % modtxt)
 
         # cleanup
         app.close_log()
@@ -311,6 +312,9 @@ def suite():
     for prgenv in ['PrgEnv-cray', 'PrgEnv-gnu', 'PrgEnv-intel', 'PrgEnv-pgi']:
         write_file(os.path.join(TMPDIR, 'modules', 'all', prgenv, '1.2.3'), "#%Module")
 
+    # add foo/1.3.2.1.1 module, required for testing ModuleAlias easyblock
+    write_file(os.path.join(TMPDIR, 'modules', 'all', 'foo', '1.3.2.1.1'), "#%Module")
+
     for easyblock in easyblocks:
         # dynamically define new inner functions that can be added as class methods to ModuleOnlyTest
         if os.path.basename(easyblock) == 'systemcompiler.py':
@@ -323,6 +327,10 @@ def suite():
         elif os.path.basename(easyblock) == 'craytoolchain.py':
             # make sure that a (known) PrgEnv is included as a dependency
             extra_txt = 'dependencies = [("PrgEnv-gnu/1.2.3", EXTERNAL_MODULE)]'
+            exec("def innertest(self): template_module_only_test(self, '%s', extra_txt='%s')" % (easyblock, extra_txt))
+        elif os.path.basename(easyblock) == 'modulealias.py':
+            # exactly one dependency is included with ModuleRC generic easyblock (and name must match)
+            extra_txt = 'dependencies = [("foo", "1.3.2.1.1")]'
             exec("def innertest(self): template_module_only_test(self, '%s', extra_txt='%s')" % (easyblock, extra_txt))
         else:
             exec("def innertest(self): template_module_only_test(self, '%s')" % easyblock)

--- a/test/easyblocks/module.py
+++ b/test/easyblocks/module.py
@@ -258,7 +258,7 @@ def template_module_only_test(self, easyblock, name='foo', version='1.3.2', extr
         finally:
             os.chdir(orig_workdir)
 
-        if os.path.basename(easyblock) == 'modulealias.py':
+        if os.path.basename(easyblock) == 'modulerc.py':
             # .modulerc must be cleaned up to avoid causing trouble (e.g. "Duplicate version symbol" errors)
             modulerc = os.path.join(TMPDIR, 'modules', 'all', name, '.modulerc')
             os.remove(modulerc)
@@ -332,7 +332,7 @@ def suite():
             # make sure that a (known) PrgEnv is included as a dependency
             extra_txt = 'dependencies = [("PrgEnv-gnu/1.2.3", EXTERNAL_MODULE)]'
             exec("def innertest(self): template_module_only_test(self, '%s', extra_txt='%s')" % (easyblock, extra_txt))
-        elif os.path.basename(easyblock) == 'modulealias.py':
+        elif os.path.basename(easyblock) == 'modulerc.py':
             # exactly one dependency is included with ModuleRC generic easyblock (and name must match)
             extra_txt = 'dependencies = [("foo", "1.2.3.4.5")]'
             test_definition = ' '.join([

--- a/test/easyblocks/module.py
+++ b/test/easyblocks/module.py
@@ -258,7 +258,11 @@ def template_module_only_test(self, easyblock, name='foo', version='1.3.2', extr
         finally:
             os.chdir(orig_workdir)
 
-        if os.path.basename(easyblock) not in ['modulealias.py']:
+        if os.path.basename(easyblock) == 'modulealias.py':
+            # .modulerc must be cleaned up to avoid causing trouble (e.g. "Duplicate version symbol" errors)
+            modulerc = os.path.join(TMPDIR, 'modules', 'all', name, '.modulerc')
+            os.remove(modulerc)
+        else:
             modfile = os.path.join(TMPDIR, 'modules', 'all', name, version)
             luamodfile = '%s.lua' % modfile
             self.assertTrue(os.path.exists(modfile) or os.path.exists(luamodfile),

--- a/test/easyblocks/module.py
+++ b/test/easyblocks/module.py
@@ -313,7 +313,7 @@ def suite():
         write_file(os.path.join(TMPDIR, 'modules', 'all', prgenv, '1.2.3'), "#%Module")
 
     # add foo/1.3.2.1.1 module, required for testing ModuleAlias easyblock
-    write_file(os.path.join(TMPDIR, 'modules', 'all', 'foo', '1.3.2.1.1'), "#%Module")
+    write_file(os.path.join(TMPDIR, 'modules', 'all', 'foo', '1.2.3.4.5'), "#%Module")
 
     for easyblock in easyblocks:
         # dynamically define new inner functions that can be added as class methods to ModuleOnlyTest
@@ -330,8 +330,12 @@ def suite():
             exec("def innertest(self): template_module_only_test(self, '%s', extra_txt='%s')" % (easyblock, extra_txt))
         elif os.path.basename(easyblock) == 'modulealias.py':
             # exactly one dependency is included with ModuleRC generic easyblock (and name must match)
-            extra_txt = 'dependencies = [("foo", "1.3.2.1.1")]'
-            exec("def innertest(self): template_module_only_test(self, '%s', extra_txt='%s')" % (easyblock, extra_txt))
+            extra_txt = 'dependencies = [("foo", "1.2.3.4.5")]'
+            test_definition = ' '.join([
+                "def innertest(self):",
+                "  template_module_only_test(self, '%s', version='1.2.3.4', extra_txt='%s')" % (easyblock, extra_txt),
+            ])
+            exec(test_definition)
         else:
             exec("def innertest(self): template_module_only_test(self, '%s')" % easyblock)
         innertest.__doc__ = "Test for using --module-only with easyblock %s" % easyblock


### PR DESCRIPTION
This is a new generic easyblock that generates a `.modulerc` file to define a module version alias rather than installing an actual module file (cfr. suggestion by @mboisson in https://github.com/easybuilders/easybuild-easyconfigs/pull/5203#issuecomment-415827214).

This can be used to for example install a `Java/1.8` wrapper (see https://github.com/easybuilders/easybuild-easyconfigs/pull/6712) for another `Java` module, without causing trouble with for example Lmod's module collection concept...

edit: now requires ~~https://github.com/easybuilders/easybuild-framework/pull/2571~~ and ~~https://github.com/easybuilders/easybuild-framework/pull/2575~~