### PR TITLE
add no_qa pattern for interactive installation command for ABAQUS

### DIFF
--- a/easybuild/easyblocks/a/abaqus.py
+++ b/easybuild/easyblocks/a/abaqus.py
@@ -174,7 +174,8 @@ class EB_ABAQUS(Binary):
                     "\[1\] Continue\n(?:.|\n)*Please choose an action:": '1',
                     "\[2\] Continue\n(?:.|\n)*Please choose an action:": '2',
                 }
-                run_cmd_qa('./StartTUI.sh', {}, std_qa=std_qa, log_all=True, simple=True, maxhits=100)
+                no_qa = [r"Please be patient;  it will take a few minutes to complete\.\n(\.)*"]
+                run_cmd_qa('./StartTUI.sh', {}, no_qa=no_qa, std_qa=std_qa, log_all=True, simple=True, maxhits=100)
 
     def sanity_check_step(self):
         """Custom sanity check for ABAQUS."""


### PR DESCRIPTION
This avoids that the installation is cancelled because the output "hangs" at what is assumed to be an unknown question, while it's actually still going...