### PR TITLE
check current start_dir value before appending 'src' subdirectory in MrBayes easyblock

### DIFF
--- a/easybuild/easyblocks/m/mrbayes.py
+++ b/easybuild/easyblocks/m/mrbayes.py
@@ -58,7 +58,7 @@ class EB_MrBayes(ConfigureMake):
             # set correct start_dir dir, and change into it
             # test whether it already contains 'src', since a reprod easyconfig would
             if not self.cfg['start_dir'].endswith('src'):
-                self.cfg['start_dir'] = os.path.join(self.cfg['start_dir'],'src')
+                self.cfg['start_dir'] = os.path.join(self.cfg['start_dir'], 'src')
             try:
                 os.chdir(self.cfg['start_dir'])
             except OSError, err:

--- a/easybuild/easyblocks/m/mrbayes.py
+++ b/easybuild/easyblocks/m/mrbayes.py
@@ -31,6 +31,7 @@ EasyBuild support for building and installing MrBayes, implemented as an easyblo
 @author: Pieter De Baets (Ghent University)
 @author: Jens Timmerman (Ghent University)
 @author: Andy Georges (Ghent University)
+@author: Maxime Boissonneault (Compute Canada, Calcul Quebec, Universite Laval)
 """
 
 import os
@@ -55,7 +56,9 @@ class EB_MrBayes(ConfigureMake):
         if LooseVersion(self.version) >= LooseVersion("3.2"):
 
             # set correct start_dir dir, and change into it
-            self.cfg['start_dir'] = os.path.join(self.cfg['start_dir'],'src')
+            # test whether it already contains 'src', since a reprod easyconfig would
+            if not self.cfg['start_dir'].endswith('src'):
+                self.cfg['start_dir'] = os.path.join(self.cfg['start_dir'],'src')
             try:
                 os.chdir(self.cfg['start_dir'])
             except OSError, err:

--- a/easybuild/easyblocks/m/mrbayes.py
+++ b/easybuild/easyblocks/m/mrbayes.py
@@ -57,7 +57,7 @@ class EB_MrBayes(ConfigureMake):
 
             # set correct start_dir dir, and change into it
             # test whether it already contains 'src', since a reprod easyconfig would
-            if not self.cfg['start_dir'].endswith('src'):
+            if os.path.basename(self.cfg['start_dir']) != 'src':
                 self.cfg['start_dir'] = os.path.join(self.cfg['start_dir'], 'src')
             try:
                 os.chdir(self.cfg['start_dir'])


### PR DESCRIPTION
This relate to issue https://github.com/easybuilders/easybuild-easyblocks/issues/1574

Using the reprod recipe fails with this error message otherwise. 
```
ERROR: Build of /cvmfs/soft.computecanada.ca/easybuild/software/2017/avx2/MPI/intel2018.3/openmpi3.1/mrbayes/3.2.6/easybuild/reprod/MrBayes-3.2.6-iompi-2018.3.312.eb failed (err: "build failed (first 300 chars): Failed to change to correct source dir /dev/shm/ebuser/avx512/MrBayes/3.2.6/iompi-2018.3.312/mrbayes-3.2.6/src/src: [Errno 2] No such file or directory: '/dev/shm/ebuser/avx512/MrBayes/3.2.6/iompi-2018.3.312/mrbayes-3.2.6/src/src'")
``` 