### PR TITLE
CHARMM - Add prebuildopts and runtest options

### DIFF
--- a/easybuild/easyblocks/c/charmm.py
+++ b/easybuild/easyblocks/c/charmm.py
@@ -110,7 +110,8 @@ class EB_CHARMM(EasyBlock):
         if self.toolchain.comp_family() == toolchain.INTELCOMP:
             build_options += " IFORT"
 
-        cmd = "%s ./install.com %s %s %s" % (self.cfg['prebuildopts'], self.arch, self.cfg['system_size'], build_options)
+        cmd = "%s ./install.com %s %s %s" % \
+              (self.cfg['prebuildopts'], self.arch, self.cfg['system_size'], build_options)
         (out, _) = run_cmd(cmd, log_all=True, simple=False, log_output=verbose)
         return out
 

--- a/easybuild/easyblocks/c/charmm.py
+++ b/easybuild/easyblocks/c/charmm.py
@@ -110,7 +110,7 @@ class EB_CHARMM(EasyBlock):
         if self.toolchain.comp_family() == toolchain.INTELCOMP:
             build_options += " IFORT"
 
-        cmd = ' '.join([self.cfg['prebuildopts'], './install.com', self.arch, self.cfg['system_size'], build_option
+        cmd = ' '.join([self.cfg['prebuildopts'], './install.com', self.arch, self.cfg['system_size'], build_options])
         (out, _) = run_cmd(cmd, log_all=True, simple=False, log_output=verbose)
         return out
 

--- a/easybuild/easyblocks/c/charmm.py
+++ b/easybuild/easyblocks/c/charmm.py
@@ -110,8 +110,7 @@ class EB_CHARMM(EasyBlock):
         if self.toolchain.comp_family() == toolchain.INTELCOMP:
             build_options += " IFORT"
 
-        cmd = "%s ./install.com %s %s %s" % \
-              (self.cfg['prebuildopts'], self.arch, self.cfg['system_size'], build_options)
+        cmd = ' '.join([self.cfg['prebuildopts'], './install.com', self.arch, self.cfg['system_size'], build_option
         (out, _) = run_cmd(cmd, log_all=True, simple=False, log_output=verbose)
         return out
 

--- a/easybuild/easyblocks/c/charmm.py
+++ b/easybuild/easyblocks/c/charmm.py
@@ -53,6 +53,7 @@ class EB_CHARMM(EasyBlock):
         extra_vars = {
             'build_options': ["FULL", "Specify the options to the build script", CUSTOM],
             'system_size': ["medium", "Specify the supported systemsize: %s" % ', '.join(KNOWN_SYSTEM_SIZES), CUSTOM],
+            'runtest': [True, "Run tests after each build", CUSTOM],
         }
         return EasyBlock.extra_options(extra_vars)
 
@@ -115,12 +116,14 @@ class EB_CHARMM(EasyBlock):
 
     def test_step(self):
         """Run the testsuite"""
-        if self.toolchain.options.get('usempi', None):
-            cmd = "cd test && ./test.com M %s %s" % (self.cfg['parallel'], self.arch)
-        else:
-            cmd = "cd test && ./test.com %s" % self.arch
-        (out, _) = run_cmd(cmd, log_all=True, simple=False)
-        return out
+        # Allow to skip the tests by setting runtest to False
+        if self.cfg['runtest']:
+            if self.toolchain.options.get('usempi', None):
+                cmd = "cd test && ./test.com M %s %s" % (self.cfg['parallel'], self.arch)
+            else:
+                cmd = "cd test && ./test.com %s" % self.arch
+            (out, _) = run_cmd(cmd, log_all=True, simple=False)
+            return out
 
     def sanity_check_step(self):
         """Custom sanity check for CHARMM."""

--- a/easybuild/easyblocks/c/charmm.py
+++ b/easybuild/easyblocks/c/charmm.py
@@ -110,7 +110,7 @@ class EB_CHARMM(EasyBlock):
         if self.toolchain.comp_family() == toolchain.INTELCOMP:
             build_options += " IFORT"
 
-        cmd = "./install.com %s %s %s" % (self.arch, self.cfg['system_size'], build_options)
+        cmd = "%s ./install.com %s %s %s" % (self.cfg['prebuildopts'], self.arch, self.cfg['system_size'], build_options)
         (out, _) = run_cmd(cmd, log_all=True, simple=False, log_output=verbose)
         return out
 


### PR DESCRIPTION
The current implementation of `charmm.py` does not support the use of `prebuildopts`. This is important to build `charmm/v43b2` since the `mpiifort` compiler must be forced by passing the `MPIIFORT=YES` variable.
In addition, I have also added the option to skip the tests, which helps a lot when just testing the build.