### PR TITLE
bump Lmod version used in Travis config to 6.6.3 (now required by framework)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ python: 2.6
 env:
   matrix:
     - ENV_MOD_VERSION=3.2.10 EASYBUILD_MODULES_TOOL=EnvironmentModulesC EASYBUILD_MODULE_SYNTAX=Tcl
-    - LMOD_VERSION=5.8
-    - LMOD_VERSION=5.8 EASYBUILD_MODULE_SYNTAX=Tcl
+    - LMOD_VERSION=6.6.3
+    - LMOD_VERSION=6.6.3 EASYBUILD_MODULE_SYNTAX=Tcl
     - LMOD_VERSION=7.7.16
     - LMOD_VERSION=7.7.16 EASYBUILD_MODULE_SYNTAX=Tcl
     - ENV_MOD_VERSION=4.0.0 EASYBUILD_MODULES_TOOL=EnvironmentModules EASYBUILD_MODULE_SYNTAX=Tcl
@@ -14,7 +14,7 @@ matrix:
   include:
     # also test default configuration with Python 2.7
     - python: 2.7
-      env: LMOD_VERSION=5.8
+      env: LMOD_VERSION=6.6.3
 addons:
   apt:
     packages:


### PR DESCRIPTION
requires because of changes in https://github.com/easybuilders/easybuild-framework/pull/2575