### PR TITLE
use --no-deps when installing .whl in TensorFlow easyblock if extension are being installed, move test run to sanity check

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -38,6 +38,7 @@ from distutils.version import LooseVersion
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage
+from easybuild.easyblocks.python import EXTS_FILTER_PYTHON_PACKAGES
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import adjust_permissions, apply_regex_substitutions, mkdir, resolve_path
@@ -83,6 +84,18 @@ class EB_TensorFlow(PythonPackage):
             'with_mkl_dnn': [True, "Make TensorFlow use Intel MKL-DNN", CUSTOM],
         }
         return PythonPackage.extra_options(extra_vars)
+
+    def __init__(self, *args, **kwargs):
+        """Initialize TensorFlow easyblock."""
+        super(EB_TensorFlow, self).__init__(*args, **kwargs)
+
+        self.cfg['exts_defaultclass'] = 'PythonPackage'
+
+        self.cfg['exts_default_options'] = {
+            'download_dep_fail': True,
+            'use_pip': True,
+        }
+        self.cfg['exts_filter'] = EXTS_FILTER_PYTHON_PACKAGES
 
     def handle_jemalloc(self):
         """Figure out whether jemalloc support should be enabled or not."""

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -368,7 +368,13 @@ class EB_TensorFlow(PythonPackage):
         whl_paths = glob.glob(os.path.join(self.builddir, 'tensorflow-%s-*.whl' % whl_version))
         if len(whl_paths) == 1:
             # --ignore-installed is required to ensure *this* wheel is installed
-            cmd = "pip install --ignore-installed --no-deps --prefix=%s %s" % (self.installdir, whl_paths[0])
+            cmd = "pip install --ignore-installed --prefix=%s %s" % (self.installdir, whl_paths[0])
+
+            # if extensions are listed, assume they will provide all required dependencies,
+            # so use --no-deps to prevent pip from downloading & installing them
+            if self.cfg['exts_list']:
+                cmd += ' --no-deps'
+
             run_cmd(cmd, log_all=True, simple=True, log_ok=True)
         else:
             raise EasyBuildError("Failed to isolate built .whl in %s: %s", whl_paths, self.builddir)


### PR DESCRIPTION
This fixes the problem reported by @agijsberts in #1536, by also using `--no-deps` in the `pip install` command.

This change implies that all additional Python packages required by `TensorFlow` that are not available in the `Python` installation (e.g. `numpy` is) are included in the easyconfig file as extensions, so all `TensorFlow` easyconfig files that use this easyblock will need to be fixed...

Two other changes are also required:

* running the MNIST tutorial example as a test now *must* be done in the sanity check, since not all extension are available yet after the `pip install` of the generated `.whl`; the comment claiming that this couldn't be done in the sanity check step was incorrect, since the build dir isn't cleaned up yet

* creating of `google/__init__.py` now doesn't make sense anymore since the `protobuf` Python package will not be installed automagically anymore (instead, it should be listed as a dependency in the `TensorFlow` easyconfig file)