### PR TITLE
Add extra path to builddir for SNPhylo >= 20160204

### DIFF
--- a/easybuild/easyblocks/s/snphylo.py
+++ b/easybuild/easyblocks/s/snphylo.py
@@ -36,7 +36,7 @@ from distutils.version import LooseVersion
 
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import adjust_permissions, mkdir
+from easybuild.tools.filetools import adjust_permissions, copy_dir, copy_file, mkdir
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
 
@@ -82,13 +82,11 @@ class EB_SNPhylo(EasyBlock):
         if LooseVersion(self.version) >= LooseVersion('20160204'):
             predir = 'SNPhylo'
 
-        try:
-            mkdir(bindir, parents=True)
-            for binfile in binfiles:
-                shutil.copy2(os.path.join(self.builddir, predir, binfile), bindir)
-            shutil.copytree(os.path.join(self.builddir, predir, 'scripts'), os.path.join(self.installdir, 'scripts'))
-        except OSError as err:
-            raise EasyBuildError("Failed to copy SNPhylo files/dirs: %s", err)
+        mkdir(bindir, parents=True)
+        for binfile in binfiles:
+            copy_file(os.path.join(self.builddir, predir, binfile), bindir)
+
+        copy_dir(os.path.join(self.builddir, predir, 'scripts'), os.path.join(self.installdir, 'scripts'))
 
     def sanity_check_step(self):
         """Custom sanity check for SNPhylo."""

--- a/easybuild/easyblocks/s/snphylo.py
+++ b/easybuild/easyblocks/s/snphylo.py
@@ -32,6 +32,7 @@ import os
 import re
 import shutil
 import stat
+from distutils.version import LooseVersion
 
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.tools.build_log import EasyBuildError
@@ -76,11 +77,16 @@ class EB_SNPhylo(EasyBlock):
         """Install by copying files/directories."""
         bindir = os.path.join(self.installdir, 'bin')
         binfiles = ['snphylo.sh', 'snphylo.cfg', 'snphylo.template']
+
+        predir = ''
+        if LooseVersion(self.version) >= LooseVersion('20160204'):
+            predir = 'SNPhylo'
+        
         try:
             mkdir(bindir, parents=True)
             for binfile in binfiles:
-                shutil.copy2(os.path.join(self.builddir, binfile), bindir)
-            shutil.copytree(os.path.join(self.builddir, 'scripts'), os.path.join(self.installdir, 'scripts'))
+                shutil.copy2(os.path.join(self.builddir, predir, binfile), bindir)
+            shutil.copytree(os.path.join(self.builddir, predir, 'scripts'), os.path.join(self.installdir, 'scripts'))
         except OSError as err:
             raise EasyBuildError("Failed to copy SNPhylo files/dirs: %s", err)
 

--- a/easybuild/easyblocks/s/snphylo.py
+++ b/easybuild/easyblocks/s/snphylo.py
@@ -81,7 +81,7 @@ class EB_SNPhylo(EasyBlock):
         predir = ''
         if LooseVersion(self.version) >= LooseVersion('20160204'):
             predir = 'SNPhylo'
-        
+
         try:
             mkdir(bindir, parents=True)
             for binfile in binfiles:


### PR DESCRIPTION
The newest version of `SNPhylo` builds in a directory with the same name and must be added to the source path of the `shutil.copy2` and `shutil.copytree` commands to correctly find the files to install.