### PR TITLE
[parmetis] Make compatible with custom configopts

### DIFF
--- a/easybuild/easyblocks/p/parmetis.py
+++ b/easybuild/easyblocks/p/parmetis.py
@@ -41,7 +41,6 @@ from easybuild.tools.filetools import mkdir, symlink, remove_file
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
 
-SHARED = 'SHARED'
 
 class EB_ParMETIS(EasyBlock):
     """Support for building and installing ParMETIS."""
@@ -187,7 +186,7 @@ class EB_ParMETIS(EasyBlock):
         config_list = self.cfg['configopts'] if isinstance(self.cfg['configopts'], list) else [self.cfg['configopts']]
         for configopt in config_list:
             for opt in configopt.split():
-                if SHARED in opt and any(trueval in opt for trueval in config_true):
+                if 'SHARED' in opt and any(trueval in opt for trueval in config_true):
                     config_shared = True
 
         if config_shared:

--- a/easybuild/easyblocks/p/parmetis.py
+++ b/easybuild/easyblocks/p/parmetis.py
@@ -193,7 +193,7 @@ class EB_ParMETIS(EasyBlock):
 
         custom_paths = {
                         'files': ['include/%smetis.h' % x for x in ["", "par"]] +
-                                 parmetis_libs,
+                                  parmetis_libs,
                         'dirs': ['Lib']
                        }
 

--- a/easybuild/easyblocks/p/parmetis.py
+++ b/easybuild/easyblocks/p/parmetis.py
@@ -30,6 +30,7 @@ EasyBuild support for ParMETIS, implemented as an easyblock
 @author: Kenneth Hoste (Ghent University)
 @author: Pieter De Baets (Ghent University)
 @author: Jens Timmerman (Ghent University)
