### PR TITLE
enhance PythonPackage/PythonBundle to run 'pip check' when 'pip install --no-deps' is used (WIP)

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -505,12 +505,12 @@ class PythonPackage(ExtensionEasyBlock):
         install_cmd = self.compose_install_command(self.installdir)
         self.log.info("Installing %s v%s with: %s", self.name, self.version, install_cmd)
 
-        # run 'pip check' before trying to install package, if pip is used with --no-deps
-        if "pip install" in install_cmd and '--no-deps' in install_cmd:
-            run_cmd("pip check", log_all=True, log_ok=True, simple=False)
-
         # actually install Python package
         (self.install_cmd_output, _) = run_cmd(install_cmd, log_all=True, log_ok=True, simple=False)
+
+        # run 'pip check' to see whether all required dependencies are available
+        if "pip install" in install_cmd and '--no-deps' in install_cmd:
+            run_cmd("pip check", log_all=True, log_ok=True, simple=False)
 
         # restore PYTHONPATH if it was set
         if pythonpath is not None:

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -254,7 +254,7 @@ class PythonPackage(ExtensionEasyBlock):
                 self.log.info("Using pip with --no-deps option")
                 self.cfg.update('installopts', '--no-deps')
 
-            # don't (try to) uninstall already availale versions of the package being installed
+            # don't (try to) uninstall already available versions of the package being installed
             self.cfg.update('installopts', '--ignore-installed')
 
             if self.cfg.get('zipped_egg', False):
@@ -502,9 +502,15 @@ class PythonPackage(ExtensionEasyBlock):
         new_pythonpath = os.pathsep.join([x for x in abs_pylibdirs + [pythonpath] if x is not None])
         env.setvar('PYTHONPATH', new_pythonpath, verbose=False)
 
+        install_cmd = self.compose_install_command(self.installdir)
+        self.log.info("Installing %s v%s with: %s", self.name, self.version, install_cmd)
+
+        # run 'pip check' before trying to install package, if pip is used with --no-deps
+        if "pip install" in install_cmd and '--no-deps' in install_cmd:
+            run_cmd("pip check", log_all=True, log_ok=True, simple=False)
+
         # actually install Python package
-        cmd = self.compose_install_command(self.installdir)
-        (self.install_cmd_output, _) = run_cmd(cmd, log_all=True, log_ok=True, simple=False)
+        (self.install_cmd_output, _) = run_cmd(install_cmd, log_all=True, log_ok=True, simple=False)
 
         # restore PYTHONPATH if it was set
         if pythonpath is not None:


### PR DESCRIPTION
Enhance `PythonPackage` to run '`pip check`' when '`pip install --no-deps`' is used, to ensure all required dependencies are available.

This (sort of) fixes #1565, in the sense that it'll make sure that all required Python packages are indeed in place, although it's not done during the sanity check, but before the actual installation of the Python package...

When testing this, this already signaled that `cffi` was missing in a bunch of `Python` easyconfigs (which is being fixed in https://github.com/easybuilders/easybuild-easyconfigs/pull/7105).

(WIP because still testing the impact this has on easyconfigs that set `use_pip = True`...)

cc @migueldiascosta