### PR TITLE
add support to CMakeMake easyblock to specify compilers using absolute file path

### DIFF
--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -37,7 +37,7 @@ import os
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.config import build_option
-from easybuild.tools.filetools import change_dir, mkdir
+from easybuild.tools.filetools import change_dir, mkdir, which
 from easybuild.tools.environment import setvar
 from easybuild.tools.run import run_cmd
 from vsc.utils.missing import nub
@@ -51,6 +51,7 @@ class CMakeMake(ConfigureMake):
         """Define extra easyconfig parameters specific to CMakeMake."""
         extra_vars = ConfigureMake.extra_options(extra_vars)
         extra_vars.update({
+            'abs_path_compilers': [False, "Specify compilers via absolute file path (not via command names)", CUSTOM],
             'srcdir': [None, "Source directory location to provide to cmake command", CUSTOM],
             'separate_build_dir': [False, "Perform build in a separate directory", CUSTOM],
         })
@@ -97,6 +98,9 @@ class CMakeMake(ConfigureMake):
         for env_name, option in env_to_options.items():
             value = os.getenv(env_name)
             if value is not None:
+                if option.endswith('_COMPILER') and self.cfg['abs_path_compilers']:
+                    value = which(value)
+                    self.log.info("Using absolute path to compiler command: %s", value)
                 options.append("-D%s='%s'" % (option, value))
 
         if build_option('rpath'):


### PR DESCRIPTION
@schiotz I consider this a cleaner approach to your need to specify compilers using full path in https://github.com/easybuilders/easybuild-easyconfigs/pull/7569