### PR TITLE
only require vsc-base for EasyBuild 2.x and 3.x in EasyBuildMeta easyblock

### DIFF
--- a/easybuild/easyblocks/e/easybuildmeta.py
+++ b/easybuild/easyblocks/e/easybuildmeta.py
@@ -51,7 +51,7 @@ class EB_EasyBuildMeta(PythonPackage):
         self.real_initial_environ = None
 
         self.easybuild_pkgs = ['easybuild-framework', 'easybuild-easyblocks', 'easybuild-easyconfigs']
-        if LooseVersion(self.version) >= LooseVersion('2.0'):
+        if LooseVersion(self.version) >= LooseVersion('2.0') and LooseVersion(self.version) <= LooseVersion('3.999'):
             # deliberately include vsc-install & vsc-base twice;
             # first time to ensure the specified vsc-install/vsc-base package is available when framework gets installed
             self.easybuild_pkgs.insert(0, 'vsc-base')
@@ -124,7 +124,12 @@ class EB_EasyBuildMeta(PythonPackage):
         easy_install_pth = os.path.join(self.installdir, self.pylibdir, 'easy-install.pth')
         if os.path.exists(easy_install_pth):
             easy_install_pth_txt = read_file(easy_install_pth)
-            for pkg in [p for p in self.easybuild_pkgs if p not in ['setuptools', 'vsc-install']]:
+
+            ignore_pkgs = ['setuptools', 'vsc-install']
+            if LooseVersion(self.version) > LooseVersion('3.999'):
+                ignore_pkgs.append('vsc-base')
+
+            for pkg in [p for p in self.easybuild_pkgs if p not in ignore_pkgs]:
                 if pkg == 'vsc-base':
                     # don't include strict version check for vsc-base
                     pkg_regex = re.compile(r"^\./%s" % pkg.replace('-', '_'), re.M)
@@ -143,7 +148,7 @@ class EB_EasyBuildMeta(PythonPackage):
             'easybuild-easyblocks': [('easybuild/easyblocks', True)],
             'easybuild-easyconfigs': [('easybuild/easyconfigs', False)],
         }
-        if LooseVersion(self.version) >= LooseVersion('2.0'):
+        if LooseVersion(self.version) >= LooseVersion('2.0') and LooseVersion(self.version) < LooseVersion('3.999'):
             subdirs_by_pkg.update({
                 'vsc-base': [('vsc/utils', True)],
             })


### PR DESCRIPTION
This is required to be able to install the upcoming EasyBuild 4.0, since `vsc-base` was ingested into `easybuild-framework` (cfr. https://github.com/easybuilders/easybuild-framework/pull/2708)