### PR TITLE
add generic easyblock for installing a bundle of Python packages

### DIFF
--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -47,14 +47,17 @@ class Bundle(EasyBlock):
     """
 
     @staticmethod
-    def extra_options():
-        extra_vars = {
+    def extra_options(extra_vars=None):
+        """Easyconfig parameters specific to bundles."""
+        if extra_vars is None:
+            extra_vars = {}
+        extra_vars.update({
             'altroot': [None, "Software name of dependency to use to define $EBROOT for this bundle", CUSTOM],
             'altversion': [None, "Software name of dependency to use to define $EBVERSION for this bundle", CUSTOM],
             'default_component_specs': [{}, "Default specs to use for every component", CUSTOM],
             'components': [(), "List of components to install: tuples w/ name, version and easyblock to use", CUSTOM],
             'default_easyblock': [None, "Default easyblock to use for components", CUSTOM],
-        }
+        })
         return EasyBlock.extra_options(extra_vars)
 
     def __init__(self, *args, **kwargs):

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -1,0 +1,103 @@
+##
+# Copyright 2018-2018 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for installing a bundle of Python packages, implemented as a generic easyblock
+
+@author: Kenneth Hoste (Ghent University)
+"""
+from easybuild.easyblocks.generic.bundle import Bundle
+from easybuild.easyblocks.generic.pythonpackage import PythonPackage, det_pylibdir
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.modules import get_software_root
+
+
+class PythonBundle(Bundle):
+    """
+    Bundle of modules: only generate module files, nothing to build/install
+    """
+
+    @staticmethod
+    def extra_options(extra_vars=None):
+        """Easyconfig parameters specific to bundles of Python packages."""
+        if extra_vars is None:
+            extra_vars = {}
+        # combine custom easyconfig parameters of Bundle & PythonPackage
+        extra_vars = Bundle.extra_options(extra_vars)
+        return PythonPackage.extra_options(extra_vars)
+
+    def __init__(self, *args, **kwargs):
+        """Initialize PythonBundle easyblock."""
+        super(PythonBundle, self).__init__(*args, **kwargs)
+
+        self.cfg['exts_defaultclass'] = 'PythonPackage'
+
+        # need to disable templating to ensure that actual value for exts_default_options is updated...
+        prev_enable_templating = self.cfg.enable_templating
+        self.cfg.enable_templating = False
+
+        # set default options for extensions according to relevant top-level easyconfig parameters
+        pypkg_keys = PythonPackage.extra_options().keys()
+        for key in pypkg_keys:
+            if key not in self.cfg['exts_default_options']:
+                self.cfg['exts_default_options'][key] = self.cfg[key]
+
+        self.cfg['exts_default_options']['download_dep_fail'] = True
+        self.log.info("Detection of downloaded extension dependencies is enabled")
+
+        self.cfg.enable_templating = prev_enable_templating
+
+        self.log.info("exts_default_options: %s", self.cfg['exts_default_options'])
+
+        self.pylibdir = None
+
+    def prepare_step(self, *args, **kwargs):
+        """Prepare for installing bundle of Python packages."""
+        super(Bundle, self).prepare_step(*args, **kwargs)
+
+        if get_software_root('Python') is None:
+            raise EasyBuildError("Python not included as dependency!")
+
+        self.pylibdir = det_pylibdir()
+
+    def test_step(self):
+        """No global test step for bundle of Python packages."""
+        # required since runtest is set to True for Python packages by default
+        pass
+
+    def make_module_extra(self, *args, **kwargs):
+        """Extra statements to include in module file: update $PYTHONPATH."""
+        txt = super(Bundle, self).make_module_extra(*args, **kwargs)
+
+        txt += self.module_generator.prepend_paths('PYTHONPATH', self.pylibdir)
+
+        return txt
+
+    def sanity_check_step(self, *args, **kwargs):
+        """Custom sanity check for bundle of Python package."""
+        custom_paths = {
+            'files': [],
+            'dirs': [self.pylibdir],
+        }
+        super(Bundle, self).sanity_check_step(*args, custom_paths=custom_paths, **kwargs)

--- a/test/easyblocks/module.py
+++ b/test/easyblocks/module.py
@@ -40,6 +40,7 @@ from vsc.utils.patterns import Singleton
 from vsc.utils.testing import EnhancedTestCase
 
 from easybuild.easyblocks.generic.intelbase import IntelBase
+from easybuild.easyblocks.generic.pythonbundle import PythonBundle
 from easybuild.easyblocks.imod import EB_IMOD
 from easybuild.easyblocks.openfoam import EB_OpenFOAM
 from easybuild.framework.easyconfig import easyconfig
@@ -214,11 +215,15 @@ def template_module_only_test(self, easyblock, name='foo', version='1.3.2', extr
             os.environ['INTEL_LICENSE_FILE'] = os.path.join(tmpdir, 'intel.lic')
             write_file(os.environ['INTEL_LICENSE_FILE'], '# dummy license')
 
-        if app_class == EB_IMOD:
+        elif app_class == EB_IMOD:
             # $JAVA_HOME must be set for IMOD
             os.environ['JAVA_HOME'] = tmpdir
 
-        if app_class == EB_OpenFOAM:
+        elif app_class == PythonBundle:
+            # $EBROOtPYTHON must be set for PythonBundle easyblock
+            os.environ['EBROOTPYTHON'] = '/fake/install/prefix/Python/2.7.14-foss-2018a'
+
+        elif app_class == EB_OpenFOAM:
             # proper toolchain must be used for OpenFOAM(-Extend), to determine value to set for $WM_COMPILER
             write_file(os.path.join(tmpdir, 'GCC', '4.9.3-2.25'), '\n'.join([
                 '#%Module',

--- a/test/easyblocks/module.py
+++ b/test/easyblocks/module.py
@@ -220,7 +220,7 @@ def template_module_only_test(self, easyblock, name='foo', version='1.3.2', extr
             os.environ['JAVA_HOME'] = tmpdir
 
         elif app_class == PythonBundle:
-            # $EBROOtPYTHON must be set for PythonBundle easyblock
+            # $EBROOTPYTHON must be set for PythonBundle easyblock
             os.environ['EBROOTPYTHON'] = '/fake/install/prefix/Python/2.7.14-foss-2018a'
 
         elif app_class == EB_OpenFOAM:


### PR DESCRIPTION
I got sick & tired of adding the same boilerplate stuff to easyconfigs that are just a bundle of Python packages, so let's add a generic easyblock specifically for that purpose...