### PR TITLE
Add support for IntelMPI in TensorFlow.

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -224,8 +224,6 @@ class EB_TensorFlow(PythonPackage):
             env.setvar(key, val)
 
         # patch configure.py (called by configure script) to avoid that Bazel abuses $HOME/.cache/bazel
-        # Should perhaps set --install_base  and --output_user_root too
-        # bazel still uses $HOME/.cache/bazel for some things.
         regex_subs = [(r"(run_shell\(\['bazel')", r"\1, '--output_base=%s'" % tmpdir)]
         apply_regex_substitutions('configure.py', regex_subs)
 

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -47,17 +47,23 @@ from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_os_name, get_os_version
 
 
-# wrapper for Intel compiler, where required environment are hardcoded to make sure they're present;
-# this is required because Bazel resets the environment in which compiler commands are executed...
+# Wrapper for Intel(MPI) compilers, where required environment variables
+# are hardcoded to make sure they are present;
+# this is required because Bazel resets the environment in which
+# compiler commands are executed...
 INTEL_COMPILER_WRAPPER = """#!/bin/bash
 
 export CPATH='%(cpath)s'
+
+# Only relevant for Intel compilers.
 export INTEL_LICENSE_FILE='%(intel_license_file)s'
-# only relevant for MPI compiler wrapper (mpiicc/mpicc etc),
-# not for regular compiler (icc)
+
+# Only relevant for MPI compiler wrapper (mpiicc/mpicc etc),
+# not for regular compiler.
 export I_MPI_ROOT='%(intel_mpi_root)s'
 
-# exclude location of this wrapper from $PATH to avoid other potential wrappers calling this wrapper
+# Exclude location of this wrapper from $PATH to avoid other potential
+# wrappers calling this wrapper.
 export PATH=$(echo $PATH | tr ':' '\n' | grep -v "^%(wrapper_dir)s$" | tr '\n' ':')
 
 %(compiler_path)s "$@"

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -170,6 +170,7 @@ class EB_TensorFlow(PythonPackage):
             impi_root = get_software_root('impi')
             if impi_root:
                 mpi_home = os.path.join(impi_root, 'intel64')
+                self.log.debug("Derived value for MPI_HOME: %s", mpi_home)
 
         config_env_vars = {
             'CC_OPT_FLAGS': os.getenv('CXXFLAGS'),

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -53,6 +53,8 @@ INTEL_COMPILER_WRAPPER = """#!/bin/bash
 
 export CPATH='%(cpath)s'
 export INTEL_LICENSE_FILE='%(intel_license_file)s'
+# only relevant for MPI compiler wrapper (mpiicc/mpicc etc),
+# not for regular compiler (icc)
 export I_MPI_ROOT='%(intel_mpi_root)s'
 
 # exclude location of this wrapper from $PATH to avoid other potential wrappers calling this wrapper


### PR DESCRIPTION
We need a separate wrappet for mpiicc (and probably for mpicxx if
using non-Intel compilers) because IntelMPI needs I_MPI_ROOT to be set.

This patch only adds support for IntelMPI with Intel compilers.

Also simplify PATH setting for the wrappers.