### PR TITLE
stop checking for deprecated pgf77 in sanity check of PGI easyblock

### DIFF
--- a/easybuild/easyblocks/p/pgi.py
+++ b/easybuild/easyblocks/p/pgi.py
@@ -173,7 +173,7 @@ class EB_PGI(PackedBinary):
         """Custom sanity check for PGI"""
         prefix = self.pgi_install_subdir
         custom_paths = {
-            'files': [os.path.join(prefix, 'bin', x) for x in ['pgcc', 'pgc++', 'pgf77', 'pgfortran', 'siterc']],
+            'files': [os.path.join(prefix, 'bin', x) for x in ['pgcc', 'pgc++', 'pgfortran', 'siterc']],
             'dirs': [os.path.join(prefix, 'bin'), os.path.join(prefix, 'lib'),
                      os.path.join(prefix, 'include'), os.path.join(prefix, 'man')]
         }


### PR DESCRIPTION
From PGI 19.1 release notes (cfr. https://www.pgroup.com/resources/docs/19.1/x86/pgi-release-notes/index.htm):

```
The pgf77 driver is deprecated. Use pgfortran to compile F77 Fortran. 
```

Without this, sanity check fails when trying to install PGI 19.1...