### PR TITLE
extract targets from buildopts in quantumespresso easyblock

### DIFF
--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -333,13 +333,16 @@ class EB_QuantumESPRESSO(ConfigureMake):
     def install_step(self):
         """Custom install step for Quantum ESPRESSO."""
 
+        # extract build targets as list
+        targets = self.cfg['buildopts'].split()
+
         # Copy all binaries
         bindir = os.path.join(self.installdir, 'bin')
         copy_dir(os.path.join(self.cfg['start_dir'], 'bin'), bindir)
 
         # Pick up files not installed in bin
         upftools = []
-        if 'upf' in self.cfg['buildopts'] or 'all' in self.cfg['buildopts']:
+        if 'upf' in targets or 'all' in targets:
             upftools = ["casino2upf.x", "cpmd2upf.x", "fhi2upf.x", "fpmd2upf.x", "ncpp2upf.x",
                         "oldcp2upf.x", "read_upf_tofile.x", "rrkj2upf.x", "uspp2upf.x", "vdb2upf.x",
                         "virtual.x"]
@@ -352,7 +355,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
             copy_file(os.path.join(self.cfg['start_dir'], upf_bin), bindir)
 
         wanttools = []
-        if 'want' in self.cfg['buildopts']:
+        if 'want' in targets:
             wanttools = ["blc2wan.x", "conductor.x", "current.x", "disentangle.x",
                          "dos.x", "gcube2plt.x", "kgrid.x", "midpoint.x", "plot.x", "sumpdos",
                          "wannier.x", "wfk2etsf.x"]
@@ -363,7 +366,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
             copy_file(os.path.join(self.cfg['start_dir'], want_bin), bindir)
 
         w90tools = []
-        if 'w90' in self.cfg['buildopts']:
+        if 'w90' in targets:
             if LooseVersion(self.version) >= LooseVersion("5.4"):
                 w90tools = ["postw90.x"]
                 if LooseVersion(self.version) < LooseVersion("6.1"):
@@ -373,7 +376,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
             copy_file(os.path.join(self.cfg['start_dir'], w90_bin), bindir)
 
         yambo_bins = []
-        if 'yambo' in self.cfg['buildopts']:
+        if 'yambo' in targets:
             yambo_bins = ["a2y", "p2y", "yambo", "ypp"]
         yambo_bins = [os.path.join('YAMBO', 'bin', x) for x in yambo_bins]
         for yambo_bin in yambo_bins:
@@ -382,36 +385,37 @@ class EB_QuantumESPRESSO(ConfigureMake):
     def sanity_check_step(self):
         """Custom sanity check for Quantum ESPRESSO."""
 
+        # extract build targets as list
+        targets = self.cfg['buildopts'].split()
+
         # build list of expected binaries based on make targets
         bins = ["iotk", "iotk.x", "iotk_print_kinds.x"]
 
-        if 'cp' in self.cfg['buildopts'] or 'all' in self.cfg['buildopts']:
+        if 'cp' in targets or 'all' in targets:
             bins.extend(["cp.x", "cppp.x", "wfdd.x"])
 
         # only for v4.x, not in v5.0 anymore, called gwl in 6.1 at least
-        if 'gww' in self.cfg['buildopts'] or 'gwl' in self.cfg['buildopts']:
+        if 'gww' in targets or 'gwl' in targets:
             bins.extend(["gww_fit.x", "gww.x", "head.x", "pw4gww.x"])
 
-        if 'ld1' in self.cfg['buildopts'] or 'all' in self.cfg['buildopts']:
+        if 'ld1' in targets or 'all' in targets:
             bins.extend(["ld1.x"])
 
-        if 'gipaw' in self.cfg['buildopts']:
+        if 'gipaw' in targets:
             bins.extend(["gipaw.x"])
 
-        if 'neb' in self.cfg['buildopts'] or 'pwall' in self.cfg['buildopts'] or \
-           'all' in self.cfg['buildopts']:
+        if 'neb' in targets or 'pwall' in targets or 'all' in targets:
             if LooseVersion(self.version) > LooseVersion("5"):
                 bins.extend(["neb.x", "path_interpolation.x"])
 
-        if 'ph' in self.cfg['buildopts'] or 'all' in self.cfg['buildopts']:
+        if 'ph' in targets or 'all' in targets:
             bins.extend(["dynmat.x", "lambda.x", "matdyn.x", "ph.x", "phcg.x", "q2r.x"])
             if LooseVersion(self.version) < LooseVersion("6"):
                 bins.extend(["d3.x"])
             if LooseVersion(self.version) > LooseVersion("5"):
                 bins.extend(["fqha.x", "q2qstar.x"])
 