+@author: Alex Domingo (Vrije Universiteit Brussel)
 """
 import os
 import shutil

--- a/easybuild/easyblocks/p/parmetis.py
+++ b/easybuild/easyblocks/p/parmetis.py
@@ -192,13 +192,13 @@ class EB_ParMETIS(EasyBlock):
 
         if config_shared:
             shlib_ext = get_shared_lib_ext()
-            parmetis_libs = ['lib/libparmetis.%s' % shlib_ext] + ['lib/libmetis.a']
+            parmetis_libs = ['lib/libparmetis.%s' % shlib_ext, 'lib/libmetis.a']
         else:
             parmetis_libs = ['lib/lib%smetis.a' % x for x in ["", "par"]]
 
         custom_paths = {
-                        'files': ['include/%smetis.h' % x for x in ["", "par"]] + parmetis_libs,
-                        'dirs': ['Lib']
-                       }
+            'files': ['include/%smetis.h' % x for x in ["", "par"]] + parmetis_libs,
+            'dirs': ['Lib']
+        }
 
         super(EB_ParMETIS, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/p/parmetis.py
+++ b/easybuild/easyblocks/p/parmetis.py
@@ -168,13 +168,11 @@ class EB_ParMETIS(EasyBlock):
         # and header files in the Lib directory (capital L). The following symlink are hence created.
         try:
             caplibdir = os.path.join(self.installdir, 'Lib')
-            if os.path.lexists(caplibdir):
-                remove_file(caplibdir)
+            remove_file(caplibdir)
             symlink(libdir, caplibdir)
             for header_file in ['metis.h', 'parmetis.h']:
                 header_path = os.path.join(libdir, header_file)
-                if os.path.lexists(header_path):
-                    remove_file(header_path)
+                remove_file(header_path)
                 symlink(os.path.join(includedir, header_file), header_path)
         except OSError as err:
             raise EasyBuildError("Something went wrong during symlink creation: %s", err)

--- a/easybuild/easyblocks/p/parmetis.py
+++ b/easybuild/easyblocks/p/parmetis.py
@@ -192,8 +192,7 @@ class EB_ParMETIS(EasyBlock):
             parmetis_libs = ['lib/lib%smetis.a' % x for x in ["", "par"]]
 
         custom_paths = {
-                        'files': ['include/%smetis.h' % x for x in ["", "par"]] +
-                                  parmetis_libs,
+                        'files': ['include/%smetis.h' % x for x in ["", "par"]] + parmetis_libs,
                         'dirs': ['Lib']
                        }
 

--- a/easybuild/easyblocks/p/parmetis.py
+++ b/easybuild/easyblocks/p/parmetis.py
@@ -41,6 +41,7 @@ from easybuild.tools.filetools import mkdir, symlink, remove_file
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
 
+SHARED = 'SHARED'
 
 class EB_ParMETIS(EasyBlock):
     """Support for building and installing ParMETIS."""
@@ -181,9 +182,15 @@ class EB_ParMETIS(EasyBlock):
         """Custom sanity check for ParMETIS."""
 
         # Paths to libraries defined depending on SHARED configuration option
-        config_shared = ['-DSHARED=%s' % val for val in ['1', 'ON', 'YES', 'TRUE', 'Y']]  # True values in CMake
-        config_optlist = [opt.upper() for configopt in self.cfg['configopts'] for opt in configopt.split()]
-        if set(config_shared) & set(config_optlist):
+        config_shared = False
+        config_true = ['1', 'ON', 'YES', 'TRUE', 'Y']  # True values in CMake
+        config_list = self.cfg['configopts'] if isinstance(self.cfg['configopts'], list) else [self.cfg['configopts']]
+        for configopt in config_list:
+            for opt in configopt.split():
+                if SHARED in opt and any(trueval in opt for trueval in config_true):
+                    config_shared = True
+
+        if config_shared:
             shlib_ext = get_shared_lib_ext()
             parmetis_libs = ['lib/libparmetis.%s' % shlib_ext] + ['lib/libmetis.a']
         else:

--- a/easybuild/easyblocks/p/parmetis.py
+++ b/easybuild/easyblocks/p/parmetis.py
@@ -167,8 +167,12 @@ class EB_ParMETIS(EasyBlock):
         # and header files in the Lib directory (capital L). The following symlink are hence created.
         try:
             llibdir = os.path.join(self.installdir, 'Lib')
+            if os.path.lexists(llibdir):
+                os.remove(llibdir)
             os.symlink(libdir, llibdir)
             for f in ['metis.h', 'parmetis.h']:
+                if os.path.lexists(os.path.join(libdir, f)):
+                    os.remove(os.path.join(libdir, f))
                 os.symlink(os.path.join(includedir, f), os.path.join(libdir, f))
         except OSError as err:
             raise EasyBuildError("Something went wrong during symlink creation: %s", err)

--- a/easybuild/easyblocks/p/parmetis.py
+++ b/easybuild/easyblocks/p/parmetis.py
@@ -186,13 +186,13 @@ class EB_ParMETIS(EasyBlock):
             custom_paths = {
                         'files': ['include/%smetis.h' % x for x in ["", "par"]] +
                                  ['lib/libparmetis.%s' % shlib_ext],
-                        'dirs':['Lib']
+                        'dirs': ['Lib']
                        }
         else:
             custom_paths = {
                         'files': ['include/%smetis.h' % x for x in ["", "par"]] +
                                  ['lib/lib%smetis.a' % x for x in ["", "par"]],
-                        'dirs':['Lib']
+                        'dirs': ['Lib']
                        }
 
         super(EB_ParMETIS, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/p/parmetis.py
+++ b/easybuild/easyblocks/p/parmetis.py
@@ -184,7 +184,8 @@ class EB_ParMETIS(EasyBlock):
 
         # Paths to libraries defined depending on SHARED configuration option
         config_shared = ['-DSHARED=%s' % val for val in ['1', 'ON', 'YES', 'TRUE', 'Y']]  # True values in CMake
-        if set(config_shared) & set([opt for configopt in self.cfg['configopts'] for opt in configopt.split()]):
+        config_optlist = [opt.upper() for configopt in self.cfg['configopts'] for opt in configopt.split()]
+        if set(config_shared) & set(config_optlist):
             shlib_ext = get_shared_lib_ext()
             parmetis_libs = ['lib/libparmetis.%s' % shlib_ext] + ['lib/libmetis.a']
         else:

--- a/easybuild/easyblocks/p/parmetis.py
+++ b/easybuild/easyblocks/p/parmetis.py
@@ -37,7 +37,7 @@ from distutils.version import LooseVersion
 
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import mkdir
+from easybuild.tools.filetools import mkdir, symlink, remove_file
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
 
@@ -181,17 +181,17 @@ class EB_ParMETIS(EasyBlock):
     def sanity_check_step(self):
         """Custom sanity check for ParMETIS."""
 
-        if '-DSHARED=1' in self.cfg['configopts']:
+        # Paths to libraries depend on SHARED configuration option
+        config_trues = ['1', 'ON', 'YES', 'TRUE', 'Y']  # strings that evaluate as True in CMake
+        if set(['-DSHARED=%s' % opt for opt in config_trues]) & set(self.cfg['configopts']):
             shlib_ext = get_shared_lib_ext()
-            custom_paths = {
-                        'files': ['include/%smetis.h' % x for x in ["", "par"]] +
-                                 ['lib/libparmetis.%s' % shlib_ext],
-                        'dirs': ['Lib']
-                       }
+            parmetis_libs = ['lib/libparmetis.%s' % shlib_ext] + ['lib/libmetis.a']
         else:
-            custom_paths = {
+            parmetis_libs = ['lib/lib%smetis.a' % x for x in ["", "par"]]
+
+        custom_paths = {
                         'files': ['include/%smetis.h' % x for x in ["", "par"]] +
-                                 ['lib/lib%smetis.a' % x for x in ["", "par"]],
+                                 parmetis_libs,
                         'dirs': ['Lib']
                        }
 

--- a/easybuild/easyblocks/p/parmetis.py
+++ b/easybuild/easyblocks/p/parmetis.py
@@ -182,9 +182,9 @@ class EB_ParMETIS(EasyBlock):
     def sanity_check_step(self):
         """Custom sanity check for ParMETIS."""
 
-        # Paths to libraries depend on SHARED configuration option
-        config_trues = ['1', 'ON', 'YES', 'TRUE', 'Y']  # strings that evaluate as True in CMake
-        if set(['-DSHARED=%s' % opt for opt in config_trues]) & set(self.cfg['configopts']):
+        # Paths to libraries defined depending on SHARED configuration option
+        config_shared = ['-DSHARED=%s' % val for val in ['1', 'ON', 'YES', 'TRUE', 'Y']]  # True values in CMake
+        if set(config_shared) & set([opt for configopt in self.cfg['configopts'] for opt in configopt.split()]):
             shlib_ext = get_shared_lib_ext()
             parmetis_libs = ['lib/libparmetis.%s' % shlib_ext] + ['lib/libmetis.a']
         else:

--- a/easybuild/easyblocks/p/parmetis.py
+++ b/easybuild/easyblocks/p/parmetis.py
@@ -39,6 +39,7 @@ from easybuild.framework.easyblock import EasyBlock
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import mkdir
 from easybuild.tools.run import run_cmd
+from easybuild.tools.systemtools import get_shared_lib_ext
 
 
 class EB_ParMETIS(EasyBlock):
@@ -48,8 +49,8 @@ class EB_ParMETIS(EasyBlock):
         """Configure ParMETIS build.
         For versions of ParMETIS < 4 , METIS is a seperate build
         New versions of ParMETIS include METIS
