### PR TITLE
use DOT_MODULERC constant in ModuleRC easyblock rather than hardcoding '.modulerc'

### DIFF
--- a/easybuild/easyblocks/generic/modulerc.py
+++ b/easybuild/easyblocks/generic/modulerc.py
@@ -56,10 +56,10 @@ class ModuleRC(EasyBlock):
     def make_module_step(self, fake=False):
         """Install .modulerc file."""
         modfile_path = self.module_generator.get_module_filepath(fake=fake)
-        modulerc = os.path.join(os.path.dirname(modfile_path), '.modulerc')
+        modulerc = os.path.join(os.path.dirname(modfile_path), self.module_generator.DOT_MODULERC)
 
         if os.path.exists(modulerc) and not build_option('force'):
-            raise EasyBuildError("Found existing .modulerc at %s, not overwriting without --force", modulerc)
+            raise EasyBuildError("Found existing file at %s, not overwriting without --force", modulerc)
 
         deps = self.cfg['dependencies']
         if len(deps) != 1:


### PR DESCRIPTION
This is required because of the changes in https://github.com/easybuilders/easybuild-framework/pull/2597, since the `.modulerc` file has to named `.modulerc.lua` in case it's generated in Lua syntax for Lmod >= 7.8