### PR TITLE
binutils: Only embed `zlib` if listed as a build dependency

### DIFF
--- a/easybuild/easyblocks/b/binutils.py
+++ b/easybuild/easyblocks/b/binutils.py
@@ -83,24 +83,24 @@ class EB_binutils(ConfigureMake):
         if zlibroot:
             self.cfg.update('configopts', '--with-system-zlib')
 
-        # statically link to zlib only if it is a build dependency
-        # see https://github.com/easybuilders/easybuild-easyblocks/issues/1350
-        build_deps = self.cfg.dependencies(build_only=True)
-        if any(dep['name'] == 'zlib' for dep in build_deps):
-            libz_path = os.path.join(zlibroot, get_software_libdir('zlib'), 'libz.a')
+            # statically link to zlib only if it is a build dependency
+            # see https://github.com/easybuilders/easybuild-easyblocks/issues/1350
+            build_deps = self.cfg.dependencies(build_only=True)
+            if any(dep['name'] == 'zlib' for dep in build_deps):
+                libz_path = os.path.join(zlibroot, get_software_libdir('zlib'), 'libz.a')
 
-            # for recent binutils versions, we need to override ZLIB in Makefile.in of components
-            if LooseVersion(self.version) >= LooseVersion('2.26'):
-                regex_subs = [
-                    (r"^(ZLIB\s*=\s*).*$", r"\1%s" % libz_path),
-                    (r"^(ZLIBINC\s*=\s*).*$", r"\1-I%s" % os.path.join(zlibroot, 'include')),
-                ]
-                for makefile in glob.glob(os.path.join(self.cfg['start_dir'], '*', 'Makefile.in')):
-                    apply_regex_substitutions(makefile, regex_subs)
+                # for recent binutils versions, we need to override ZLIB in Makefile.in of components
+                if LooseVersion(self.version) >= LooseVersion('2.26'):
+                    regex_subs = [
+                        (r"^(ZLIB\s*=\s*).*$", r"\1%s" % libz_path),
+                        (r"^(ZLIBINC\s*=\s*).*$", r"\1-I%s" % os.path.join(zlibroot, 'include')),
+                    ]
+                    for makefile in glob.glob(os.path.join(self.cfg['start_dir'], '*', 'Makefile.in')):
+                        apply_regex_substitutions(makefile, regex_subs)
 
-            # for older versions, injecting the path to the static libz library into $LIBS works
-            else:
-                libs += ' ' + libz_path
+                # for older versions, injecting the path to the static libz library into $LIBS works
+                else:
+                    libs += ' ' + libz_path
 
         self.cfg.update('preconfigopts', "env LIBS='%s'" % libs)
         self.cfg.update('prebuildopts', "env LIBS='%s'" % libs)
@@ -180,7 +180,7 @@ class EB_binutils(ConfigureMake):
                 os.path.join('include', 'libiberty.h'),
             ])
 
-        # if zlib is listed as a build dependency, it should get linked in statically
+        # if zlib is listed as a build dependency, it should have been linked in statically
         build_deps = self.cfg.dependencies(build_only=True)
         if any(dep['name'] == 'zlib' for dep in build_deps):
             for binary in binaries:

--- a/easybuild/easyblocks/b/binutils.py
+++ b/easybuild/easyblocks/b/binutils.py
@@ -78,10 +78,15 @@ class EB_binutils(ConfigureMake):
 
             libs += ' '.join('-Wl,-rpath=%s' % libdir for libdir in libdirs)
 
-        # statically link to zlib if it is a (build) dependency
+        # configure using `--with-system-zlib` if zlib is a (build) dependency
         zlibroot = get_software_root('zlib')
         if zlibroot:
             self.cfg.update('configopts', '--with-system-zlib')
+
+        # statically link to zlib only if it is a build dependency
+        # see https://github.com/easybuilders/easybuild-easyblocks/issues/1350
+        build_deps = self.cfg.dependencies(build_only=True)
+        if any(dep['name'] == 'zlib' for dep in build_deps):
             libz_path = os.path.join(zlibroot, get_software_libdir('zlib'), 'libz.a')
 
             # for recent binutils versions, we need to override ZLIB in Makefile.in of components
@@ -175,8 +180,9 @@ class EB_binutils(ConfigureMake):
                 os.path.join('include', 'libiberty.h'),
             ])
 
-        # if zlib is listed as a dependency, it should get linked in statically
-        if get_software_root('zlib'):
+        # if zlib is listed as a build dependency, it should get linked in statically
+        build_deps = self.cfg.dependencies(build_only=True)
+        if any(dep['name'] == 'zlib' for dep in build_deps):
             for binary in binaries:
                 bin_path = os.path.join(self.installdir, 'bin', binary)
                 out, _ = run_cmd("file %s" % bin_path, simple=False)


### PR DESCRIPTION
Addresses https://github.com/easybuilders/easybuild-easyblocks/issues/1350 in conjunction with https://github.com/easybuilders/easybuild-easyconfigs/pull/8340

This does *not* address the issue that `libz.a` is included in `libbfd.a` when specified as a build dependency. At the moment, I don't believe that this is fixable at all without rewriting parts of the Makefile(s).