### PR TITLE
Make serial, smpar and dm+sm builds of WRF work and pass tests.

### DIFF
--- a/easybuild/easyblocks/w/wrf.py
+++ b/easybuild/easyblocks/w/wrf.py
@@ -158,7 +158,7 @@ class EB_WRF(EasyBlock):
 
         # fetch selected build type (and make sure it makes sense)
         known_build_types = ['serial', 'smpar', 'dmpar', 'dm+sm']
-        self.parallel_build_types = ["dmpar", "smpar", "dm+sm"]
+        self.parallel_build_types = ["dmpar", "dm+sm"]
         bt = self.cfg['buildtype']
 
         if bt not in known_build_types:

--- a/easybuild/easyblocks/w/wrf.py
+++ b/easybuild/easyblocks/w/wrf.py
@@ -302,7 +302,7 @@ class EB_WRF(EasyBlock):
                 test_cmd = "ulimit -s unlimited && %s && %s" % (self.toolchain.mpi_cmd_for("./ideal.exe", 1),
                                                                 self.toolchain.mpi_cmd_for("./wrf.exe", n))
             else:
-                test_cmd = "ulimit -s unlimited && ./ideal.exe && ./wrf.exe" % n
+                test_cmd = "ulimit -s unlimited && ./ideal.exe && ./wrf.exe >rsl.error.0000 2>&1"
 
             def run_test():
                 """Run a single test and check for success."""

--- a/easybuild/easyblocks/w/wrf.py
+++ b/easybuild/easyblocks/w/wrf.py
@@ -164,6 +164,9 @@ class EB_WRF(EasyBlock):
         if bt not in known_build_types:
             raise EasyBuildError("Unknown build type: '%s'. Supported build types: %s", bt, known_build_types)
 
+        # Escape the "+" in "dm+sm" since it's being used in a regexp below.
+        bt = bt.replace('+', '\+')
+
         # fetch option number based on build type option and selected build type
         if LooseVersion(self.version) >= LooseVersion('3.7'):
             # the two relevant lines in the configure output for WRF 3.8 are:

--- a/easybuild/easyblocks/w/wrf.py
+++ b/easybuild/easyblocks/w/wrf.py
@@ -165,7 +165,7 @@ class EB_WRF(EasyBlock):
             raise EasyBuildError("Unknown build type: '%s'. Supported build types: %s", bt, known_build_types)
 
         # Escape the "+" in "dm+sm" since it's being used in a regexp below.
-        bt = bt.replace('+', '\+')
+        bt = bt.replace('+', r'\+')
 
         # fetch option number based on build type option and selected build type
         if LooseVersion(self.version) >= LooseVersion('3.7'):


### PR DESCRIPTION
run_test only checks rsl.error.0000 which isn't created for a serial run.