### PR TITLE
Handle multiple installation keys for MATLAB

### DIFF
--- a/easybuild/easyblocks/m/matlab.py
+++ b/easybuild/easyblocks/m/matlab.py
@@ -60,7 +60,6 @@ class EB_MATLAB(PackedBinary):
     def extra_options():
         extra_vars = {
             'java_options': ['-Xmx256m', "$_JAVA_OPTIONS value set for install and in module file.", CUSTOM],
-            'tmpdir': [None, "Tempdir during installation, passed to matlab installer", CUSTOM],
             'key': [None, "Installation key(s), make one install for each key. Single key or a list of keys", CUSTOM],
         }
         return PackedBinary.extra_options(extra_vars)

--- a/easybuild/easyblocks/m/matlab.py
+++ b/easybuild/easyblocks/m/matlab.py
@@ -129,19 +129,13 @@ class EB_MATLAB(PackedBinary):
         if LooseVersion(self.version) >= LooseVersion('2016b'):
             change_dir(self.builddir)
 
-        # MATLAB installer ignores TMPDIR
-        tmpdir = ''
-        if self.cfg['tmpdir']:
-            tmpd = self.cfg['tmpdir']
-        else:
-            tmpd = os.getenv('TMPDIR', '')
-        if tmpd:
-            tmpdir = '-tmpdir %s' % tmpd
+        # MATLAB installer ignores TMPDIR (always uses /tmp) and might need a large tmpdir
+        tmpdir = "-tmpdir %s" % tempfile.mkdtemp()
 
         keys = self.cfg['key']
         if keys is None:
             keys = os.getenv('EB_MATLAB_KEY', '00000-00000-00000-00000-00000-00000-00000-00000-00000-00000')
-        if isinstance(keys, str):
+        if isinstance(keys, basestring):
             keys = keys.split(',')
 
         # Make one install for each key

--- a/easybuild/easyblocks/m/matlab.py
+++ b/easybuild/easyblocks/m/matlab.py
@@ -36,6 +36,7 @@ import re
 import os
 import shutil
 import stat
+import tempfile
 
 from distutils.version import LooseVersion
 


### PR DESCRIPTION
One can have multiple installation keys to matlab, if so one has to do
one install per key.
Matlab installer ignores TMPDIR (always using /tmp), give use the -tmpdir option.
Don't add JAVA_OPTIONS to the module file if there are no java_options.