### PR TITLE
 configure CP2K with correct DATA_DIR value rather than relying on $CP2K_DATA_DIR environment variable

### DIFF
--- a/easybuild/easyblocks/c/cp2k.py
+++ b/easybuild/easyblocks/c/cp2k.py
@@ -240,6 +240,9 @@ class EB_CP2K(EasyBlock):
 
         options['LIBS'] = "-Wl,--start-group %s -Wl,--end-group" % options['LIBS']
 
+        # specify correct location for 'data' directory in final installation
+        options['DATA_DIR'] = os.path.join(self.installdir, 'data')
+
         # create arch file using options set
         archfile = os.path.join(self.cfg['start_dir'], 'arch', '%s.%s' % (self.typearch, self.cfg['type']))
         txt = self._generate_makefile(options)
@@ -650,6 +653,11 @@ class EB_CP2K(EasyBlock):
 
         if self.cfg['runtest']:
 
+            # we need to specify location of 'data' directory in *build* dir,
+            # since we've configured CP2K to look into the installation directory
+            # (where 'data' will be copied to in install step)
+            setvar('CP2K_DATA_DIR', os.path.join(self.cfg['start_dir'], 'data'))
+
             if not build_option('mpi_tests'):
                 self.log.info("Skipping testing of CP2K since MPI testing is disabled")
                 return
@@ -859,12 +867,3 @@ class EB_CP2K(EasyBlock):
             custom_paths['files'].append(os.path.join('include', 'libcp2k.h'))
             custom_paths['files'].append(os.path.join('include', 'libcp2k.mod'))
         super(EB_CP2K, self).sanity_check_step(custom_paths=custom_paths)
-
-    def make_module_extra(self):
-        """Set up a CP2K_DATA_DIR environment variable to find CP2K provided basis sets"""
-
-        txt = super(EB_CP2K, self).make_module_extra()
-        datadir = os.path.join(self.installdir, 'data')
-        if os.path.exists(datadir):
-            txt += self.module_generator.set_environment('CP2K_DATA_DIR', datadir)
-        return txt

--- a/easybuild/easyblocks/c/cp2k.py
+++ b/easybuild/easyblocks/c/cp2k.py
@@ -867,3 +867,17 @@ class EB_CP2K(EasyBlock):
             custom_paths['files'].append(os.path.join('include', 'libcp2k.h'))
             custom_paths['files'].append(os.path.join('include', 'libcp2k.mod'))
         super(EB_CP2K, self).sanity_check_step(custom_paths=custom_paths)
+
+    def make_module_extra(self):
+        """Set up a CP2K_DATA_DIR environment variable to find CP2K provided basis sets"""
+
+        txt = super(EB_CP2K, self).make_module_extra()
+
+        # also define $CP2K_DATA_DIR in module,
+        # even though CP2K was already configured to pick up 'data' from install dir
+        # this could be useful for users to access the 'data' dir in a documented way (and it doesn't hurt)
+        datadir = os.path.join(self.installdir, 'data')
+        if os.path.exists(datadir):
+            txt += self.module_generator.set_environment('CP2K_DATA_DIR', datadir)
+
+        return txt

--- a/easybuild/easyblocks/c/cp2k.py
+++ b/easybuild/easyblocks/c/cp2k.py
@@ -41,7 +41,6 @@ import fileinput
 import glob
 import re
 import os
-import shutil
 import sys
 from distutils.version import LooseVersion
 
@@ -50,7 +49,7 @@ from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.environment import setvar
-from easybuild.tools.filetools import copy_dir, copy_file, mkdir, search_file, write_file
+from easybuild.tools.filetools import change_dir, copy_dir, copy_file, mkdir, write_file
 from easybuild.tools.config import build_option
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
@@ -260,10 +259,7 @@ class EB_CP2K(EasyBlock):
             modincpath = os.path.join(os.path.dirname(os.path.normpath(self.cfg['start_dir'])), 'modinc')
             self.log.debug("Preparing module files in %s" % modincpath)
 
-            try:
-                os.mkdir(modincpath)
-            except OSError as err:
-                raise EasyBuildError("Failed to create directory for module include files: %s", err)
+            mkdir(modincpath, parents=True)
 
             # get list of modinc source files
             modincdir = os.path.join(imkl, self.cfg["modincprefix"], 'include')
@@ -387,7 +383,7 @@ class EB_CP2K(EasyBlock):
                     path = os.path.join(self.cfg['start_dir'], path)
                     if os.path.isdir(path):
                         libinttools_path = path
-                        os.chdir(libinttools_path)
+                        change_dir(libinttools_path)
                 if not libinttools_path:
                     raise EasyBuildError("No libinttools dir found")
 
@@ -413,7 +409,6 @@ class EB_CP2K(EasyBlock):
         else:
             # throw a warning, since CP2K without Libint doesn't make much sense
             self.log.warning("Libint module not loaded, so building without Libint support")
-
 
         libxc = get_software_root('libxc')
         if libxc:
@@ -621,10 +616,7 @@ class EB_CP2K(EasyBlock):
         """
 
         makefiles = os.path.join(self.cfg['start_dir'], 'makefiles')
-        try:
-            os.chdir(makefiles)
-        except OSError as err:
-            raise EasyBuildError("Can't change to makefiles dir %s: %s", makefiles, err)
+        change_dir(makefiles)
 
         # modify makefile for parallel build
         parallel = self.cfg['parallel']
@@ -648,7 +640,7 @@ class EB_CP2K(EasyBlock):
         # clean first
         run_cmd(cmd + " clean", log_all=True, simple=True, log_output=True)
 
-        #build_and_install
+        # build and install
         if self.cfg['library']:
             cmd += ' libcp2k'
         run_cmd(cmd + " all", log_all=True, simple=True, log_output=True)
@@ -666,10 +658,7 @@ class EB_CP2K(EasyBlock):
                 setvar('OMP_NUM_THREADS', self.cfg['omp_num_threads'])
 
             # change to root of build dir
-            try:
-                os.chdir(self.builddir)
-            except OSError as err:
-                raise EasyBuildError("Failed to change to %s: %s", self.builddir, err)
+            change_dir(self.builddir)
 
             # use regression test reference output if available
             # try and find an unpacked directory that starts with 'LAST-'


### PR DESCRIPTION
Relying on `$CP2K_DATA_DIR` is problematic in some contexts; for example, it requires that the MPI processes also run in an environment where `$CP2K_DATA_DIR` is (still) defines.

Change made on recommendation of @dev-zero (one of the CP2K core developers).

(see also https://github.com/cp2k/cp2k/issues/234)