### PR TITLE
be more patient when running interactive Allwmake.firstInstall command for recent OpenFOAM-Extend versions

### DIFF
--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -305,7 +305,7 @@ class EB_OpenFOAM(EasyBlock):
                 r"\s*\^\s*",  # warning indicator
                 "Cleaning .*",
             ]
-            run_cmd_qa(cmd_tmpl % 'Allwmake.firstInstall', qa, no_qa=noqa, log_all=True, simple=True)
+            run_cmd_qa(cmd_tmpl % 'Allwmake.firstInstall', qa, no_qa=noqa, log_all=True, simple=True, maxhits=500)
         else:
             cmd = 'Allwmake'
             if LooseVersion(self.version.strip('v+')) > LooseVersion('1606'):


### PR DESCRIPTION
On slow filesystems, the installation of `OpenFOAM-Extend` could get interrupted because `run_cmd_qa` thinks it's running into an unknown question, whether it's actually just taking a while before new output is produced...

(fix for problem reported on EasyBuild Slack)