### PR TITLE
only read 'configure' script when it's actually there

### DIFF
--- a/easybuild/easyblocks/generic/configuremake.py
+++ b/easybuild/easyblocks/generic/configuremake.py
@@ -196,7 +196,7 @@ class ConfigureMake(EasyBlock):
         # it is possible that the configure script is generated using preconfigopts...
         # if so, we're at the mercy of the gods
         build_type_option = ''
-        if AUTOCONF_GENERATED_MSG in read_file(configure_command):
+        if os.path.exist(configure_command) and AUTOCONF_GENERATED_MSG in read_file(configure_command):
             build_type = self.cfg.get('build_type')
 
             if build_type is None:


### PR DESCRIPTION
fix for bug introduced in #1506:

```
== configuring...
== FAILED: Installation ended unsuccessfully (build directory: /tmp/easybuild_build/numactl/2.0.11/iccifort-2016.3.210-GCC-4.9.3-2.25): build failed (first 300 chars): Failed to read ./configure: [Errno 2] No such file or directory: './configure'
```

cc @ocaisa 