### PR TITLE
fix import statement for DUMMY_TOOLCHAIN_NAME

### DIFF
--- a/easybuild/easyblocks/b/binutils.py
+++ b/easybuild/easyblocks/b/binutils.py
@@ -39,7 +39,7 @@ from easybuild.tools.filetools import apply_regex_substitutions, copy_file
 from easybuild.tools.modules import get_software_libdir, get_software_root
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
-from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME
+from easybuild.tools.toolchain.toolchain import DUMMY_TOOLCHAIN_NAME
 
 
 class EB_binutils(ConfigureMake):

--- a/easybuild/easyblocks/generic/buildenv.py
+++ b/easybuild/easyblocks/generic/buildenv.py
@@ -23,12 +23,12 @@
 # along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
 ##
 """
-EasyBuild support for creating a module that loads the build 
-environment flags for the current toolchain 
+EasyBuild support for creating a module that loads the build
+environment flags for the current toolchain
 
 @author: Alan O'Cais (Juelich Supercomputing Centre)
 """
-from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME
+from easybuild.tools.toolchain.toolchain import DUMMY_TOOLCHAIN_NAME
 from easybuild.easyblocks.generic.bundle import Bundle
 
 

--- a/easybuild/easyblocks/generic/systemmpi.py
+++ b/easybuild/easyblocks/generic/systemmpi.py
@@ -34,13 +34,13 @@ from easybuild.easyblocks.generic.bundle import Bundle
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.easyblocks.generic.systemcompiler import extract_compiler_version
 from easybuild.easyblocks.impi import EB_impi
-from easybuild.framework.easyconfig.easyconfig import ActiveMNS
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError, print_warning
 from easybuild.tools.filetools import read_file, resolve_path, which
 from easybuild.tools.modules import get_software_version
 from easybuild.tools.run import run_cmd
-from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME
+from easybuild.tools.toolchain.toolchain import DUMMY_TOOLCHAIN_NAME
+
 
 class SystemMPI(Bundle, ConfigureMake, EB_impi):
     """

--- a/easybuild/easyblocks/l/libxml2.py
+++ b/easybuild/easyblocks/l/libxml2.py
@@ -39,7 +39,7 @@ from easybuild.easyblocks.generic.pythonpackage import PythonPackage
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.systemtools import get_shared_lib_ext
-from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME
+from easybuild.tools.toolchain.toolchain import DUMMY_TOOLCHAIN_NAME
 
 
 class EB_libxml2(ConfigureMake, PythonPackage):

--- a/easybuild/easyblocks/t/tbb.py
+++ b/easybuild/easyblocks/t/tbb.py
@@ -44,7 +44,7 @@ from easybuild.easyblocks.generic.intelbase import IntelBase, ACTIVATION_NAME_20
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_version
 from easybuild.tools.systemtools import get_gcc_version, get_platform_name
-from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME
+from easybuild.tools.toolchain.toolchain import DUMMY_TOOLCHAIN_NAME
 
 
 def get_tbb_gccprefix():


### PR DESCRIPTION
This is required after the merge of https://github.com/easybuilders/easybuild-framework/pull/2836 where some constants had to be moved a bit...