### PR TITLE
use result of det_pylibdir() in sanity check for numpy/scipy to ensure correct path is checked

### DIFF
--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -39,6 +39,7 @@ import tempfile
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.fortranpythonpackage import FortranPythonPackage
+from easybuild.easyblocks.generic.pythonpackage import det_pylibdir
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import change_dir, mkdir, rmtree2
@@ -297,6 +298,13 @@ class EB_numpy(FortranPythonPackage):
     def sanity_check_step(self, *args, **kwargs):
         """Custom sanity check for numpy."""
 
+        # can't use self.pylibdir here, need to determine path on the fly using currently active 'python' command;
+        # this is important for numpy installations for multiple Python version (via multi_deps)
+        custom_paths = {
+            'files': [],
+            'dirs': [det_pylibdir()],
+        }
+
         custom_commands = []
 
         if LooseVersion(self.version) >= LooseVersion("1.10"):
@@ -313,7 +321,7 @@ class EB_numpy(FortranPythonPackage):
             # _dotblas is required for decent performance of numpy.dot(), but only there in numpy 1.9.x and older
             custom_commands.append("python -c 'import numpy.core._dotblas'")
 
-        return super(EB_numpy, self).sanity_check_step(custom_commands=custom_commands)
+        return super(EB_numpy, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
 
     def make_module_extra_numpy_include(self):
         """

--- a/easybuild/easyblocks/s/scipy.py
+++ b/easybuild/easyblocks/s/scipy.py
@@ -34,6 +34,7 @@ EasyBuild support for building and installing scipy, implemented as an easyblock
 from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.fortranpythonpackage import FortranPythonPackage
+from easybuild.easyblocks.generic.pythonpackage import det_pylibdir
 import easybuild.tools.toolchain as toolchain
 
 
@@ -56,3 +57,15 @@ class EB_scipy(FortranPythonPackage):
             # which requires unsetting $LDFLAGS
             if self.toolchain.comp_family() in [toolchain.GCC, toolchain.CLANGGCC]:  # @UndefinedVariable
                 self.cfg.update('preinstallopts', "unset LDFLAGS && ")
+
+    def sanity_check_step(self, *args, **kwargs):
+        """Custom sanity check for scipy."""
+
+        # can't use self.pylibdir here, need to determine path on the fly using currently active 'python' command;
+        # this is important for numpy installations for multiple Python version (via multi_deps)
+        custom_paths = {
+            'files': [],
+            'dirs': [det_pylibdir()],
+        }
+
+        return super(EB_scipy, self).sanity_check_step(custom_paths=custom_paths)


### PR DESCRIPTION
follow-up for #1665, without this the default `bin` & `lib` or `lib64` directory are checked for `numpy` & `scipy`, which doesn't make sense...