### PR TITLE
Fixing `tau.py` to work with the `reprod` recipe. 

### DIFF
--- a/easybuild/easyblocks/t/tau.py
+++ b/easybuild/easyblocks/t/tau.py
@@ -113,7 +113,7 @@ class EB_TAU(ConfigureMake):
         iter_cnt = len(self.cfg['extra_backends']) + 1
 
         # define list of configure options to iterate over
-        if self.cfg['configopts']:
+        if self.cfg['configopts'] and isinstance(self.cfg['configopts'], basestring):
             raise EasyBuildError("Specifying additional configure options for TAU is not supported (yet)")
 
         self.cfg['configopts'] = [mpi_tmpl, openmp_tmpl, hybrid_tmpl] * iter_cnt


### PR DESCRIPTION
The reprod recipe fails on this : 
```
== Results of the build can be found in the log file(s) /tmp/eb-0i_Jz3/easybuild-TAU-2.27.1-20181114.141518.ThWHv.log
ERROR: Build of /cvmfs/soft.computecanada.ca/easybuild/software/2017/avx2/MPI/gcc7.3/openmpi3.1/tau/2.27.1/easybuild/reprod/TAU-2.27.1-gompi-2018.3.312.eb failed (err: 'build failed (first 300 chars): Specifying additional configure options for TAU is not supported (yet)')
``` 

because the configops are saved. 

This relates to https://github.com/easybuilders/easybuild-easyblocks/issues/1574