### PR TITLE
Add generic easyblock for Go packages/applications

### DIFF
--- a/easybuild/easyblocks/generic/gopackage.py
+++ b/easybuild/easyblocks/generic/gopackage.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+##
+# Copyright 2009-2018 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for building and installing Go packages, implemented as an easyblock
+
+@author: Bob Dröge (University of Groningen)
+"""
+import os
+import shutil
+
+from easybuild.framework.easyconfig import CUSTOM
+from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.filetools import mkdir
+from easybuild.tools.run import run_cmd, parse_log_for_error
+from easybuild.tools.modules import get_software_root
+
+class GoPackage(ExtensionEasyBlock):
+    """
+    Install a Go package as a separate module, or as an extension.
+    """
+
+    def configure_step(self):
+        """Custom configure: fetch the sources of the dependencies."""
+        cmd = "env GOPATH=%s go get -d ./..." % (self.builddir)
+        run_cmd(cmd)
+
+    def build_step(self):
+        """Build the Go packages."""
+        cmd = "env GOPATH=%s go build ./..." % (self.builddir)
+        run_cmd(cmd)
+
+    def install_step(self):
+        """Install procedure for Go packages."""
+        cmd = "env GOBIN=%s GOPATH=%s go install ./..." % (self.installdir, self.builddir)
+        run_cmd(cmd)
+
+    def make_module_req_guess(self):
+        """Add the installation directory to PATH."""
+        guesses = super(GoPackage, self).make_module_req_guess()
+        guesses['PATH'] = ['']
+        return guesses
+
+    def make_module_req_guess(self):
+        """Customized dictionary of paths to look for with PERL*LIB."""
+
+        guesses = super(GoPackage, self).make_module_req_guess()
+        guesses.update({
+            "PATH" : [''],
+        })
+        return guesses

--- a/easybuild/easyblocks/generic/gopackage.py
+++ b/easybuild/easyblocks/generic/gopackage.py
@@ -31,11 +31,9 @@ EasyBuild support for building and installing Go packages, implemented as an eas
 import os
 import shutil
 
-from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import mkdir
-from easybuild.tools.run import run_cmd, parse_log_for_error
+from easybuild.tools.run import run_cmd
 from easybuild.tools.modules import get_software_root
 
 class GoPackage(ExtensionEasyBlock):
@@ -45,6 +43,8 @@ class GoPackage(ExtensionEasyBlock):
 
     def configure_step(self):
         """Custom configure: fetch the sources of the dependencies."""
+        if not get_software_root("Go"):
+            raise EasyBuildError("Go packages require to have a Go module in the builddependencies.")
         cmd = "env GOPATH=%s go get -d ./..." % (self.builddir)
         run_cmd(cmd)
 

--- a/easybuild/easyblocks/generic/gopackage.py
+++ b/easybuild/easyblocks/generic/gopackage.py
@@ -44,7 +44,7 @@ class GoPackage(Tarball):
     def install_step(self):
         """Install procedure for Go packages."""
         if not get_software_root("Go"):
-            raise EasyBuildError("Go packages require to have a Go module in the builddependencies.")
+            raise EasyBuildError("Go packages require to have a Go module in the (build)dependencies.")
         cmd = "env GOBIN=%s GOPATH=%s go get ./..." % (self.installdir, self.builddir)
         run_cmd(cmd)
 

--- a/easybuild/easyblocks/generic/gopackage.py
+++ b/easybuild/easyblocks/generic/gopackage.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ##
-# Copyright 2009-2018 Ghent University
+# Copyright 2009-2019 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/easyblocks/generic/gopackage.py
+++ b/easybuild/easyblocks/generic/gopackage.py
@@ -31,44 +31,25 @@ EasyBuild support for building and installing Go packages, implemented as an eas
 import os
 import shutil
 
-from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
+from easybuild.easyblocks.generic.tarball import Tarball
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd
 from easybuild.tools.modules import get_software_root
 
-class GoPackage(ExtensionEasyBlock):
+class GoPackage(Tarball):
     """
     Install a Go package as a separate module, or as an extension.
     """
 
-    def configure_step(self):
-        """Custom configure: fetch the sources of the dependencies."""
-        if not get_software_root("Go"):
-            raise EasyBuildError("Go packages require to have a Go module in the builddependencies.")
-        cmd = "env GOPATH=%s go get -d ./..." % (self.builddir)
-        run_cmd(cmd)
-
-    def build_step(self):
-        """Build the Go packages."""
-        cmd = "env GOPATH=%s go build ./..." % (self.builddir)
-        run_cmd(cmd)
-
     def install_step(self):
         """Install procedure for Go packages."""
-        cmd = "env GOBIN=%s GOPATH=%s go install ./..." % (self.installdir, self.builddir)
+        if not get_software_root("Go"):
+            raise EasyBuildError("Go packages require to have a Go module in the builddependencies.")
+        cmd = "env GOBIN=%s GOPATH=%s go get ./..." % (self.installdir, self.builddir)
         run_cmd(cmd)
 
     def make_module_req_guess(self):
         """Add the installation directory to PATH."""
         guesses = super(GoPackage, self).make_module_req_guess()
         guesses['PATH'] = ['']
-        return guesses
-
-    def make_module_req_guess(self):
-        """Customized dictionary of paths to look for with PERL*LIB."""
-
-        guesses = super(GoPackage, self).make_module_req_guess()
-        guesses.update({
-            "PATH" : [''],
-        })
         return guesses

--- a/easybuild/easyblocks/generic/gopackage.py
+++ b/easybuild/easyblocks/generic/gopackage.py
@@ -28,13 +28,11 @@ EasyBuild support for building and installing Go packages, implemented as an eas
 
 @author: Bob Dröge (University of Groningen)
 """
