### PR TITLE
GROMACS - Use fp-model precise if FMA instructions are missing

### DIFF
--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -140,6 +140,8 @@ class EB_GROMACS(CMakeMake):
                 self.log.info("Setting precise=True intel toolchain option to remove -ftz build flag")
                 self.toolchain.options['precise'] = True
 
+        # This must be called after enforcing the precise option otherwise the
+        # change will be ignored.
         super(EB_GROMACS, self).prepare_step(*args, **kwargs)
 
     def configure_step(self):

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -132,7 +132,7 @@ class EB_GROMACS(CMakeMake):
         # denormal results being flushed to zero. This will cause errors for very small
         # arguments without FMA support since some intermediate results might be denormal.
         # [https://redmine.gromacs.org/issues/2335]
-        # Set -fp-model precise on non-FMA CPUs to produce correct results.        
+        # Set -fp-model precise on non-FMA CPUs to produce correct results.
         if self.toolchain.comp_family() == toolchain.INTELCOMP:
             cpu_features = get_cpu_features()
             if 'fma' not in cpu_features:


### PR DESCRIPTION
When testing `GROMACS` built with the Intel compilers on Sandy Bridge processors, errors similar to the one below will appear for `SimdMathTest.exp`, `SimdMathTest.expSingleAccuracy` and `SimdMathTest.expSingleAccuracyUnsafe`:
```
[ RUN      ] SimdMathTest.exp
/tmp/vsc40023/easybuild_build/GROMACS/2018.2/intel-2017b/gromacs-2018.2/src/gromacs/simd/tests/simd_math.cpp:457: Failure
Failing SIMD math function ulp comparison between std::exp and exp
Requested ulp tolerance: 16
Requested abs tolerance: 0
Denormals can be 0: true
Largest Ulp difference occurs for x=-87.301673889160156
Ref  values: 1.2172079232486158e-38
SIMD values: 0
Ulp diff.:   8686286
[  FAILED  ] SimdMathTest.exp (2 ms)
```
This is due to the denormal results being flushing to zero when `-ftz` is used at build time. This will cause errors for very small arguments without FMA support since some intermediate results might be denormal [1].
By forcing EB to use `-fp-model precise` when building with processors without FMA instructions, the `-ftz` flag is not added and all the tests pass.

Fixes build issues in https://github.com/easybuilders/easybuild-easyconfigs/pull/7228 and https://github.com/easybuilders/easybuild-easyconfigs/pull/7229

[1] https://redmine.gromacs.org/issues/2335