### PR TITLE
enhance sanity check for icc & ifort: also check for compilers_and_libraries_*/linux subdirectory

### DIFF
--- a/easybuild/easyblocks/i/icc.py
+++ b/easybuild/easyblocks/i/icc.py
@@ -69,11 +69,18 @@ class EB_icc(IntelBase):
 
         self.debuggerpath = None
 
-        if LooseVersion(self.version) >= LooseVersion('2016') and self.cfg['components'] is None:
-            # we need to use 'ALL' by default, using 'DEFAULTS' results in key things not being installed (e.g. bin/icc)
-            self.cfg['components'] = [COMP_ALL]
-            self.log.debug("Nothing specified for components, but required for version 2016, using %s instead",
-                           self.cfg['components'])
+        self.comp_libs_subdir = None
+
+        if LooseVersion(self.version) >= LooseVersion('2016'):
+
+            self.comp_libs_subdir = os.path.join('compilers_and_libraries_%s' % self.version, 'linux')
+
+            if self.cfg['components'] is None:
+                # we need to use 'ALL' by default,
+                # using 'DEFAULTS' results in key things not being installed (e.g. bin/icc)
+                self.cfg['components'] = [COMP_ALL]
+                self.log.debug("Nothing specified for components, but required for version 2016, using %s instead",
+                               self.cfg['components'])
 
     def install_step(self):
         """
@@ -120,6 +127,11 @@ class EB_icc(IntelBase):
             'files': sanity_check_files,
             'dirs': [],
         }
+
+        # make very sure that expected 'compilers_and_libraries_<VERSION>/linux' subdir is there for recent versions,
+        # since we rely on it being there in make_module_req_guess
+        if self.comp_libs_subdir:
+            custom_paths['dirs'].append(self.comp_libs_subdir)
 
         custom_commands = ["which icc"]
 
@@ -189,7 +201,7 @@ class EB_icc(IntelBase):
             else:
                 # new directory layout for Intel Parallel Studio XE 2016
                 # https://software.intel.com/en-us/articles/new-directory-layout-for-intel-parallel-studio-xe-2016
-                prefix = 'compilers_and_libraries_%s/linux' % self.version
+                prefix = self.comp_libs_subdir
                 # Debugger requires INTEL_PYTHONHOME, which only allows for a single value
                 self.debuggerpath = 'debugger_%s' % self.version.split('.')[0]
 

--- a/easybuild/easyblocks/i/ifort.py
+++ b/easybuild/easyblocks/i/ifort.py
@@ -37,7 +37,7 @@ import os
 from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.intelbase import IntelBase
-from easybuild.easyblocks.icc import EB_icc  #@UnresolvedImport
+from easybuild.easyblocks.icc import EB_icc  # @UnresolvedImport
 from easybuild.tools.systemtools import get_shared_lib_ext
 
 
@@ -72,6 +72,11 @@ class EB_ifort(EB_icc, IntelBase):
             'files': [os.path.join(binprefix, x) for x in bins] + [os.path.join(libprefix, 'lib%s' % l) for l in libs],
             'dirs': [],
         }
+
+        # make very sure that expected 'compilers_and_libraries_<VERSION>/linux' subdir is there for recent versions,
+        # since we rely on it being there in make_module_req_guess
+        if self.comp_libs_subdir:
+            custom_paths['dirs'].append(self.comp_libs_subdir)
 
         custom_commands = ["which ifort"]
 


### PR DESCRIPTION
The `icc` and `ifort` easyblocks heavily rely on the `compilers_and_libraries_%(version)s/linux` subdirectory being there when generating the module file.

If the directory is not there as expected, for example because the wrong version was used, then the generated module file is crippled.

We already have a check in place that catches this issue (the `which icc` being run in the sanity check), but it's worthwhile to also have an explicit check for this subdirectory, since that results in a clearer error message, and you're likely to quickly figure out what's wrong.