### PR TITLE
avoid hardcoding --with-rdma configure option in MVAPICH2 easyblock

### DIFF
--- a/easybuild/easyblocks/m/mvapich2.py
+++ b/easybuild/easyblocks/m/mvapich2.py
@@ -70,8 +70,6 @@ class EB_MVAPICH2(EB_MPICH):
 
         if self.cfg['rdma_type']:
             add_configopts.append('--with-rdma=%s' % self.cfg['rdma_type'])
-        else:
-            add_configopts.append('--without-rdma')
 
         # enable specific support options (if desired)
         if self.cfg['withmpe']:

--- a/easybuild/easyblocks/m/mvapich2.py
+++ b/easybuild/easyblocks/m/mvapich2.py
@@ -67,7 +67,11 @@ class EB_MVAPICH2(EB_MPICH):
 
         # additional configuration options
         add_configopts = []
-        add_configopts.append('--with-rdma=%s' % self.cfg['rdma_type'])
+
+        if self.cfg['rdma_type']:
+            add_configopts.append('--with-rdma=%s' % self.cfg['rdma_type'])
+        else:
+            add_configopts.append('--without-rdma')
 
         # enable specific support options (if desired)
         if self.cfg['withmpe']:


### PR DESCRIPTION
fix for problem reported by @peterinl via #7167

With this change included, you can avoid that `--with-rdma` is used by setting `rdma_type = None` or `rdma_type = ''` or `rdma_type = False` in the `MVAPICH2` easyconfig file.