### PR TITLE
SNPhylo - Fix scripts installation path

### DIFF
--- a/easybuild/easyblocks/s/snphylo.py
+++ b/easybuild/easyblocks/s/snphylo.py
@@ -44,6 +44,12 @@ from easybuild.tools.run import run_cmd
 class EB_SNPhylo(EasyBlock):
     """Support for building and installing SNPhylo."""
 
+    def __init__(self, *args, **kwargs):
+        """Set custom class variables."""
+        super(EB_SNPhylo, self).__init__(*args, **kwargs)
+
+        self.scripts_path = os.path.join('bin', 'scripts')
+
     def configure_step(self):
         """No configure step for SNPhylo."""
         pass
@@ -78,26 +84,22 @@ class EB_SNPhylo(EasyBlock):
         bindir = os.path.join(self.installdir, 'bin')
         binfiles = ['snphylo.sh', 'snphylo.cfg', 'snphylo.template']
 
-        # Starting from v20160204:
-        #   * the source archive has a different directory tree
-        #   * snphylo.sh looks for scripts in $EBROOTSNPHYLO/bin/scripts
+        # Starting from v20160204 the source archive has a different directory tree
         if LooseVersion(self.version) >= LooseVersion('20160204'):
             predir = 'SNPhylo'
-            scripts_path = os.path.join(self.installdir, 'bin', 'scripts')
         else:
             predir = ''
-            scripts_path = os.path.join(self.installdir, 'scripts')
 
         mkdir(bindir, parents=True)
         for binfile in binfiles:
             copy_file(os.path.join(self.builddir, predir, binfile), bindir)
 
-        copy_dir(os.path.join(self.builddir, predir, 'scripts'), scripts_path)
+        copy_dir(os.path.join(self.builddir, predir, 'scripts'), os.path.join(self.installdir, self.scripts_path))
 
     def sanity_check_step(self):
         """Custom sanity check for SNPhylo."""
         custom_paths = {
             'files': ['bin/snphylo.sh', 'bin/snphylo.cfg', 'bin/snphylo.template'],
-            'dirs': ['scripts'],
+            'dirs': [self.scripts_path],
         }
         super(EB_SNPhylo, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/s/snphylo.py
+++ b/easybuild/easyblocks/s/snphylo.py
@@ -78,15 +78,21 @@ class EB_SNPhylo(EasyBlock):
         bindir = os.path.join(self.installdir, 'bin')
         binfiles = ['snphylo.sh', 'snphylo.cfg', 'snphylo.template']
 
-        predir = ''
+        # Starting from v20160204:
+        #   * the source archive has a different directory tree
+        #   * snphylo.sh looks for scripts in $EBROOTSNPHYLO/bin/scripts
         if LooseVersion(self.version) >= LooseVersion('20160204'):
             predir = 'SNPhylo'
+            scripts_path = os.path.join(self.installdir, 'bin', 'scripts')
+        else:
+            predir = ''
+            scripts_path = os.path.join(self.installdir, 'scripts')
 
         mkdir(bindir, parents=True)
         for binfile in binfiles:
             copy_file(os.path.join(self.builddir, predir, binfile), bindir)
 
-        copy_dir(os.path.join(self.builddir, predir, 'scripts'), os.path.join(self.installdir, 'scripts'))
+        copy_dir(os.path.join(self.builddir, predir, 'scripts'), scripts_path)
 
     def sanity_check_step(self):
         """Custom sanity check for SNPhylo."""


### PR DESCRIPTION
The current easyblock installs the scripts provided by `SNPhylo/20160204` in `$EBROOTSNPHYLO/scripts` while the `snphylo.sh` main executable in `SNPhylo/20160204` looks for them in `$EBROOTSNPHYLO/bin/scripts` and fails with the following error:
```
Start to remove low quality data.
/opt/easybuild/software/MPI/GCC/6.4.0-2.28/OpenMPI/2.1.1/Python/3.6.3/bin/python: can't open file '/opt/easybuild/software/MPI/GCC/6.4.0-2.28/OpenMPI/2.1.1/SNPhylo/20160204-Python-3.6.3-R-3.4.3/bin/scripts/remove_no_genotype_data.py': [Errno 2] No such file or directory
```