### PR TITLE
QuantumEspresso: Parsing of additional compilation parameters

### DIFF
--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -54,6 +54,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
             'hybrid': [False, "Enable hybrid build (with OpenMP)", CUSTOM],
             'with_scalapack': [True, "Enable ScaLAPACK support", CUSTOM],
             'with_ace': [False, "Enable Adaptively Compressed Exchange support", CUSTOM],
+            'ntypx': [10, "Max number of different types of atom", CUSTOM],
         }
         return ConfigureMake.extra_options(extra_vars)
 
@@ -232,6 +233,11 @@ class EB_QuantumESPRESSO(ConfigureMake):
             make_ext = '.inc'
         else:
             make_ext = '.sys'
+
+        if self.cfg['ntypx']:
+          regex_subs = [(r"^ntypx\s*=\s*\d+", r"ntypx = %s" % ntypx)]
+           apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_subs)
+           print('REGEX: {}'.format(regex_subs))
 
         # patch make.sys file
         fn = os.path.join(self.cfg['start_dir'], 'make' + make_ext)

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -238,21 +238,19 @@ class EB_QuantumESPRESSO(ConfigureMake):
         else:
             make_ext = '.sys'
 
+        # patch Modules/parameter.f90 file to set compilation parameters
+        regex_para = []
         if self.cfg['ntypx']:
-            regex_subs = [(r"ntypx\s*=\s*\d+", r"ntypx = %s" % self.cfg['ntypx'])]
-            apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_subs)
+            regex_para.append((r"ntypx\s*=\s*\S+", r"ntypx = %s" % self.cfg['ntypx']))
         if self.cfg['nsx']:
-            regex_subs = [(r"nsx\s*=\s*\w+", r"nsx = %s" % self.cfg['nsx'])]
-            apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_subs)
+            regex_para.append((r"nsx\s*=\s*\S+", r"nsx = %s" % self.cfg['nsx']))
         if self.cfg['npk']:
-            regex_subs = [(r"npk\s*=\s*\d+", r"npk = %s" % self.cfg['npk'])]
-            apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_subs)
+            regex_para.append((r"npk\s*=\s*\S+", r"npk = %s" % self.cfg['npk']))
         if self.cfg['lmaxx']:
-            regex_subs = [(r"lmaxx\s*=\s*\d+", r"lmaxx = %s" % self.cfg['lmaxx'])]
-            apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_subs)
+            regex_para.append((r"lmaxx\s*=\s*\S+", r"lmaxx = %s" % self.cfg['lmaxx']))
         if self.cfg['lqmax']:
-            regex_subs = [(r"lqmax\s*=\s*\S+", r"lqmax = %s" % self.cfg['lqmax'])]
-            apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_subs)
+            regex_para.append((r"lqmax\s*=\s*\S+", r"lqmax = %s" % self.cfg['lqmax']))
+        apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_para)
 
         # patch make.sys file
         fn = os.path.join(self.cfg['start_dir'], 'make' + make_ext)

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -239,20 +239,20 @@ class EB_QuantumESPRESSO(ConfigureMake):
             make_ext = '.sys'
 
         if self.cfg['ntypx']:
-          regex_subs = [(r"ntypx\s*=\s*\d+", r"ntypx = %s" % self.cfg['ntypx'])]
-          apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_subs)
+            regex_subs = [(r"ntypx\s*=\s*\d+", r"ntypx = %s" % self.cfg['ntypx'])]
+            apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_subs)
         if self.cfg['nsx']:
-          regex_subs = [(r"nsx\s*=\s*\w+", r"nsx = %s" % self.cfg['nsx'])]
-          apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_subs)
+            regex_subs = [(r"nsx\s*=\s*\w+", r"nsx = %s" % self.cfg['nsx'])]
+            apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_subs)
         if self.cfg['npk']:
-          regex_subs = [(r"npk\s*=\s*\d+", r"npk = %s" % self.cfg['npk'])]
-          apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_subs)
+            regex_subs = [(r"npk\s*=\s*\d+", r"npk = %s" % self.cfg['npk'])]
+            apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_subs)
         if self.cfg['lmaxx']:
-          regex_subs = [(r"lmaxx\s*=\s*\d+", r"lmaxx = %s" % self.cfg['lmaxx'])]
-          apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_subs)
+            regex_subs = [(r"lmaxx\s*=\s*\d+", r"lmaxx = %s" % self.cfg['lmaxx'])]
+            apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_subs)
         if self.cfg['lqmax']:
-          regex_subs = [(r"lqmax\s*=\s*\S+", r"lqmax = %s" % self.cfg['lqmax'])]
-          apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_subs)
+            regex_subs = [(r"lqmax\s*=\s*\S+", r"lqmax = %s" % self.cfg['lqmax'])]
+            apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_subs)
 
         # patch make.sys file
         fn = os.path.join(self.cfg['start_dir'], 'make' + make_ext)

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -240,16 +240,9 @@ class EB_QuantumESPRESSO(ConfigureMake):
 
         # patch Modules/parameter.f90 file to set compilation parameters
         regex_para = []