-        if 'pp' in self.cfg['buildopts'] or 'pwall' in self.cfg['buildopts'] or \
-           'all' in self.cfg['buildopts']:
+        if 'pp' in targets or 'pwall' in targets or 'all' in targets:
             bins.extend(["average.x", "bands.x", "dos.x", "epsilon.x", "initial_state.x",
                          "plan_avg.x", "plotband.x", "plotproj.x", "plotrho.x", "pmw.x", "pp.x",
                          "projwfc.x", "sumpdos.x", "pw2wannier90.x", "pw_export.x", "pw2gw.x",
@@ -421,7 +425,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
             else:
                 bins.extend(["pw2casino.x"])
 
-        if 'pw' in self.cfg['buildopts'] or 'all' in self.cfg['buildopts']:
+        if 'pw' in targets or 'all' in targets:
             bins.extend(["dist.x", "ev.x", "kpoints.x", "pw.x", "pwi2xsf.x"])
             if LooseVersion(self.version) >= LooseVersion("5.1"):
                 bins.extend(["generate_rVV10_kernel_table.x"])
@@ -432,16 +436,15 @@ class EB_QuantumESPRESSO(ConfigureMake):
             if LooseVersion(self.version) < LooseVersion("5.3.0"):
                 bins.extend(["band_plot.x", "bands_FS.x", "kvecs_FS.x"])
 
-        if 'pwcond' in self.cfg['buildopts'] or 'pwall' in self.cfg['buildopts'] or \
-           'all' in self.cfg['buildopts']:
+        if 'pwcond' in targets or 'pwall' in targets or 'all' in targets:
             bins.extend(["pwcond.x"])
 
-        if 'tddfpt' in self.cfg['buildopts'] or 'all' in self.cfg['buildopts']:
+        if 'tddfpt' in targets or 'all' in targets:
             if LooseVersion(self.version) > LooseVersion("5"):
                 bins.extend(["turbo_lanczos.x", "turbo_spectrum.x"])
 
         upftools = []
-        if 'upf' in self.cfg['buildopts'] or 'all' in self.cfg['buildopts']:
+        if 'upf' in targets or 'all' in targets:
             upftools = ["casino2upf.x", "cpmd2upf.x", "fhi2upf.x", "fpmd2upf.x", "ncpp2upf.x",
                         "oldcp2upf.x", "read_upf_tofile.x", "rrkj2upf.x", "uspp2upf.x", "vdb2upf.x",
                         "virtual.x"]
@@ -450,10 +453,10 @@ class EB_QuantumESPRESSO(ConfigureMake):
             if LooseVersion(self.version) >= LooseVersion("6.3"):
                 upftools.extend(["fix_upf.x"])
 
-        if 'vdw' in self.cfg['buildopts']:  # only for v4.x, not in v5.0 anymore
+        if 'vdw' in targets:  # only for v4.x, not in v5.0 anymore
             bins.extend(["vdw.x"])
 
-        if 'w90' in self.cfg['buildopts']:
+        if 'w90' in targets:
             bins.extend(["wannier90.x"])
             if LooseVersion(self.version) >= LooseVersion("5.4"):
                 bins.extend(["postw90.x"])
@@ -461,23 +464,23 @@ class EB_QuantumESPRESSO(ConfigureMake):
                     bins.extend(["w90chk2chk.x"])
 
         want_bins = []
-        if 'want' in self.cfg['buildopts']:
+        if 'want' in targets:
             want_bins = ["blc2wan.x", "conductor.x", "current.x", "disentangle.x",
                          "dos.x", "gcube2plt.x", "kgrid.x", "midpoint.x", "plot.x", "sumpdos",
                          "wannier.x", "wfk2etsf.x"]
             if LooseVersion(self.version) > LooseVersion("5"):
                 want_bins.extend(["cmplx_bands.x", "decay.x", "sax2qexml.x", "sum_sgm.x"])
 
-        if 'xspectra' in self.cfg['buildopts']:
+        if 'xspectra' in targets:
             bins.extend(["xspectra.x"])
 
 
         yambo_bins = []
-        if 'yambo' in self.cfg['buildopts']:
+        if 'yambo' in targets:
             yambo_bins = ["a2y", "p2y", "yambo", "ypp"]
 
         d3q_bins = []
-        if 'd3q' in self.cfg['buildopts']:
+        if 'd3q' in targets:
             d3q_bins = ['d3_asr3.x', 'd3_import3py.x', 'd3_lw.x', 'd3_q2r.x',
                         'd3_qq2rr.x', 'd3q.x', 'd3_r2q.x', 'd3_recenter.x',
                         'd3_sparse.x', 'd3_sqom.x', 'd3_tk.x']


### PR DESCRIPTION
looking for substrings is not very precise, i.e., `'all' in self.cfg['buildopts']` is `True` if `buildopts` includes `pwall` instead of `all`, and then the sanity check fails
