### PR TITLE
Make sure meson has -Dlibdir=lib so it doesn't install libraries in lib/x86_64-linux-gnu on Debian/Ubuntu multiarch systems

### DIFF
--- a/easybuild/easyblocks/generic/mesonninja.py
+++ b/easybuild/easyblocks/generic/mesonninja.py
@@ -70,7 +70,9 @@ class MesonNinja(EasyBlock):
 
         # Make sure libdir doesn't get set to lib/x86_64-linux-gnu or something
         # on Debian/Ubuntu multiarch systems and others.
-        if '-Dlibdir' not in self.cfg['configopts']:
+        no_Dlibdir = '-Dlibdir' not in self.cfg['configopts']
+        no_libdir = '--libdir' not in self.cfg['configopts']
+        if no_Dlibdir and no_libdir:
             self.cfg.update('configopts', '-Dlibdir=lib')
 
         cmd = "%(preconfigopts)s meson --prefix %(installdir)s %(configopts)s %(sourcedir)s" % {

--- a/easybuild/easyblocks/generic/mesonninja.py
+++ b/easybuild/easyblocks/generic/mesonninja.py
@@ -68,6 +68,11 @@ class MesonNinja(EasyBlock):
             mkdir(builddir)
             change_dir(builddir)
 
+        # Make sure libdir doesn't get set to lib/x86_64-linux-gnu or something
+        # on Debian/Ubuntu multiarch systems and others.
+        if '-Dlibdir' not in self.cfg['configopts']:
+            self.cfg.update('configopts', '-Dlibdir=lib')
+
         cmd = "%(preconfigopts)s meson --prefix %(installdir)s %(configopts)s %(sourcedir)s" % {
             'configopts': self.cfg['configopts'],
             'installdir': self.installdir,


### PR DESCRIPTION
Make sure meson has -Dlibdir=lib so it doesn't install libraries in lib/x86_64-linux-gnu on Debian/Ubuntu multiarch systems.