### PR TITLE
enhance sanity check for Blender to make sure that Cycles render engine is available

### DIFF
--- a/easybuild/easyblocks/b/blender.py
+++ b/easybuild/easyblocks/b/blender.py
@@ -112,4 +112,8 @@ class EB_Blender(CMakeMake):
             'files': ['bin/blender'],
             'dirs': [],
         }
-        super(EB_Blender, self).sanity_check_step(custom_paths=custom_paths)
+
+        # make sure Cycles render engine is available
+        custom_commands = ["blender -b -E help | grep CYCLES"]
+
+        super(EB_Blender, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)


### PR DESCRIPTION
I managed to accidentally build `Blender` without the Cycles render engine recently, so it's worth adding a check for this...