### PR TITLE
don't assume cmake arguments when configure_cmd is set in CMakeMake easyblock

### DIFF
--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -134,12 +134,18 @@ class CMakeMake(ConfigureMake):
 
         options_string = ' '.join(options)
 
-        command = ' '.join([
-            self.cfg['preconfigopts'],
-            self.cfg.get('configure_cmd') or DEFAULT_CONFIGURE_CMD,
-            options_string,
-            self.cfg['configopts'],
-            srcdir])
+        if self.cfg.get('configure_cmd'):
+            command = ' '.join([
+                    self.cfg['preconfigopts'],
+                    self.cfg.get('configure_cmd'),
+                    self.cfg['configopts']])
+        else:
+            command = ' '.join([
+                    self.cfg['preconfigopts'],
+                    DEFAULT_CONFIGURE_CMD,
+                    options_string,
+                    self.cfg['configopts'],
+                    srcdir])
         (out, _) = run_cmd(command, log_all=True, simple=False)
 
         return out

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -134,18 +134,19 @@ class CMakeMake(ConfigureMake):
 
         options_string = ' '.join(options)
 
-        if self.cfg.get('configure_cmd') != DEFAULT_CONFIGURE_CMD:
-            command = ' '.join([
-                    self.cfg['preconfigopts'],
-                    self.cfg.get('configure_cmd'),
-                    self.cfg['configopts']])
-        else:
+        if self.cfg.get('configure_cmd') == DEFAULT_CONFIGURE_CMD:
             command = ' '.join([
                     self.cfg['preconfigopts'],
                     DEFAULT_CONFIGURE_CMD,
                     options_string,
                     self.cfg['configopts'],
                     srcdir])
+        else:
+            command = ' '.join([
+                    self.cfg['preconfigopts'],
+                    self.cfg.get('configure_cmd'),
+                    self.cfg['configopts']])
+
         (out, _) = run_cmd(command, log_all=True, simple=False)
 
         return out

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -134,7 +134,7 @@ class CMakeMake(ConfigureMake):
 
         options_string = ' '.join(options)
 
-        if self.cfg.get('configure_cmd'):
+        if self.cfg.get('configure_cmd') != DEFAULT_CONFIGURE_CMD:
             command = ' '.join([
                     self.cfg['preconfigopts'],
                     self.cfg.get('configure_cmd'),


### PR DESCRIPTION
even if `configure_cmd` is simply a script running `cmake`, it may not accept the flags in `options_string` and the `src_dir` as arguments, and as it is they cannot be removed - the proposed solution gives back control to the easyconfig, imho