### PR TITLE
pass $PYTHONPATH while building TensorFlow, disable cross-compilation mode if optarch is set, fix sanity check for installing TensorFlow as extension

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -439,7 +439,7 @@ class EB_TensorFlow(PythonPackage):
         # test installation using MNIST tutorial examples
         if self.cfg['runtest']:
             pythonpath = os.getenv('PYTHONPATH', '')
-            env.setvar('PYTHONPATH', '%s:%s' % (os.path.join(self.installdir, self.pylibdir), pythonpath))
+            env.setvar('PYTHONPATH', os.pathsep.join([os.path.join(self.installdir, self.pylibdir), pythonpath]))
 
             for mnist_py in ['mnist_softmax.py', 'mnist_with_summaries.py']:
                 tmpdir = tempfile.mkdtemp(suffix='-tf-%s-test' % os.path.splitext(mnist_py)[0])

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -432,6 +432,10 @@ class EB_TensorFlow(PythonPackage):
         ]
         res = super(EB_TensorFlow, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
 
+        # determine top-level directory
+        # start_dir is not set when TensorFlow is installed as an extension, then fall back to ext_dir
+        topdir = self.start_dir or self.ext_dir
+
         # test installation using MNIST tutorial examples
         if self.cfg['runtest']:
             pythonpath = os.getenv('PYTHONPATH', '')
@@ -439,7 +443,7 @@ class EB_TensorFlow(PythonPackage):
 
             for mnist_py in ['mnist_softmax.py', 'mnist_with_summaries.py']:
                 tmpdir = tempfile.mkdtemp(suffix='-tf-%s-test' % os.path.splitext(mnist_py)[0])
-                mnist_py = os.path.join(self.start_dir, 'tensorflow', 'examples', 'tutorials', 'mnist', mnist_py)
+                mnist_py = os.path.join(topdir, 'tensorflow', 'examples', 'tutorials', 'mnist', mnist_py)
                 cmd = "%s %s --data_dir %s" % (self.python_cmd, mnist_py, tmpdir)
                 run_cmd(cmd, log_all=True, simple=True, log_ok=True)
 


### PR DESCRIPTION
Passing down `$PYTHONPATH` to Bazel is required to be able to build `TensorFlow` 1.11.0, which requires that particular Python packages are pre-installed (`keras_applications` and `keras_preprocessing`), see also https://github.com/tensorflow/tensorflow/issues/22395 .

Also using `--distinct_host_configuration=false` is required for TensorFlow 1.11.0 because of a bug in Bazel (see https://github.com/bazelbuild/bazel/issues/6473).

But it's probably a good idea to use `--distinct_host_configuration=false` when not cross compiling, , since it can significantly speed up the build process (see https://docs.bazel.build/versions/master/guide.html#configurations).

Both these changes should not affect existing easyconfigs (already verified with `TensorFlow-1.10.1-foss-2018b-Python-3.6.6.eb`).