### PR TITLE
removed checks for Boussinesq and sonic solvers for OpenFOAM 7, since those have been deprecated

### DIFF
--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -361,6 +361,11 @@ class EB_OpenFOAM(EasyBlock):
                [os.path.join(toolsdir, "surface%s" % x) for x in ["Add", "Find", "Smooth"]] + \
                [os.path.join(toolsdir, x) for x in ['blockMesh', 'checkMesh', 'deformedGeom', 'engineSwirl',
                                                     'modifyMesh', 'refineMesh']]
+
+        # remove Boussinesq and sonic since for OpenFOAM >= 7, since those solvers are deprecated
+        if LooseVersion(self.version) >= LooseVersion('7'):
+            bins = [x for x in bins if "Boussinesq" not in x and "sonic" not in x]
+
         # check for the Pstream and scotchDecomp libraries, there must be a dummy one and an mpi one
         if 'extend' in self.name.lower():
             libs = [os.path.join(libsdir, "libscotchDecomp.%s" % shlib_ext),

--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -356,15 +356,18 @@ class EB_OpenFOAM(EasyBlock):
         # some randomly selected binaries
         # if one of these is missing, it's very likely something went wrong
         bins = [os.path.join(self.openfoamdir, "bin", x) for x in ["paraFoam"]] + \
-               [os.path.join(toolsdir, "buoyant%sSimpleFoam" % x) for x in ["", "Boussinesq"]] + \
-               [os.path.join(toolsdir, "%sFoam" % x) for x in ["boundary", "engine", "sonic"]] + \
+               [os.path.join(toolsdir, "buoyantSimpleFoam")] + \
+               [os.path.join(toolsdir, "%sFoam" % x) for x in ["boundary", "engine"]] + \
                [os.path.join(toolsdir, "surface%s" % x) for x in ["Add", "Find", "Smooth"]] + \
                [os.path.join(toolsdir, x) for x in ['blockMesh', 'checkMesh', 'deformedGeom', 'engineSwirl',
                                                     'modifyMesh', 'refineMesh']]
 
-        # remove Boussinesq and sonic since for OpenFOAM >= 7, since those solvers are deprecated
-        if LooseVersion(self.version) >= LooseVersion('7'):
-            bins = [x for x in bins if "Boussinesq" not in x and "sonic" not in x]
+        # only include Boussinesq and sonic since for OpenFOAM < 7, since those solvers have been deprecated
+        if LooseVersion(self.version) < LooseVersion('7'):
+            bins.extend([
+                os.path.join(toolsdir, "buoyantBoussinesqSimpleFoam"),
+                os.path.join(toolsdir, "sonicFoam")
+            ])
 
         # check for the Pstream and scotchDecomp libraries, there must be a dummy one and an mpi one
         if 'extend' in self.name.lower():


### PR DESCRIPTION
In the OpenFOAM 7 release notes : 

Solvers: The Boussinesq equation of state can now be applied to any buoyancy solver, deprecating the specialized buoyantBoussinesq[SP]impleFoam solvers [ commit 9bf346 ].

Solvers:  The sonicFoam, sonicDyMFoam and sonicLiquidFoam are deprecated since their functionality has been merged into the rhoPimpleFoam solver, running the transonic option [ commit 3341f9 ].  Added LTS capability to pimpleFoam, providing the option to accelerate solutions to steady-state [ commit e1e3e2 ]

