### PR TITLE
also take into account 'custom_paths' passed down to sanity_check_step before injecting default sanity_check_paths value that uses %(pyshortver)s template value

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -597,7 +597,7 @@ class PythonPackage(ExtensionEasyBlock):
         # but only for stand-alone installations, not for extensions;
         # this is relevant for installations of Python packages for multiple Python versions (via multi_deps)
         # (we can not pass this via custom_paths, since then the %(pyshortver)s template value will not be resolved)
-        if not self.is_extension and not self.cfg['sanity_check_paths']:
+        if not self.is_extension and not self.cfg['sanity_check_paths'] and kwargs.get('custom_paths') is None:
             self.cfg['sanity_check_paths'] = {
                 'files': [],
                 'dirs': [os.path.join('lib', 'python%(pyshortver)s', 'site-packages')],


### PR DESCRIPTION
Without this fix for a problem introduced with #1664, installing `EasyBuild` with EasyBuild is broken.

The sanity check fails as follows:

```
== sanity checking...
   ...
  >> (non-empty) directory 'lib/python%(pyshortver)s/site-packages' found: FAILED

```

This happens because the `%(pyshortver)s` template value in `lib/python%(pyshortver)s/site-packages` does not get resolved since `Python` is not a real dependency: it's specified as an allowed system dependency via `allow_system_deps` in the `EasyBuild` easyconfig files.