### PR TITLE
enhance Python easyblock to also include <prefix>/include/python* in $CPATH

### DIFF
--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -262,10 +262,10 @@ class EB_Python(ConfigureMake):
         """
         guesses = super(EB_Python, self).make_module_req_guess()
 
-        pyincdir = os.path.join('include', 'python' + self.pyshortver)
-        if LooseVersion(self.version) >= LooseVersion('3'):
-            pyincdir += 'm'
-
-        guesses['CPATH'].append(pyincdir)
+        pyincdirs = glob.glob(os.path.join(self.installdir, 'include', 'python' + self.pyshortver + '*'))
+        if len(pyincdirs) == 1:
+            guesses['CPATH'].append(os.path.join('include', os.path.basename(pyincdirs[0])))
+        else:
+            raise EasyBuildError("Failed to isolate subdirectory with Python header files: %s", pyincdirs)
 
         return guesses

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -265,7 +265,9 @@ class EB_Python(ConfigureMake):
         pyincdirs = glob.glob(os.path.join(self.installdir, 'include', 'python' + self.pyshortver + '*'))
         if len(pyincdirs) == 1:
             guesses['CPATH'].append(os.path.join('include', os.path.basename(pyincdirs[0])))
-        else:
+        elif pyincdirs:
+            # only fail if *multiple* hits were found
+            # under --module-only --force or --extended-dry-run, nothing may actually be installed (yet)
             raise EasyBuildError("Failed to isolate subdirectory with Python header files: %s", pyincdirs)
 
         return guesses


### PR DESCRIPTION
fix for #1446 reported by @akesandgren

Generated `Python` module files are as expected:

```diff
$ diff -u /prefix/modules/all/Python/3.6.6-intel-2018b.lua.bk /prefix/modules/all/Python/3.6.6-intel-2018b.lua
--- /prefix/modules/all/Python/3.6.6-intel-2018b.lua.bk	2018-12-15 09:59:14.938975000 +0100
+++ /prefix/modules/all/Python/3.6.6-intel-2018b.lua	2019-01-19 11:37:33.613860000 +0100
@@ -71,6 +71,7 @@
 end

 prepend_path("CPATH", pathJoin(root, "include"))
+prepend_path("CPATH", pathJoin(root, "include/python3.6m"))
 prepend_path("LD_LIBRARY_PATH", pathJoin(root, "lib"))
 prepend_path("LIBRARY_PATH", pathJoin(root, "lib"))
 prepend_path("MANPATH", pathJoin(root, "share/man"))

$ diff -u /prefix/modules/all/Python/2.7.15-intel-2018b.lua.bk /prefix/modules/all/Python/2.7.15-intel-2018b.lua
--- /prefix/modules/all/Python/2.7.15-intel-2018b.lua.bk	2019-01-04 22:06:17.270376000 +0100
+++ /prefix/modules/all/Python/2.7.15-intel-2018b.lua	2019-01-19 11:36:31.050536000 +0100
@@ -67,6 +67,7 @@
 end

 prepend_path("CPATH", pathJoin(root, "include"))
+prepend_path("CPATH", pathJoin(root, "include/python2.7"))
 prepend_path("LD_LIBRARY_PATH", pathJoin(root, "lib"))
 prepend_path("LIBRARY_PATH", pathJoin(root, "lib"))
 prepend_path("MANPATH", pathJoin(root, "share/man"))

```