### PR TITLE
use os.getcwd() rather than self.startdir in TensorFlow easyblock to fix installation of TensorFlow as extension in a bundle

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -308,7 +308,7 @@ class EB_TensorFlow(PythonPackage):
             regex_subs.extend([('-fPIE', '-fPIC'), ('"-pie"', '"-fPIC"')])
 
         # patch all CROSSTOOL* scripts to fix hardcoding of locations of binutils/GCC binaries
-        for path, dirnames, filenames in os.walk(self.start_dir):
+        for path, dirnames, filenames in os.walk(os.getcwd()):
             for filename in filenames:
                 if filename.startswith('CROSSTOOL'):
                     full_path = os.path.join(path, filename)


### PR DESCRIPTION
`self.start_dir` doesn't point to the correct location when `TensorFlow` is being installed as an extension...

This is a backward-compatible change, I've verified that with existing easyconfigs where `TensorFlow` is installed stand-alone.