-        
-        Run 'cmake' in the build dir to get rid of a 'user friendly' 
+
+        Run 'cmake' in the build dir to get rid of a 'user friendly'
         help message that is displayed without this step.
         """
         if LooseVersion(self.version) >= LooseVersion("4"):
@@ -180,7 +181,15 @@ class EB_ParMETIS(EasyBlock):
     def sanity_check_step(self):
         """Custom sanity check for ParMETIS."""
 
-        custom_paths = {
+        if '-DSHARED=1' in self.cfg['configopts']:
+            shlib_ext = get_shared_lib_ext()
+            custom_paths = {
+                        'files': ['include/%smetis.h' % x for x in ["", "par"]] +
+                                 ['lib/libparmetis.%s' % shlib_ext],
+                        'dirs':['Lib']
+                       }
+        else:
+            custom_paths = {
                         'files': ['include/%smetis.h' % x for x in ["", "par"]] +
                                  ['lib/lib%smetis.a' % x for x in ["", "par"]],
                         'dirs':['Lib']

--- a/easybuild/easyblocks/p/parmetis.py
+++ b/easybuild/easyblocks/p/parmetis.py
@@ -167,14 +167,15 @@ class EB_ParMETIS(EasyBlock):
         # other applications depending on ParMETIS (SuiteSparse for one) look for both ParMETIS libraries
         # and header files in the Lib directory (capital L). The following symlink are hence created.
         try:
-            llibdir = os.path.join(self.installdir, 'Lib')
-            if os.path.lexists(llibdir):
-                os.remove(llibdir)
-            os.symlink(libdir, llibdir)
-            for f in ['metis.h', 'parmetis.h']:
-                if os.path.lexists(os.path.join(libdir, f)):
-                    os.remove(os.path.join(libdir, f))
-                os.symlink(os.path.join(includedir, f), os.path.join(libdir, f))
+            caplibdir = os.path.join(self.installdir, 'Lib')
+            if os.path.lexists(caplibdir):
+                remove_file(caplibdir)
+            symlink(libdir, caplibdir)
+            for header_file in ['metis.h', 'parmetis.h']:
+                header_path = os.path.join(libdir, header_file)
+                if os.path.lexists(header_path):
+                    remove_file(header_path)
+                symlink(os.path.join(includedir, header_file), header_path)
         except OSError as err:
             raise EasyBuildError("Something went wrong during symlink creation: %s", err)
 


### PR DESCRIPTION
Currently the easyblock for ParMETIS fails the sanity check with `configopts = '-DSHARED=1'`, which builds its shared libraries but disables the static ones. This patch adds a conditional check on configopts to the sanity check function.

This patch also enforces that symlinks are removed before creation to avoid `file already exists` errors  with builds with multiple iterations.