### PR TITLE
Make sure bazel doesn't write files in $HOME/.cache when building tensorflow

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -224,7 +224,7 @@ class EB_TensorFlow(PythonPackage):
             env.setvar(key, val)
 
         # patch configure.py (called by configure script) to avoid that Bazel abuses $HOME/.cache/bazel
-        regex_subs = [(r"(run_shell\(\['bazel')", r"\1, '--output_base=%s'" % tmpdir)]
+        regex_subs = [(r"(run_shell\(\['bazel')", r"\1, '--output_base=%s', '--install_base=%s'" % (tmpdir, os.path.join(tmpdir, 'inst_base')))]
         apply_regex_substitutions('configure.py', regex_subs)
 
         cmd = self.cfg['preconfigopts'] + './configure ' + self.cfg['configopts']
@@ -302,9 +302,10 @@ class EB_TensorFlow(PythonPackage):
                     apply_regex_substitutions(full_path, regex_subs)
 
         tmpdir = tempfile.mkdtemp(suffix='-bazel-build')
+        user_root_tmpdir = tempfile.mkdtemp(suffix='-user_root')
 
         # compose "bazel build" command with all its options...
-        cmd = [self.cfg['prebuildopts'], 'bazel', '--output_base=%s' % tmpdir, 'build']
+        cmd = [self.cfg['prebuildopts'], 'bazel', '--output_base=%s' % tmpdir, '--install_base=%s' % os.path.join(tmpdir, 'inst_base'), '--output_user_root=%s' % user_root_tmpdir, 'build']
 
         # build with optimization enabled
         # cfr. https://docs.bazel.build/versions/master/user-manual.html#flag--compilation_mode

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -224,7 +224,8 @@ class EB_TensorFlow(PythonPackage):
             env.setvar(key, val)
 
         # patch configure.py (called by configure script) to avoid that Bazel abuses $HOME/.cache/bazel
-        regex_subs = [(r"(run_shell\(\['bazel')", r"\1, '--output_base=%s', '--install_base=%s'" % (tmpdir, os.path.join(tmpdir, 'inst_base')))]
+        regex_subs = [(r"(run_shell\(\['bazel')",
+            r"\1, '--output_base=%s', '--install_base=%s'" % (tmpdir, os.path.join(tmpdir, 'inst_base')))]
         apply_regex_substitutions('configure.py', regex_subs)
 
         cmd = self.cfg['preconfigopts'] + './configure ' + self.cfg['configopts']
@@ -305,7 +306,8 @@ class EB_TensorFlow(PythonPackage):
         user_root_tmpdir = tempfile.mkdtemp(suffix='-user_root')
 
         # compose "bazel build" command with all its options...
-        cmd = [self.cfg['prebuildopts'], 'bazel', '--output_base=%s' % tmpdir, '--install_base=%s' % os.path.join(tmpdir, 'inst_base'), '--output_user_root=%s' % user_root_tmpdir, 'build']
+        cmd = [self.cfg['prebuildopts'], 'bazel', '--output_base=%s' % tmpdir,
+            '--install_base=%s' % os.path.join(tmpdir, 'inst_base'), '--output_user_root=%s' % user_root_tmpdir, 'build']
 
         # build with optimization enabled
         # cfr. https://docs.bazel.build/versions/master/user-manual.html#flag--compilation_mode

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -225,7 +225,7 @@ class EB_TensorFlow(PythonPackage):
 
         # patch configure.py (called by configure script) to avoid that Bazel abuses $HOME/.cache/bazel
         regex_subs = [(r"(run_shell\(\['bazel')",
-            r"\1, '--output_base=%s', '--install_base=%s'" % (tmpdir, os.path.join(tmpdir, 'inst_base')))]
+                      r"\1, '--output_base=%s', '--install_base=%s'" % (tmpdir, os.path.join(tmpdir, 'inst_base')))]
         apply_regex_substitutions('configure.py', regex_subs)
 
         cmd = self.cfg['preconfigopts'] + './configure ' + self.cfg['configopts']
@@ -307,7 +307,8 @@ class EB_TensorFlow(PythonPackage):
 
         # compose "bazel build" command with all its options...
         cmd = [self.cfg['prebuildopts'], 'bazel', '--output_base=%s' % tmpdir,
-            '--install_base=%s' % os.path.join(tmpdir, 'inst_base'), '--output_user_root=%s' % user_root_tmpdir, 'build']
+            '--install_base=%s' % os.path.join(tmpdir, 'inst_base'),
+            '--output_user_root=%s' % user_root_tmpdir, 'build']
 
         # build with optimization enabled
         # cfr. https://docs.bazel.build/versions/master/user-manual.html#flag--compilation_mode

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -225,7 +225,7 @@ class EB_TensorFlow(PythonPackage):
 
         # patch configure.py (called by configure script) to avoid that Bazel abuses $HOME/.cache/bazel
         regex_subs = [(r"(run_shell\(\['bazel')",
-                      r"\1, '--output_base=%s', '--install_base=%s'" % (tmpdir, os.path.join(tmpdir, 'inst_base')))]
+                       r"\1, '--output_base=%s', '--install_base=%s'" % (tmpdir, os.path.join(tmpdir, 'inst_base')))]
         apply_regex_substitutions('configure.py', regex_subs)
 
         cmd = self.cfg['preconfigopts'] + './configure ' + self.cfg['configopts']
@@ -307,8 +307,8 @@ class EB_TensorFlow(PythonPackage):
 
         # compose "bazel build" command with all its options...
         cmd = [self.cfg['prebuildopts'], 'bazel', '--output_base=%s' % tmpdir,
-            '--install_base=%s' % os.path.join(tmpdir, 'inst_base'),
-            '--output_user_root=%s' % user_root_tmpdir, 'build']
+               '--install_base=%s' % os.path.join(tmpdir, 'inst_base'),
+               '--output_user_root=%s' % user_root_tmpdir, 'build']
 
         # build with optimization enabled
         # cfr. https://docs.bazel.build/versions/master/user-manual.html#flag--compilation_mode


### PR DESCRIPTION
It still creates an empty directory, $HOME/.cache/bazel/_bazel_username,
but at least it doesn't write files in there.

This fixes https://github.com/easybuilders/easybuild-easyblocks/issues/1515