### PR TITLE
update QuantumESPRESSO easyblock for v6.4.1

### DIFF
--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -142,16 +142,14 @@ class EB_QuantumESPRESSO(ConfigureMake):
                                      "version %s or newer" % (self.version, elpa_min_ver))
 
             if self.toolchain.options.get('openmp', False):
-                elpa_include = os.path.join(elpa, 'include', 'elpa_openmp-%s' % elpa_v)
-            else:
-                elpa_include = os.path.join(elpa, 'include', 'elpa-%s' % elpa_v)
-            repls.append(('IFLAGS', '-I%s' % os.path.join(elpa_include, 'modules'), True))
-            self.cfg.update('configopts', '--with-elpa-include=%s' % elpa_include)
-            if self.toolchain.options.get('openmp', False):
+                elpa_include = 'elpa_openmp-%s' % elpa_v
                 elpa_lib = 'libelpa_openmp.a'
             else:
+                elpa_include = 'elpa-%s' % elpa_v
                 elpa_lib = 'libelpa.a'
-
+            elpa_include = os.path.join(elpa, 'include', elpa_include)
+            repls.append(('IFLAGS', '-I%s' % os.path.join(elpa_include, 'modules'), True))
+            self.cfg.update('configopts', '--with-elpa-include=%s' % elpa_include)
             elpa_lib = os.path.join(elpa, 'lib', elpa_lib)
             self.cfg.update('configopts', '--with-elpa-lib=%s' % elpa_lib)
 

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -60,7 +60,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
     def __init__(self, *args, **kwargs):
         """Add extra config options specific to Quantum ESPRESSO."""
         super(EB_QuantumESPRESSO, self).__init__(*args, **kwargs)
-
+ 
         if LooseVersion(self.version) >= LooseVersion("6"):
             self.install_subdir = "qe-%s" % self.version
         else:
@@ -141,7 +141,13 @@ class EB_QuantumESPRESSO(ConfigureMake):
                 raise EasyBuildError("QuantumESPRESSO %s needs ELPA to be " +
                                      "version %s or newer" % (self.version, elpa_min_ver))
 
-            elpa_include = os.path.join(elpa, 'include')
+            if LooseVersion(elpa_v) < LooseVersion("2018"):
+                elpa_include = os.path.join(elpa, 'include')
+            else:
+                if self.toolchain.options.get('openmp', False):
+                    elpa_include = os.path.join(elpa, 'include', 'elpa_openmp-%s' % elpa_v)
+                else:
+                    elpa_include = os.path.join(elpa, 'include', 'elpa-%s' % elpa_v)
             repls.append(('IFLAGS', '-I%s' % os.path.join(elpa_include, 'modules'), True))
             self.cfg.update('configopts', '--with-elpa-include=%s' % elpa_include)
             if self.toolchain.options.get('openmp', False):
@@ -343,46 +349,26 @@ class EB_QuantumESPRESSO(ConfigureMake):
         copy_dir(os.path.join(self.cfg['start_dir'], 'bin'), bindir)
 
         # Pick up files not installed in bin
-        upftools = []
+        def copy_binaries(path):
+            full_dir = os.path.join(self.cfg['start_dir'], path)
+            self.log.info("Looking for binaries in %s" % full_dir)
+            for filename in os.listdir(full_dir):
+                full_path = os.path.join(full_dir, filename)
+                if os.path.isfile(full_path):
+                    if filename.endswith('.x'):
+                        copy_file(full_path, bindir)
+
         if 'upf' in targets or 'all' in targets:
-            upftools = ["casino2upf.x", "cpmd2upf.x", "fhi2upf.x", "fpmd2upf.x", "ncpp2upf.x",
-                        "oldcp2upf.x", "read_upf_tofile.x", "rrkj2upf.x", "uspp2upf.x", "vdb2upf.x",
-                        "virtual.x"]
-            if LooseVersion(self.version) > LooseVersion("5"):
-                upftools.extend(["interpolate.x", "upf2casino.x"])
-            if LooseVersion(self.version) >= LooseVersion("6.3"):
-                upftools.extend(["fix_upf.x"])
-        upf_bins = [os.path.join('upftools', x) for x in upftools]
-        for upf_bin in upf_bins:
-            copy_file(os.path.join(self.cfg['start_dir'], upf_bin), bindir)
+            copy_binaries('upftools')
 
-        wanttools = []
         if 'want' in targets:
-            wanttools = ["blc2wan.x", "conductor.x", "current.x", "disentangle.x",
-                         "dos.x", "gcube2plt.x", "kgrid.x", "midpoint.x", "plot.x", "sumpdos",
-                         "wannier.x", "wfk2etsf.x"]
-            if LooseVersion(self.version) > LooseVersion("5"):
-                wanttools.extend(["cmplx_bands.x", "decay.x", "sax2qexml.x", "sum_sgm.x"])
-        want_bins = [os.path.join('WANT', 'bin', x) for x in wanttools]
-        for want_bin in want_bins:
-            copy_file(os.path.join(self.cfg['start_dir'], want_bin), bindir)
+            copy_binaries('WANT')
 
-        w90tools = []
         if 'w90' in targets:
-            if LooseVersion(self.version) >= LooseVersion("5.4"):
-                w90tools = ["postw90.x"]
-                if LooseVersion(self.version) < LooseVersion("6.1"):
-                    w90tools = ["w90chk2chk.x"]
-        w90_bins = [os.path.join('W90', x) for x in w90tools]
-        for w90_bin in w90_bins:
-            copy_file(os.path.join(self.cfg['start_dir'], w90_bin), bindir)
+            copy_binaries('W90')
 
