### PR TITLE
revert change that adds 'include/python<version>*' to $CPATH for Python

### DIFF
--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -254,20 +254,3 @@ class EB_Python(ConfigureMake):
                 raise EasyBuildError("Expected to find exactly one _tkinter*.so: %s", tkinter_so_hits)
 
         super(EB_Python, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
-
-    def make_module_req_guess(self):
-        """
-        Return dictionary with additional entries for path-like environment variables;
-        also include <prefix>/include/python* to $CPATH.
-        """
-        guesses = super(EB_Python, self).make_module_req_guess()
-
-        pyincdirs = glob.glob(os.path.join(self.installdir, 'include', 'python' + self.pyshortver + '*'))
-        if len(pyincdirs) == 1:
-            guesses['CPATH'].append(os.path.join('include', os.path.basename(pyincdirs[0])))
-        elif pyincdirs:
-            # only fail if *multiple* hits were found
-            # under --module-only --force or --extended-dry-run, nothing may actually be installed (yet)
-            raise EasyBuildError("Failed to isolate subdirectory with Python header files: %s", pyincdirs)
-
-        return guesses


### PR DESCRIPTION
This reverts the changes made in #1619, since it turns it causes problem with `ROOT` for example, leading to errors like:

```
In file included from /tmp/easybuild_build/ROOT/6.14.08/foss-2019a-Python-2.7.15/root-6-14-08/graf2d/asimage/src/TASPluginGS.cxx:40:
/prefix/software/Python/2.7.15-foss-2019a/include/python2.7/import.h:10:18: error: expected constructor, destructor, or type conversion before ‘PyImport_GetMagicNumber’
 PyAPI_FUNC(long) PyImport_GetMagicNumber(void);
                  ^~~~~~~~~~~~~~~~~~~~~~~
/prefix/software/Python/2.7.15-foss-2019a/include/python2.7/import.h:11:11: error: expected constructor, destructor, or type conversion before ‘(’ token     PyAPI_FUNC(PyObject *) PyImport_ExecCodeModule(char *name, PyObject *co);
           ^
```

The issue is that the Python header files have quite generic names like `import.h`:

```
abstract.h	   code.h	    funcobject.h    methodobject.h  pyconfig.h	    pystrcmp.h	    timefuncs.h
asdl.h		   compile.h	    genobject.h     modsupport.h    pyctype.h	    pystrtod.h	    token.h
ast.h		   complexobject.h  graminit.h	    moduleobject.h  py_curses.h     Python-ast.h    traceback.h
bitset.h	   cStringIO.h	    grammar.h	    node.h	    pydebug.h	    Python.h	    tupleobject.h
boolobject.h	   datetime.h	    import.h	    object.h	    pyerrors.h	    pythonrun.h     ucnhash.h
bufferobject.h	   descrobject.h    intobject.h     objimpl.h	    pyexpat.h	    pythread.h	    unicodeobject.h
bytearrayobject.h  dictobject.h     intrcheck.h     opcode.h	    pyfpe.h	    rangeobject.h   warnings.h
bytes_methods.h    dtoa.h	    iterobject.h    osdefs.h	    pygetopt.h	    setobject.h     weakrefobject.h
bytesobject.h	   enumobject.h     listobject.h    parsetok.h	    pymacconfig.h   sliceobject.h
cellobject.h	   errcode.h	    longintrepr.h   patchlevel.h    pymactoolbox.h  stringobject.h
ceval.h		   eval.h	    longobject.h    pgen.h	    pymath.h	    structmember.h
classobject.h	   fileobject.h     marshal.h	    pgenheaders.h   pymem.h	    structseq.h
cobject.h	   floatobject.h    memoryobject.h  pyarena.h	    pyport.h	    symtable.h
codecs.h	   frameobject.h    metagrammar.h   pycapsule.h     pystate.h	    sysmodule.h
```

So it's quite easy to introduce a clash on names of header files by always injecting `include/python2.7` to `$CPATH`...