### PR TITLE
fixing fftw reprod by skipping early if configopts is a list

### DIFF
--- a/easybuild/easyblocks/f/fftw.py
+++ b/easybuild/easyblocks/f/fftw.py
@@ -149,7 +149,7 @@ class EB_FFTW(ConfigureMake):
         common_config_opts = self.cfg['configopts']
 
         # early exit if common_config_opts is not a string
-        if not isinstance(common_config_opts,basestring):
+        if not isinstance(common_config_opts, basestring):
             self.log.warning("Found configopts that is a list. Skipping auto-configuration.")
             self.log.debug("List of configure options to iterate over: %s", self.cfg['configopts'])
 

--- a/easybuild/easyblocks/f/fftw.py
+++ b/easybuild/easyblocks/f/fftw.py
@@ -148,6 +148,13 @@ class EB_FFTW(ConfigureMake):
         # keep track of configopts specified in easyconfig file, so we can include them in each iteration later
         common_config_opts = self.cfg['configopts']
 
+        # early exit if common_config_opts is not a string
+        if not isinstance(common_config_opts,basestring):
+            self.log.warning("Found configopts that is a list. Skipping auto-configuration.")
+            self.log.debug("List of configure options to iterate over: %s", self.cfg['configopts'])
+
+            return super(EB_FFTW, self).run_all_steps(*args, **kwargs)
+
         self.cfg['configopts'] = []
 
         for prec in FFTW_PRECISION_FLAGS:


### PR DESCRIPTION
Related to https://github.com/easybuilders/easybuild-easyblocks/issues/1574
Building the "reprod" recipe fails with 
```
  File "/cvmfs/soft.computecanada.ca/easybuild/lib/python2.7/site-packages/easybuild-framework/easybuild/framework/easyblock.py", line 2860, in build_and_install_one
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/cvmfs/soft.computecanada.ca/easybuild/lib/python2.7/site-packages/easybuild-easyblocks/easybuild/easyblocks/f/fftw.py", line 212, in run_all_steps
    self.cfg.update('configopts', [' '.join(prec_configopts) + ' ' + common_config_opts])
TypeError: cannot concatenate 'str' and 'list' objects
``` 

if not for this PR. 