### PR TITLE
also take into account custom easyconfig parameters from CMakeMake in BamTools easyblock

### DIFF
--- a/easybuild/easyblocks/b/bamtools.py
+++ b/easybuild/easyblocks/b/bamtools.py
@@ -44,10 +44,12 @@ class EB_BamTools(MakeCp, CMakeMake):
     @staticmethod
     def extra_options(extra_vars=None):
         """Extra easyconfig parameters for BamTools."""
-        extra = MakeCp.extra_options()
+        extra_vars = MakeCp.extra_options()
+
         # files_to_copy is not mandatory here, since we overwrite it in install_step
-        extra['files_to_copy'][2] = CUSTOM
-        return extra
+        extra_vars['files_to_copy'][2] = CUSTOM
+
+        return CMakeMake.extra_options(extra_vars=extra_vars)
 
     def configure_step(self):
         """Configure BamTools build."""


### PR DESCRIPTION
fix for problem introduced with the changes in #1628 (cc @mboisson)

The `BamTools` easyblock should've been taking into account `CMakeMake.extra_options` all along, but it never really was a problem until now.

The issue manifested itself as follows when building `BamTools`:

```
== configuring...
  >> running command:
        [started at: 2019-03-14 13:51:41]
        [output logged in /tmp/eb-OFpHzj/easybuild-run_cmd-p6lGxa.log]
        ./configure -DCMAKE_INSTALL_PREFIX=/user/gent/400/vsc40023/eb_phanpyscratch/CO7/skylake-ib/software/BamTools/2.5.1-intel-2018b -DCMAKE_C_COMPILER='icc' -DCMAKE_Fortran_FLAGS='-O2 -xHost -ftz -fp-speculation=safe -fp-model source -fPIC' -DCMAKE_CXX_FLAGS='-O2 -xHost -ftz -fp-speculation=safe -fp-model source -fPIC' -DCMAKE_CXX_COMPILER='icpc' -DCMAKE_Fortran_COMPILER='ifort' -DCMAKE_C_FLAGS='-O2 -xHost -ftz -fp-speculation=safe -fp-model source -fPIC' -DCMAKE_VERBOSE_MAKEFILE=ON  ..
  >> command completed: exit 127, ran in < 1s
```

Note the `./configure`, which should be `cmake` of course...