### PR TITLE
always set self.pylibdir in PythonPackage.set_pylibdirs(), which is important when installing Python packages for multiple Python versions via multi_deps

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -289,10 +289,11 @@ class PythonPackage(ExtensionEasyBlock):
 
     def set_pylibdirs(self):
         """Set Python lib directory-related class variables."""
+
         # pylibdir is the 'main' Python lib directory
-        if self.pylibdir == UNKNOWN:
-            self.pylibdir = det_pylibdir(python_cmd=self.python_cmd)
+        self.pylibdir = det_pylibdir(python_cmd=self.python_cmd)
         self.log.debug("Python library dir: %s" % self.pylibdir)
+
         # on (some) multilib systems, the platform-specific library directory for the system Python is different
         # cfr. http://serverfault.com/a/88739/126446
         # so, we keep a list of different Python lib directories to take into account


### PR DESCRIPTION
Ran into a hard to diagnose error like this when installing `h5py` for both Python 2.7.15 and 3.7.2 via `multi_deps` without this change:

```
ImportError: dynamic module does not define module export function (PyInit__multiarray_umath)
```

I think it's fine to simply always set `self.pylibdir`, regardless of whether it was set already or not. It's basically a case of premature optimization as far as I can tell, and `set_pylibdirs` should only get called once in a normal (non-multi-deps) installation.