-import os
-import shutil
-
 from easybuild.easyblocks.generic.tarball import Tarball
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd
 from easybuild.tools.modules import get_software_root
+
 
 class GoPackage(Tarball):
     """


### PR DESCRIPTION
This is a generic easyblock that allows Go packages to be installed. It uses the "go get" command to get (the sources of) the dependencies, and to build and install everything.

I'm currently setting GOPATH to the build dir and GOBIN to the install dir: this means that only the compiled executables will be installed, while the sources will be wiped; since I'm not really a Go expert, does it make sense to do so? I think by doing so (and setting GOPATH in the modulefile), it would allow other modules to reuse code from this module. But since it's not really clear which dependencies the "go get" command installs, for now I preferred to just remove all sources.

Furthermore, it's basically now just compiling the Go files, and you don't need the Go module for running them. There's a check in the easyblock that raises an error if there is no Go module in the (build)dependencies. Is this the right approach, or should this for instance be added as a toolchain instead?

I've tested this easyblock with a SeqKit easyconfig (also see https://github.com/easybuilders/easybuild-easyconfigs/pull/6885):
```
easyblock = 'GoPackage'

name = 'SeqKit'
version = '0.10.0'

homepage = 'https://bioinf.shenwei.me/seqkit/'
description = """SeqKit - a cross-platform and ultrafast toolkit for FASTA/Q file manipulation"""

toolchain = {'name': 'dummy', 'version': ''}

source_urls = ['https://github.com/shenwei356/%(namelower)s/archive/']
sources = ['v%(version)s.tar.gz']

builddependencies = [('Go', '1.11.5')]

sanity_check_paths = {
    'files': ['%(namelower)s'],
    'dirs': [],
}

moduleclass = 'bio'
```

And with a dummy easyconfig that compiles this golang-example project:
https://github.com/buildkite/golang-example

For both of them, this easyblock worked, though only with a recent version of Go (1.11.5). It did not work with Go 1.8.1; I suspect this is due to some changes in the "go get" command that were introduced in newer version.