### PR TITLE
make sure correct value for install_cmd is picked up in ConfigureMake

### DIFF
--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -120,7 +120,7 @@ class CMakeMake(ConfigureMake):
 
         command = ' '.join([
             self.cfg['preconfigopts'],
-            self.cfg.get('configure_cmd', DEFAULT_CONFIGURE_CMD),
+            self.cfg.get('configure_cmd') or DEFAULT_CONFIGURE_CMD,
             options_string,
             self.cfg['configopts'],
             srcdir])

--- a/easybuild/easyblocks/generic/configuremake.py
+++ b/easybuild/easyblocks/generic/configuremake.py
@@ -208,7 +208,7 @@ class ConfigureMake(EasyBlock):
         if prefix_opt is None:
             prefix_opt = '--prefix='
 
-        configure_command = cmd_prefix + self.cfg.get('configure_cmd', DEFAULT_CONFIGURE_CMD)
+        configure_command = cmd_prefix + (self.cfg.get('configure_cmd') or DEFAULT_CONFIGURE_CMD)
 
         # avoid using config.guess from an Autoconf generated package as it is frequently out of date;
         # use the version downloaded by EasyBuild instead, and provide the result to the configure command;
@@ -276,7 +276,7 @@ class ConfigureMake(EasyBlock):
 
         cmd = ' '.join([
             self.cfg['prebuildopts'],
-            self.cfg.get('build_cmd', DEFAULT_BUILD_CMD),
+            self.cfg.get('build_cmd') or DEFAULT_BUILD_CMD,
             paracmd,
             self.cfg['buildopts'],
         ])
@@ -305,7 +305,7 @@ class ConfigureMake(EasyBlock):
 
         cmd = ' '.join([
             self.cfg['preinstallopts'],
-            self.cfg.get('install_cmd', DEFAULT_INSTALL_CMD),
+            self.cfg.get('install_cmd') or DEFAULT_INSTALL_CMD,
             self.cfg['installopts'],
         ])
 


### PR DESCRIPTION
While testing https://github.com/easybuilders/easybuild-easyconfigs/pull/7906 I ran into the following problem that was introduced via #1628:

```
== installing...
ERROR: Traceback (most recent call last):
  File "/prefix/lib/python2.6/site-packages/easybuild_framework-3.9.0.dev0-py2.7.egg/easybuild/main.py", line 112, in build_and_install_software
    (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env)
  File "/prefix/lib/python2.7/site-packages/easybuild_framework-3.9.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2882, in build_and_install_one
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/prefix/lib/python2.7/site-packages/easybuild_framework-3.9.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2792, in run_all_steps
    self.run_step(step_name, step_methods)
  File "/prefix/lib/python2.7/site-packages/easybuild_framework-3.9.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2665, in run_step
    step_method(self)()
  File "/prefix/lib/python2.7/site-packages/easybuild_easyblocks-3.9.0.dev0-py2.7.egg/easybuild/easyblocks/generic/configuremake.py", line 312, in install_step
    self.cfg['installopts'],
TypeError: sequence item 1: expected string, NoneType found
```

The problem here is that the `Mono` easyblock derives from both `ConfigureMake` and `Rpm`, which in turns derives from `Binary`.
Since `install_cmd` is also defined as a custom easyconfig parameter for the `Binary` easyblock, `self.cfg.get('install_cmd', default)` returns `None` (i.e., the default value for `install_cmd` set in the `Binary` easyblock) rather than the intended `default`.

This is easily fixed by using `self.cfg.get('install_cmd') or default` instead.
The same change is applied to `configure_cmd` and `build_cmd` for the sake of consistency...