### PR TITLE
make hpcg log pattern more generic, it changed in 3.1

### DIFF
--- a/easybuild/easyblocks/h/hpcg.py
+++ b/easybuild/easyblocks/h/hpcg.py
@@ -80,7 +80,7 @@ class EB_HPCG(ConfigureMake):
             # find log file, check for success
             success_regex = re.compile(r"Scaled Residual \[[0-9.e-]+\]")
             try:
-                hpcg_logs = glob.glob('hpcg_log*txt')
+                hpcg_logs = glob.glob('hpcg*txt')
                 if len(hpcg_logs) == 1:
                     txt = open(hpcg_logs[0], 'r').read()
                     self.log.debug("Contents of HPCG log file %s: %s" % (hpcg_logs[0], txt))


### PR DESCRIPTION
in 3.1 there is no "_log" before the timestamp, not sure if it is worth adding a test for version number