### PR TITLE
support bypassing use of system type obtained with recent config.guess in ConfigureMake

### DIFF
--- a/easybuild/easyblocks/generic/configuremake.py
+++ b/easybuild/easyblocks/generic/configuremake.py
@@ -73,7 +73,8 @@ class ConfigureMake(EasyBlock):
             'prefix_opt': [None, "Prefix command line option for configure script ('--prefix=' if None)", CUSTOM],
             'tar_config_opts': [False, "Override tar settings as determined by configure.", CUSTOM],
             'build_type': [None, "Type of system package is being configured for, e.g., x86_64-pc-linux-gnu "
-                                 "(determined by config.guess shipped with EasyBuild if None)", CUSTOM],
+                                 "(determined by config.guess shipped with EasyBuild if None, "
+                                 "False implies to leave it up to the configure script)", CUSTOM],
         })
         return extra_vars
 
@@ -221,7 +222,7 @@ class ConfigureMake(EasyBlock):
                     build_type = build_type.strip()
                     self.log.info("%s returned a build type %s", self.config_guess, build_type)
 
-            if build_type is not None:
+            if build_type is not None and build_type:
                 build_type_option = '--build=' + build_type
 
         cmd = ' '.join([


### PR DESCRIPTION
We currently don't have a way of bypassing the use of the system type obtained with the self-downloaded `config.guess` (cfr. #1506), other than specifying a value ourselves.

It runs out that passing the value to `--build` breaks `Hypre` (which somehow escaped my attention during the regression test for EasyBuild v3.7.0...), see also https://github.com/easybuilders/easybuild-easyconfigs/issues/6922 .