### PR TITLE
Fix Gromacs use of MKL for non-Intel compilers (e.g. gomkl toolchain).

### DIFF
--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -149,7 +149,9 @@ class EB_GROMACS(CMakeMake):
             if get_software_root('imkl'):
                 # using MKL for FFT, so it will also be used for BLAS/LAPACK
                 self.cfg.update('configopts', '-DGMX_FFT_LIBRARY=mkl -DMKL_INCLUDE_DIR="$EBROOTMKL/mkl/include" ')
-                mkl_libs = [os.path.join(os.getenv('LAPACK_LIB_DIR'), lib) for lib in ['libmkl_lapack.a']]
+                libs = os.getenv('LAPACK_STATIC_LIBS').split(',')
+                mkl_libs = [os.path.join(os.getenv('LAPACK_LIB_DIR'), lib) for lib in libs if lib != 'libgfortran.a']
+                mkl_libs = ['-Wl,--start-group'] + mkl_libs + ['-Wl,--end-group']
                 self.cfg.update('configopts', '-DMKL_LIBRARIES="%s" ' % ';'.join(mkl_libs))
             else:
                 shlib_ext = get_shared_lib_ext()


### PR DESCRIPTION
Using only 'libmkl_lapack.a' (a text file with
GROUP (libmkl_intel_lp64.a libmkl_intel_thread.a libmkl_core.a)
) only works with the Intel compiler.
It can use $LAPACK_STATIC_LIBS but needs to use -Wl,--start-group
and -Wl,--end-group to avoid symbol errors.

There is no need to use the threaded MKL, so don't use MT here,
following the same method that was used for other BLAS/LAPACK.