### PR TITLE
Mathematica: let's answer SELinux question with 'no'?

### DIFF
--- a/easybuild/easyblocks/m/mathematica.py
+++ b/easybuild/easyblocks/m/mathematica.py
@@ -68,6 +68,7 @@ class EB_Mathematica(Binary):
         qa = {
             r"Enter the installation directory, or press ENTER to select %s: >" % qa_install_path: self.installdir,
             r"Create directory (y/n)? >": 'y',
+            r"Should the installer attempt to make this change (y/n)? >": 'y',
             r"or press ENTER to select /usr/local/bin: >": os.path.join(self.installdir, "bin"), 
         }
         no_qa = [

--- a/easybuild/easyblocks/m/mathematica.py
+++ b/easybuild/easyblocks/m/mathematica.py
@@ -68,7 +68,7 @@ class EB_Mathematica(Binary):
         qa = {
             r"Enter the installation directory, or press ENTER to select %s: >" % qa_install_path: self.installdir,
             r"Create directory (y/n)? >": 'y',
-            r"Should the installer attempt to make this change (y/n)? >": 'y',
+            r"Should the installer attempt to make this change (y/n)? >": 'n',
             r"or press ENTER to select /usr/local/bin: >": os.path.join(self.installdir, "bin"), 
         }
         no_qa = [


### PR DESCRIPTION
In case when `SELinux` is enabled (e.g. in `permissive` mode like I have it), Mathematica asks if the SELinux context of installed files should be updated by the installer:

```
The installer has detected that SELinux is enabled on this system. The
security context of the included libraries may need to be altered in order
for Wolfram Mathematica to function properly.

Should the installer attempt to make this change (y/n)?
```

Currently, this questions stays unanswered and the installation fails.
Having this question in Q/A dictionary will fix this "problem".

I assume "yes" is the right answer for most of the sites.