### PR TITLE
correctly define comp.src in Bundle easyblock, to fix compatibility with easyblocks that leverage self.src

### DIFF
--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -205,8 +205,33 @@ class Bundle(EasyBlock):
 
             # need to run fetch_patches to ensure per-component patches are applied
             comp.fetch_patches()
-            # location of first unpacked source is used to determine where to apply patch(es)
-            comp.src = [{'finalpath': comp.cfg['start_dir']}]
+
+            comp.src = []
+
+            # find match entries in self.src for this component
+            for source in comp.cfg['sources']:
+                if isinstance(source, basestring):
+                    comp_src_fn = source
+                elif isinstance(source, dict):
+                    if 'filename' in source:
+                        comp_src_fn = source['filename']
+                    else:
+                        raise EasyBuildError("Encountered source file specified as dict without 'filename': %s", source)
+                else:
+                    raise EasyBuildError("Specification of unknown type for source file: %s", source)
+
+                found = False
+                for src in self.src:
+                    if src['name'] == comp_src_fn:
+                        self.log.info("Found spec for source %s for component %s: %s", comp_src_fn, comp.name, src)
+                        comp.src.append(src)
+                        found = True
+                        break
+                if not found:
+                    raise EasyBuildError("Failed to find spec for source %s for component %s", comp_src_fn, comp.name)
+
+                # location of first unpacked source is used to determine where to apply patch(es)
+                comp.src[-1]['finalpath'] = comp.cfg['start_dir']
 
             # run relevant steps
             for step_name in ['patch', 'configure', 'build', 'install']:


### PR DESCRIPTION
fix for bug reported by @klust on the EasyBuild Slack channel, when trying to use the `CmpCp` easyblock to install a `Bundle` component:

```
== 2019-08-13 13:11:06,237 build_log.py:163 ERROR EasyBuild crashed with an error (at ?:124 in __init__): Traceback (most recent call last):
  File "/apps/antwerpen/x86_64/centos7/EasyBuild/3.9.3/lib/python2.7/site-packages/easybuild_framework-3.9.3-py2.7.egg/easybuild/main.py", line 112, in build_and_install_software
    (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env)
  File "/apps/antwerpen/x86_64/centos7/EasyBuild/3.9.3/lib/python2.7/site-packages/easybuild_framework-3.9.3-py2.7.egg/easybuild/framework/easyblock.py", line 3046, in build_and_install_one
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/apps/antwerpen/x86_64/centos7/EasyBuild/3.9.3/lib/python2.7/site-packages/easybuild_framework-3.9.3-py2.7.egg/easybuild/framework/easyblock.py", line 2956, in run_all_steps
    self.run_step(step_name, step_methods)
  File "/apps/antwerpen/x86_64/centos7/EasyBuild/3.9.3/lib/python2.7/site-packages/easybuild_framework-3.9.3-py2.7.egg/easybuild/framework/easyblock.py", line 2826, in run_step
    step_method(self)()
  File "/apps/antwerpen/x86_64/centos7/EasyBuild/3.9.3/lib/python2.7/site-packages/easybuild_easyblocks-3.9.3-py2.7.egg/easybuild/easyblocks/generic/bundle.py", line 216, in install_step
    comp.run_step(step_name, [lambda x: getattr(x, '%s_step' % step_name)])
  File "/apps/antwerpen/x86_64/centos7/EasyBuild/3.9.3/lib/python2.7/site-packages/easybuild_framework-3.9.3-py2.7.egg/easybuild/framework/easyblock.py", line 2826, in run_step
    step_method(self)()
  File "/apps/antwerpen/x86_64/centos7/EasyBuild/3.9.3/lib/python2.7/site-packages/easybuild_easyblocks-3.9.3-py2.7.egg/easybuild/easyblocks/generic/cmdcp.py", line 64, in build_step
    src = src['path']
KeyError: 'path'
```