### PR TITLE
replace '-' with '_' in default 'import' check for Python packages

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -219,7 +219,7 @@ class PythonPackage(ExtensionEasyBlock):
 
         # use lowercase name as default value for expected module name (used in sanity check)
         if 'modulename' not in self.options:
-            self.options['modulename'] = self.name.lower()
+            self.options['modulename'] = self.name.lower().replace('-', '_')
             self.log.info("Using default value for expected module name (lowercase software name): '%s'",
                           self.options['modulename'])
 


### PR DESCRIPTION
This avoids having to provide a custom `modulename` for Python packages like `python-magic`, where the test should be done with `import python_magic`.

This just changes the default, and since `-` is not a valid character in a Python module name, so this shouldn't break anything...