### PR TITLE
fix version check on using '-log' option to 'Allwmake' in OpenFOAM easyblock

### DIFF
--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -308,7 +308,7 @@ class EB_OpenFOAM(EasyBlock):
             run_cmd_qa(cmd_tmpl % 'Allwmake.firstInstall', qa, no_qa=noqa, log_all=True, simple=True)
         else:
             cmd = 'Allwmake'
-            if LooseVersion(self.version) >= LooseVersion('1606'):
+            if LooseVersion(self.version.strip('v+')) > LooseVersion('1606'):
                 # use Allwmake -log option if possible since this can be useful during builds, but also afterwards
                 cmd += ' -log'
             run_cmd(cmd_tmpl % cmd, log_all=True, simple=True, log_output=True)


### PR DESCRIPTION
`Allwmake -log` is not supported in OpenFOAM v1606+, so the version check was wrong (should be `>` rather than `>=`).

In addition, we need to strip off `v` and `+` because of the funky OpenFOAM versioning scheme...

Without this, `Allwmake -log` is always used with versions like `v<digits>`:

```
>>> LooseVersion('v1606') > LooseVersion('1606')
True
```