### PR TITLE
Changing numpy test command to fix the f2py errors

### DIFF
--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -66,7 +66,7 @@ class EB_numpy(FortranPythonPackage):
         self.sitecfg = None
         self.sitecfgfn = 'site.cfg'
         self.testinstall = True
-        self.testcmd = "cd .. && LDFLAGS='-shared -Wall' FFLAGS='-fPIC' %(python)s -c 'import numpy; numpy.test(verbose=2)'"
+        self.testcmd = "cd .. && LDFLAGS='-shared -Wall' %(python)s -c 'import numpy; numpy.test(verbose=2)'"
 
     def configure_step(self):
         """Configure numpy build by composing site.cfg contents."""

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -66,7 +66,7 @@ class EB_numpy(FortranPythonPackage):
         self.sitecfg = None
         self.sitecfgfn = 'site.cfg'
         self.testinstall = True
-        self.testcmd = "cd .. && %(python)s -c 'import numpy; numpy.test(verbose=2)'"
+        self.testcmd = "cd .. && LDFLAGS='-shared -Wall' FFLAGS='-fPIC' %(python)s -c 'import numpy; numpy.test(verbose=2)'"
 
     def configure_step(self):
         """Configure numpy build by composing site.cfg contents."""


### PR DESCRIPTION
Ref https://github.com/easybuilders/easybuild-easyblocks/issues/605

This fixes the four fortran compile errors when we run the numpy test suite