### PR TITLE
make PythonPackage aware of (pre)testopts

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -529,7 +529,8 @@ class PythonPackage(ExtensionEasyBlock):
                 run_cmd(cmd, log_all=True, simple=True, verbose=False)
 
             if self.testcmd:
-                cmd = "%s%s" % (extrapath, self.testcmd % {'python': self.python_cmd})
+                testcmd = self.testcmd % {'python': self.python_cmd}
+                cmd = ' '.join([extrapath, self.cfg['pretestopts'], testcmd, self.cfg['testopts']])
                 run_cmd(cmd, log_all=True, simple=True)
 
             if testinstalldir:


### PR DESCRIPTION
I need this to fix the currently broken `MAJIQ` easyconfig, which includes an old version of `numpy` where the tests hang unless `$KMP_INIT_AT_FORK` is set to `FALSE` (see https://software.intel.com/en-us/forums/intel-math-kernel-library/topic/760830)...