### PR TITLE
update OpenBLAS easyblock to be aware of POWER9 support in OpenBLAS 0.3.6

### DIFF
--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -31,7 +31,7 @@ from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import adjust_permissions, patch_perl_script_autoflush, read_file, which, write_file
 from easybuild.tools.run import run_cmd, run_cmd_qa
-from easybuild.tools.systemtools import POWER, X86_64, get_cpu_architecture, get_shared_lib_ext
+from easybuild.tools.systemtools import get_shared_lib_ext
 
 # Wrapper script definition
 WRAPPER_TEMPLATE = """#!/bin/sh
@@ -57,27 +57,6 @@ class EB_CUDA(Binary):
             'host_compilers': [None, "Host compilers for which a wrapper will be generated", CUSTOM]
         }
         return Binary.extra_options(extra_vars)
-
-    def fetch_sources(self, sources=None, checksums=None):
-        """
-        We need to modify the source filename based on the architecture
-        """
-        if sources is None:
-            sources = self.cfg['sources']
-
-        myarch = get_cpu_architecture()
-        if myarch == X86_64:
-            cudaarch = ''
-        elif myarch == POWER:
-            cudaarch = '_ppc64le'
-        else:
-            raise EasyBuildError("Architecture %s is not supported for CUDA on EasyBuild", myarch)
-
-        modified_sources = []
-        for source in sources:
-            modified_sources.append(source % {'cudaarch': cudaarch})
-
-        return Binary.fetch_sources(self, modified_sources, checksums)
 
     def extract_step(self):
         """Extract installer to have more control, e.g. options, patching Perl scripts, etc."""

--- a/easybuild/easyblocks/o/openblas.py
+++ b/easybuild/easyblocks/o/openblas.py
@@ -4,8 +4,10 @@ EasyBuild support for building and installing OpenBLAS, implemented as an easybl
 @author: Andrew Edmondson (University of Birmingham)
 """
 import os
+from distutils.version import LooseVersion
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.systemtools import POWER, get_cpu_architecture, get_shared_lib_ext
+from easybuild.tools.build_log import print_warning
 
 
 class EB_OpenBLAS(ConfigureMake):
@@ -21,8 +23,9 @@ class EB_OpenBLAS(ConfigureMake):
             'USE_OPENMP': '1',
             'USE_THREAD': '1',
         }
-        if get_cpu_architecture() == POWER:
+        if LooseVersion(self.version) < LooseVersion('0.3.6') and get_cpu_architecture() == POWER:
             # There doesn't seem to be a POWER9 option yet, but POWER8 should work.
+            print_warning("OpenBLAS 0.3.5 and lower have known issues on POWER systems")
             default_opts['TARGET'] = 'POWER8'
 
         for key in sorted(default_opts.keys()):


### PR DESCRIPTION
OpenBLAS 0.3.6 has explicit support for POWER9 so we don't need to tell it to use POWER8 any more.

Also, 0.3.5 has quite a few bugs on POWER9, so including a warning message.