### PR TITLE
update Q&A patterns in SAS easyblock for version 9.4 + add support for custom license file path

### DIFF
--- a/easybuild/easyblocks/s/sas.py
+++ b/easybuild/easyblocks/s/sas.py
@@ -61,7 +61,7 @@ class EB_SAS(EasyBlock):
             "SAS Home:": self.installdir,
             "Install SAS Software (default: Yes):": '',
             "Configure SAS Software (default: Yes):": '',
-            "SAS Installation Data File:": '',
+            "SAS Installation Data File:": self.license_file,
             "Press Enter to continue:": '',
             "Configure as a Unicode server (default: No):": 'N',
             "SAS/ACCESS Interface to MySQL (default: Yes):": 'N',
@@ -72,7 +72,6 @@ class EB_SAS(EasyBlock):
             "Port Number:": '',
             "Configure SAS Studio Basic (default: Yes):": 'N',
             "Press Enter to finish:": '',
-            "SAS Installation Data File:": self.license_file,
             "Global Standards Library:": os.path.join(self.installdir, 'cstGlobalLibrary'),
             "Sample Library:": os.path.join(self.installdir, 'cstSampleLibrary'),
         }

--- a/easybuild/easyblocks/s/sas.py
+++ b/easybuild/easyblocks/s/sas.py
@@ -34,6 +34,19 @@ from easybuild.tools.run import run_cmd_qa
 class EB_SAS(EasyBlock):
     """Support for building/installing SAS."""
 
+    def __init__(self, *args, **kwargs):
+        """Custom constructor for SAS easyblock, initialize custom class variables."""
+
+        super(EB_SAS, self).__init__(*args, **kwargs)
+
+        # Use default SAS Installation Data File path
+        self.license_file = ''
+
+        # Set custom SAS Installation Data File path if defined and existing
+        if self.cfg['license_file'] is not None and os.path.isfile(self.cfg['license_file']):
+            self.license_file = self.cfg['license_file']
+            self.log.info("Custom SAS Installation Data File found: %s" % self.license_file)
+
     def configure_step(self):
         """No custom configurationprocedure for SAS."""
         pass
@@ -59,6 +72,9 @@ class EB_SAS(EasyBlock):
             "Port Number:": '',
             "Configure SAS Studio Basic (default: Yes):": 'N',
             "Press Enter to finish:": '',
+            "SAS Installation Data File:": self.license_file,
+            "Global Standards Library:": os.path.join(self.installdir, 'cstGlobalLibrary'),
+            "Sample Library:": os.path.join(self.installdir, 'cstSampleLibrary'),
         }
         std_qa = {
             "Incomplete Deployment\s*(.*[^:])+Selection:": '2',  # 2: Ignore previous deployment and start again
@@ -71,6 +87,7 @@ class EB_SAS(EasyBlock):
             "Select Language Support\s*(.*[^:]\n)+Selections:": '',
             "Select Regional Settings\s*(.*[^:]\n)+Selection:": '',
             "Select Support Option\s*(.*[^:]\n)+Selection:": '2',  # 2: Do Not Send
+            "Select SAS Foundation Products(.*[^:]\s*\n)+Selection:": '',
         }
         no_qa = [
             "\.\.\.$",

--- a/easybuild/easyblocks/s/sas.py
+++ b/easybuild/easyblocks/s/sas.py
@@ -45,7 +45,7 @@ class EB_SAS(EasyBlock):
         # Set custom SAS Installation Data File path if defined and existing
         if self.cfg['license_file'] is not None and os.path.isfile(self.cfg['license_file']):
             self.license_file = self.cfg['license_file']
-            self.log.info("Custom SAS Installation Data File found: %s" % self.license_file)
+            self.log.info("Custom SAS Installation Data File found: %s", self.license_file)
 
     def configure_step(self):
         """No custom configurationprocedure for SAS."""

--- a/easybuild/easyblocks/s/sas.py
+++ b/easybuild/easyblocks/s/sas.py
@@ -43,7 +43,7 @@ class EB_SAS(EasyBlock):
         self.license_file = ''
 
         # Set custom SAS Installation Data File path if defined and existing
-        if self.cfg['license_file'] is not None and os.path.isfile(self.cfg['license_file']):
+        if self.cfg['license_file'] and os.path.isfile(self.cfg['license_file']):
             self.license_file = self.cfg['license_file']
             self.log.info("Custom SAS Installation Data File found: %s", self.license_file)
 


### PR DESCRIPTION
On our installation of the latest release of `SAS/9.4` a few additional questions were asked that were not explicitly contemplated by the easyblock. This PR adds definitions for such questions.

In addition, it now supports the ability to specify a custom path for the SAS Installation Data File. If it is left undefined, SAS will pick the default path within the extracted sources directory.