### PR TITLE
delete the temp dir where test's logs are saved

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -447,4 +447,6 @@ class EB_TensorFlow(PythonPackage):
                 cmd = "%s %s --data_dir %s" % (self.python_cmd, mnist_py, tmpdir)
                 run_cmd(cmd, log_all=True, simple=True, log_ok=True)
 
+            os.rmdir('/tmp/tensorflow')
+
         return res


### PR DESCRIPTION
I tested the tensorflow installation with userA and then rerun the same installation with userB and I found that there was a folder `/tmp/tensorflow` owned by userA. 

My `$TMPDIR=/scratch` so it's ignored