### PR TITLE
Fix configure step for GROMACS version < 4.6

### DIFF
--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -191,6 +191,7 @@ class EB_GROMACS(CMakeMake):
                 self.cfg.update('configopts', "--without-gsl")
 
             # actually run configure via ancestor (not direct parent)
+            self.cfg['configure_cmd'] = "./configure"
             ConfigureMake.configure_step(self)
 
             # Now patch GROMACS for PLUMED between configure and build


### PR DESCRIPTION
When installing an older version of GROMACS that still makes use of Autotools, one gets
```
running command "./bootstrap &&  cmake --prefix=/opt/easybuild/osuse/software/GROMACS/4.5.7-foss-2019a    --enable-static  --with-external-blas --with-external-lapack  --without-x  --enable-threads  --without-gsl"
```
This fixes it by setting it back to 
```
running command "./bootstrap &&  ./configure --prefix=/opt/easybuild/osuse/software/GROMACS/4.5.7-foss-2019a    --enable-static  --with-external-blas --with-external-lapack  --without-x  --enable-threads  --without-gsl"
```