### PR TITLE
fix GROMACS easyblock for list-type configopts

### DIFF
--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -490,7 +490,8 @@ class EB_GROMACS(CMakeMake):
             dirs.append(os.path.join(self.lib_subdir, 'pkgconfig'))
 
         custom_paths = {
-            'files': [os.path.join('bin', b) for b in bin_files] + [os.path.join(self.lib_subdir, l) for l in lib_files],
+            'files': [os.path.join('bin', b) for b in bin_files] + 
+                     [os.path.join(self.lib_subdir, l) for l in lib_files],
             'dirs': dirs,
         }
         super(EB_GROMACS, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -468,18 +468,29 @@ class EB_GROMACS(CMakeMake):
             libnames.extend([libname + mpisuff for libname in libnames])
 
         suff = ''
-        # add the _d suffix to the suffix, in case of the double precission
-        if re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg['configopts'], re.I):
-            suff = '_d'
 
-        libs = ['lib%s%s.%s' % (libname, suff, self.libext) for libname in libnames]
+        # make sure that configopts is a list:
+        configopts = self.cfg['configopts']
+        if type(configopts) is str:
+            configopts = [configopts]
+
+        libs = []
+        binaries = []
+
+        for cfgopts in configopts:
+            # add the _d suffix to the suffix, in case of the double precission
+            if re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', cfgopts, re.I):
+                suff = '_d'
+
+            libs += ['lib%s%s.%s' % (libname, suff, self.libext) for libname in libnames]
+            binaries += [b + suff for b in bins]
 
         # pkgconfig dir not available for earlier versions, exact version to use here is unclear
         if LooseVersion(self.version) >= LooseVersion('4.6'):
             dirs.append(os.path.join(self.lib_subdir, 'pkgconfig'))
 
         custom_paths = {
-            'files': [os.path.join('bin', b + suff) for b in bins] + [os.path.join(self.lib_subdir, l) for l in libs],
+            'files': [os.path.join('bin', b) for b in binaries] + [os.path.join(self.lib_subdir, l) for l in libs],
             'dirs': dirs,
         }
         super(EB_GROMACS, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -470,27 +470,27 @@ class EB_GROMACS(CMakeMake):
         suff = ''
 
         # make sure that configopts is a list:
-        configopts = self.cfg['configopts']
-        if type(configopts) is str:
-            configopts = [configopts]
+        configopts_list = self.cfg['configopts']
+        if isinstance(configopts_list, str):
+            configopts_list = [configopts_list]
 
-        libs = []
-        binaries = []
+        lib_files = []
+        bin_files = []
 
-        for cfgopts in configopts:
+        for configopts in configopts_list:
             # add the _d suffix to the suffix, in case of the double precission
-            if re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', cfgopts, re.I):
+            if re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', configopts, re.I):
                 suff = '_d'
 
-            libs += ['lib%s%s.%s' % (libname, suff, self.libext) for libname in libnames]
-            binaries += [b + suff for b in bins]
+            lib_files.extend(['lib%s%s.%s' % (libname, suff, self.libext) for libname in libnames])
+            bin_files.extend([b + suff for b in bins])
 
         # pkgconfig dir not available for earlier versions, exact version to use here is unclear
         if LooseVersion(self.version) >= LooseVersion('4.6'):
             dirs.append(os.path.join(self.lib_subdir, 'pkgconfig'))
 
         custom_paths = {
-            'files': [os.path.join('bin', b) for b in binaries] + [os.path.join(self.lib_subdir, l) for l in libs],
+            'files': [os.path.join('bin', b) for b in bin_files] + [os.path.join(self.lib_subdir, l) for l in lib_files],
             'dirs': dirs,
         }
         super(EB_GROMACS, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -490,8 +490,8 @@ class EB_GROMACS(CMakeMake):
             dirs.append(os.path.join(self.lib_subdir, 'pkgconfig'))
 
         custom_paths = {
-            'files': [os.path.join('bin', b) for b in bin_files] + 
-                     [os.path.join(self.lib_subdir, l) for l in lib_files],
+            'files': [os.path.join('bin', b) for b in bin_files] +
+                [os.path.join(self.lib_subdir, l) for l in lib_files],
             'dirs': dirs,
         }
         super(EB_GROMACS, self).sanity_check_step(custom_paths=custom_paths)


### PR DESCRIPTION
GROMACS easyblock currently fails in `sanity_check_step` when used
with a list-type `configopts` config like:

```
configopts = [
    "-DGMX_THREAD_MPI=OFF -DGMX_DOUBLE=OFF",
    "-DGMX_THREAD_MPI=OFF -DGMX_DOUBLE=ON",
]
```

This patch fixes this issue by correctly iterating over multiple
configopts strings to determine which binary and lib names to
check for.