-        if self.cfg['ntypx']:
-            regex_para.append((r"ntypx\s*=\s*\S+", r"ntypx = %s" % self.cfg['ntypx']))
-        if self.cfg['nsx']:
-            regex_para.append((r"nsx\s*=\s*\S+", r"nsx = %s" % self.cfg['nsx']))
-        if self.cfg['npk']:
-            regex_para.append((r"npk\s*=\s*\S+", r"npk = %s" % self.cfg['npk']))
-        if self.cfg['lmaxx']:
-            regex_para.append((r"lmaxx\s*=\s*\S+", r"lmaxx = %s" % self.cfg['lmaxx']))
-        if self.cfg['lqmax']:
-            regex_para.append((r"lqmax\s*=\s*\S+", r"lqmax = %s" % self.cfg['lqmax']))
+        for key in ['lmaxx', 'lqmax', 'npk', 'nsx', 'ntypx']:
+            if self.cfg[key]:
+                regex_para.append((key + r'\s*=[^,&!]+', '{0} = {1}'.format(key, self.cfg[key])))
         apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_para)
 
         # patch make.sys file

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -52,13 +52,13 @@ class EB_QuantumESPRESSO(ConfigureMake):
         """Custom easyconfig parameters for Quantum ESPRESSO."""
         extra_vars = {
             'hybrid': [False, "Enable hybrid build (with OpenMP)", CUSTOM],
-            'with_scalapack': [True, "Enable ScaLAPACK support", CUSTOM],
-            'with_ace': [False, "Enable Adaptively Compressed Exchange support", CUSTOM],
-            'ntypx': [False, "Max number of different types of atom", CUSTOM],
-            'nsx': [False, "max number of atomic species (CP)", CUSTOM],
-            'npk': [False, "max number of k-points", CUSTOM],
             'lmaxx': [False, "max non local angular momentum (l=0 to lmaxx)", CUSTOM],
             'lqmax': [False, "max number of angular momenta of Q", CUSTOM],
+            'npk': [False, "max number of k-points", CUSTOM],
+            'nsx': [False, "max number of atomic species (CP)", CUSTOM],
+            'ntypx': [False, "Max number of different types of atom", CUSTOM],
+            'with_ace': [False, "Enable Adaptively Compressed Exchange support", CUSTOM],
+            'with_scalapack': [True, "Enable ScaLAPACK support", CUSTOM],
         }
         return ConfigureMake.extra_options(extra_vars)
 

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -54,7 +54,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
             'hybrid': [False, "Enable hybrid build (with OpenMP)", CUSTOM],
             'with_scalapack': [True, "Enable ScaLAPACK support", CUSTOM],
             'with_ace': [False, "Enable Adaptively Compressed Exchange support", CUSTOM],
-            'ntypx': [10, "Max number of different types of atom", CUSTOM],
+            'ntypx': [False, "Max number of different types of atom", CUSTOM],
         }
         return ConfigureMake.extra_options(extra_vars)
 
@@ -235,9 +235,8 @@ class EB_QuantumESPRESSO(ConfigureMake):
             make_ext = '.sys'
 
         if self.cfg['ntypx']:
-          regex_subs = [(r"^ntypx\s*=\s*\d+", r"ntypx = %s" % ntypx)]
-           apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_subs)
-           print('REGEX: {}'.format(regex_subs))
+          regex_subs = [(r"ntypx\s*=\s*\d+", r"ntypx = %s" % self.cfg['ntypx'])]
+          apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_subs)
 
         # patch make.sys file
         fn = os.path.join(self.cfg['start_dir'], 'make' + make_ext)

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -55,6 +55,10 @@ class EB_QuantumESPRESSO(ConfigureMake):
             'with_scalapack': [True, "Enable ScaLAPACK support", CUSTOM],
             'with_ace': [False, "Enable Adaptively Compressed Exchange support", CUSTOM],
             'ntypx': [False, "Max number of different types of atom", CUSTOM],
+            'nsx': [False, "max number of atomic species (CP)", CUSTOM],
+            'npk': [False, "max number of k-points", CUSTOM],
+            'lmaxx': [False, "max non local angular momentum (l=0 to lmaxx)", CUSTOM],
+            'lqmax': [False, "max number of angular momenta of Q", CUSTOM],
         }
         return ConfigureMake.extra_options(extra_vars)
 
@@ -236,6 +240,18 @@ class EB_QuantumESPRESSO(ConfigureMake):
 
         if self.cfg['ntypx']:
           regex_subs = [(r"ntypx\s*=\s*\d+", r"ntypx = %s" % self.cfg['ntypx'])]
+          apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_subs)
+        if self.cfg['nsx']:
+          regex_subs = [(r"nsx\s*=\s*\w+", r"nsx = %s" % self.cfg['nsx'])]
+          apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_subs)
+        if self.cfg['npk']:
+          regex_subs = [(r"npk\s*=\s*\d+", r"npk = %s" % self.cfg['npk'])]
+          apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_subs)
+        if self.cfg['lmaxx']:
+          regex_subs = [(r"lmaxx\s*=\s*\d+", r"lmaxx = %s" % self.cfg['lmaxx'])]
+          apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_subs)
+        if self.cfg['lqmax']:
+          regex_subs = [(r"lqmax\s*=\s*\S+", r"lqmax = %s" % self.cfg['lqmax'])]
           apply_regex_substitutions(os.path.join('Modules', 'parameters.f90'), regex_subs)
 
         # patch make.sys file


### PR DESCRIPTION
Adds the ability to specify compilation parameters in the easyconfig file which so far had to be changed laboriously in the source files.
These compilation parameters are specified in the QuantumEspresso [user manual in section 2.5](https://www.quantum-espresso.org/Doc/user_guide/node12.html)

To test it you have to specify one or multiple of the parameters in the easyconfig. Is there a way to write a test case?

PS: This is my first trail in modifying a easyblock but I think it might be useful for other users.