-        yambo_bins = []
         if 'yambo' in targets:
-            yambo_bins = ["a2y", "p2y", "yambo", "ypp"]
-        yambo_bins = [os.path.join('YAMBO', 'bin', x) for x in yambo_bins]
-        for yambo_bin in yambo_bins:
-            copy_file(os.path.join(self.cfg['start_dir'], yambo_bin), bindir)
+            copy_binaries('YAMBO')
 
     def sanity_check_step(self):
         """Custom sanity check for Quantum ESPRESSO."""
@@ -394,7 +380,10 @@ class EB_QuantumESPRESSO(ConfigureMake):
         bins = ["iotk", "iotk.x", "iotk_print_kinds.x"]
 
         if 'cp' in targets or 'all' in targets:
-            bins.extend(["cp.x", "cppp.x", "wfdd.x"])
+            bins.extend(["cp.x", "wfdd.x"])
+            if LooseVersion(self.version) < LooseVersion("6.4"):
+                bins.append("cppp.x")
+
 
         # only for v4.x, not in v5.0 anymore, called gwl in 6.1 at least
         if 'gww' in targets or 'gwl' in targets:
@@ -420,12 +409,14 @@ class EB_QuantumESPRESSO(ConfigureMake):
         if 'pp' in targets or 'pwall' in targets or 'all' in targets:
             bins.extend(["average.x", "bands.x", "dos.x", "epsilon.x", "initial_state.x",
                          "plan_avg.x", "plotband.x", "plotproj.x", "plotrho.x", "pmw.x", "pp.x",
-                         "projwfc.x", "sumpdos.x", "pw2wannier90.x", "pw_export.x", "pw2gw.x",
+                         "projwfc.x", "sumpdos.x", "pw2wannier90.x", "pw2gw.x",
                          "wannier_ham.x", "wannier_plot.x"])
-            if LooseVersion(self.version) > LooseVersion("5"):
+            if LooseVersion(self.version) > LooseVersion("5") and LooseVersion(self.version) < LooseVersion("6.4"):
                 bins.extend(["pw2bgw.x", "bgw2pw.x"])
-            else:
+            elif LooseVersion(self.version) <= LooseVersion("5"):
                 bins.extend(["pw2casino.x"])
+            if LooseVersion(self.version) < LooseVersion("6.4"):
+                bins.extend(["pw_export.x"])
 
         if 'pw' in targets or 'all' in targets:
             bins.extend(["dist.x", "ev.x", "kpoints.x", "pw.x", "pwi2xsf.x"])
@@ -448,12 +439,15 @@ class EB_QuantumESPRESSO(ConfigureMake):
         upftools = []
         if 'upf' in targets or 'all' in targets:
             upftools = ["casino2upf.x", "cpmd2upf.x", "fhi2upf.x", "fpmd2upf.x", "ncpp2upf.x",
-                        "oldcp2upf.x", "read_upf_tofile.x", "rrkj2upf.x", "uspp2upf.x", "vdb2upf.x",
-                        "virtual.x"]
+                        "oldcp2upf.x", "read_upf_tofile.x", "rrkj2upf.x", "uspp2upf.x", "vdb2upf.x"]
             if LooseVersion(self.version) > LooseVersion("5"):
                 upftools.extend(["interpolate.x", "upf2casino.x"])
             if LooseVersion(self.version) >= LooseVersion("6.3"):
                 upftools.extend(["fix_upf.x"])
+            if LooseVersion(self.version) < LooseVersion("6.4"):
+                upftools.extend(["virtual.x"])
+            else:
+                upftools.extend(["virtual_v2.x"])
 
         if 'vdw' in targets:  # only for v4.x, not in v5.0 anymore
             bins.extend(["vdw.x"])

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -60,7 +60,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
     def __init__(self, *args, **kwargs):
         """Add extra config options specific to Quantum ESPRESSO."""
         super(EB_QuantumESPRESSO, self).__init__(*args, **kwargs)
- 
+
         if LooseVersion(self.version) >= LooseVersion("6"):
             self.install_subdir = "qe-%s" % self.version
         else:
@@ -141,13 +141,10 @@ class EB_QuantumESPRESSO(ConfigureMake):
                 raise EasyBuildError("QuantumESPRESSO %s needs ELPA to be " +
                                      "version %s or newer" % (self.version, elpa_min_ver))
 
-            if LooseVersion(elpa_v) < LooseVersion("2018"):
-                elpa_include = os.path.join(elpa, 'include')
+            if self.toolchain.options.get('openmp', False):
+                elpa_include = os.path.join(elpa, 'include', 'elpa_openmp-%s' % elpa_v)
             else:
-                if self.toolchain.options.get('openmp', False):
-                    elpa_include = os.path.join(elpa, 'include', 'elpa_openmp-%s' % elpa_v)
-                else:
-                    elpa_include = os.path.join(elpa, 'include', 'elpa-%s' % elpa_v)
+                elpa_include = os.path.join(elpa, 'include', 'elpa-%s' % elpa_v)
             repls.append(('IFLAGS', '-I%s' % os.path.join(elpa_include, 'modules'), True))
             self.cfg.update('configopts', '--with-elpa-include=%s' % elpa_include)
             if self.toolchain.options.get('openmp', False):


### PR DESCRIPTION
1. Generalize binary copying code
2. Add full include paths for ELPA (2017+ we have skipped the symlinks, might as well just always use the right include path)
3. Remove sanity check for binaries dropped from > v6.4
