### PR TITLE
fix Bundle.check_checksums to checksums for extensions are also checked

### DIFF
--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -162,7 +162,7 @@ class Bundle(EasyBlock):
 
         :return: list of strings describing checksum issues (missing checksums, wrong checksum type, etc.)
         """
-        checksum_issues = []
+        checksum_issues = super(Bundle, self).check_checksums()
 
         for comp in self.comp_cfgs:
             checksum_issues.extend(self.check_checksums_for(comp, sub="of component %s" % comp['name']))


### PR DESCRIPTION
Because of this bug, the Travis tests in https://github.com/easybuilders/easybuild-easyconfigs/pull/8536 passed while they shouldn't have, because of the missing checksum for the `pyrsistent` extension...