### PR TITLE
also add --without-go configure option for SWIG as we ''disable everything by default"

### DIFF
--- a/easybuild/easyblocks/s/swig.py
+++ b/easybuild/easyblocks/s/swig.py
@@ -39,7 +39,7 @@ class EB_SWIG(ConfigureMake):
         """Set some extra environment variables before configuring."""
 
         # disable everything by default
-        for x in ["r", "clisp", "allegrocl", "lua", "csharp", "chicken", "pike ",
+        for x in ["r", "clisp", "allegrocl", "lua", "csharp", "chicken", "go", "pike ",
                   "ocaml","php", "ruby", "mzscheme", "guile", "gcj", "java",
                   "octave", "perl5", "python3", "tcl"]:
             self.cfg.update('configopts', "--without-%s" % x)


### PR DESCRIPTION
..as we here

> disable everything by default

we should disable go too.

tested on SWIG `SWIG-3.0.12-foss-2018b-Python-2.7.15.eb` and `SWIG-4.0.0-foss-2019a-Python-2.7.15`.