### PR TITLE
quantumespresso.py: Ifort compiler needs -assume byterecl

### DIFF
--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -162,7 +162,9 @@ class EB_QuantumESPRESSO(ConfigureMake):
             env.setvar('FCCPP', "%s -E" % os.getenv('CC'))
 
         if comp_fam == toolchain.INTELCOMP:
-            repls.append(('F90FLAGS', '-fpp', True))
+            # Intel compiler must have -assume byterecl (see install/configure)
+            repls.append(('F90FLAGS', '-fpp -assume byterecl', True))
+            repls.append(('FFLAGS', '-assume byterecl', True))
         elif comp_fam == toolchain.GCC:
             repls.append(('F90FLAGS', '-cpp', True))
 


### PR DESCRIPTION
See install/configure for the default settings.

Should fix Intel builds of https://github.com/easybuilders/easybuild-easyconfigs/pull/6593