### PR TITLE
advisor: since 2019u3 license not required

### DIFF
--- a/easybuild/easyblocks/a/advisor.py
+++ b/easybuild/easyblocks/a/advisor.py
@@ -48,12 +48,10 @@ class EB_Advisor(IntelBase):
             self.subdir = 'advisor'
 
     def prepare_step(self, *args, **kwargs):
-        """Since 2019u3 there is no license check."""
+        """Since 2019u3 there is no license required."""
         if LooseVersion(self.version) >= LooseVersion('2019_update3'):
             kwargs['requires_runtime_license'] = False
-            super(EB_Advisor, self).prepare_step(*args, **kwargs)
-        else:
-            super(EB_Advisor, self).prepare_step(*args, **kwargs)
+        super(EB_Advisor, self).prepare_step(*args, **kwargs)
 
     def make_module_req_guess(self):
         """Find reasonable paths for Advisor"""

--- a/easybuild/easyblocks/a/advisor.py
+++ b/easybuild/easyblocks/a/advisor.py
@@ -27,6 +27,7 @@ EasyBuild support for installing the Intel Advisor XE, implemented as an easyblo
 
 @author: Lumir Jasiok (IT4Innovations)
 @author: Damian Alvarez (Forschungszentrum Juelich GmbH)
+@author: Josef Dvoracek (Institute of Physics, Czech Academy of Sciences)
 """
 
 from distutils.version import LooseVersion
@@ -45,6 +46,14 @@ class EB_Advisor(IntelBase):
             self.subdir = 'advisor_xe'
         else:
             self.subdir = 'advisor'
+
+    def prepare_step(self, *args, **kwargs):
+        """Since 2019u3 there is no license check."""
+        if LooseVersion(self.version) >= LooseVersion('2019_update3'):
+            kwargs['requires_runtime_license'] = False
+            super(EB_Advisor, self).prepare_step(*args, **kwargs)
+        else:
+            super(EB_Advisor, self).prepare_step(*args, **kwargs)
 
     def make_module_req_guess(self):
         """Find reasonable paths for Advisor"""


### PR DESCRIPTION
[release notes](https://software.intel.com/en-us/articles/intel-advisor-release-notes#2019u3):

> Simplified installation and licensing (serial numbers and license files are no longer required for this product).