### PR TITLE
Trilinos - Support build against MKL

### DIFF
--- a/easybuild/easyblocks/t/trilinos.py
+++ b/easybuild/easyblocks/t/trilinos.py
@@ -124,6 +124,12 @@ class EB_Trilinos(CMakeMake):
                 lib_names += ";libgfortran.a"
             self.cfg.update('configopts', '-D%s_LIBRARY_NAMES="%s"' % (dep, lib_names))
 
+        # MKL
+        if get_software_root('imkl'):
+            self.cfg.update('configopts', "-DTPL_ENABLE_MKL:BOOL=ON")
+            self.cfg.update('configopts', '-DMKL_LIBRARY_DIRS:PATH="%s/lib/intel64"' % os.getenv('MKLROOT'))
+            self.cfg.update('configopts', '-DMKL_INCLUDE_DIRS:PATH="%s/include"' % os.getenv('MKLROOT'))
+
         # UMFPACK is part of SuiteSparse
         suitesparse = get_software_root('SuiteSparse')
         if suitesparse:

--- a/easybuild/easyblocks/t/trilinos.py
+++ b/easybuild/easyblocks/t/trilinos.py
@@ -42,7 +42,6 @@ from easybuild.tools.config import build_path
 from easybuild.tools.filetools import mkdir, rmtree2, symlink
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.systemtools import get_shared_lib_ext
-from distutils.version import LooseVersion
 
 
 class EB_Trilinos(CMakeMake):

--- a/easybuild/easyblocks/t/trilinos.py
+++ b/easybuild/easyblocks/t/trilinos.py
@@ -42,6 +42,7 @@ from easybuild.tools.config import build_path
 from easybuild.tools.filetools import mkdir, rmtree2, symlink
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.systemtools import get_shared_lib_ext
+from distutils.version import LooseVersion
 
 
 class EB_Trilinos(CMakeMake):
@@ -125,7 +126,7 @@ class EB_Trilinos(CMakeMake):
             self.cfg.update('configopts', '-D%s_LIBRARY_NAMES="%s"' % (dep, lib_names))
 
         # MKL
-        if get_software_root('imkl'):
+        if get_software_root('imkl') and LooseVersion(self.version) >= LooseVersion('12.12'):
             self.cfg.update('configopts', "-DTPL_ENABLE_MKL:BOOL=ON")
             self.cfg.update('configopts', '-DMKL_LIBRARY_DIRS:PATH="%s/lib/intel64"' % os.getenv('MKLROOT'))
             self.cfg.update('configopts', '-DMKL_INCLUDE_DIRS:PATH="%s/include"' % os.getenv('MKLROOT'))


### PR DESCRIPTION
Trilinos has a dedicated flag for building against MKL that should be used in conjunction with the BLAS and LAPACK flags. Set the flag to `True` if MKL is available.