### PR TITLE
vtune: no license needed since 2019u3

### DIFF
--- a/easybuild/easyblocks/v/vtune.py
+++ b/easybuild/easyblocks/v/vtune.py
@@ -50,6 +50,14 @@ class EB_VTune(IntelBase):
         elif loosever >= LooseVersion('2018'):
             self.subdir = 'vtune_amplifier'
 
+    def prepare_step(self, *args, **kwargs):
+        """Since 2019u3 there is no license check."""
+        if LooseVersion(self.version) >= LooseVersion('2019_update3'):
+            kwargs['requires_runtime_license'] = False
+            super(EB_VTune, self).prepare_step(*args, **kwargs)
+        else:
+            super(EB_VTune, self).prepare_step(*args, **kwargs)
+
     def make_installdir(self):
         """Do not create installation directory, install script handles that already."""
         super(EB_VTune, self).make_installdir(dontcreate=True)

--- a/easybuild/easyblocks/v/vtune.py
+++ b/easybuild/easyblocks/v/vtune.py
@@ -51,12 +51,10 @@ class EB_VTune(IntelBase):
             self.subdir = 'vtune_amplifier'
 
     def prepare_step(self, *args, **kwargs):
-        """Since 2019u3 there is no license check."""
+        """Since 2019u3 there is no license required."""
         if LooseVersion(self.version) >= LooseVersion('2019_update3'):
             kwargs['requires_runtime_license'] = False
-            super(EB_VTune, self).prepare_step(*args, **kwargs)
-        else:
-            super(EB_VTune, self).prepare_step(*args, **kwargs)
+        super(EB_VTune, self).prepare_step(*args, **kwargs)
 
     def make_installdir(self):
         """Do not create installation directory, install script handles that already."""


### PR DESCRIPTION
as written in [release notes](https://software.intel.com/en-us/articles/intel-advisor-release-notes) no license is required since this $update.