### PR TITLE
vmd.py: Make the plugins build use the correct tcl library version.

### DIFF
--- a/easybuild/easyblocks/v/vmd.py
+++ b/easybuild/easyblocks/v/vmd.py
@@ -118,6 +118,7 @@ class EB_VMD(ConfigureMake):
             'LINUXAMD64',
             "TCLINC='-I%s'" % tclinc,
             "TCLLIB='-L%s'" % tcllib,
+            "TCLLDFLAGS='-ltcl%s'" % tclshortver,
             "NETCDFINC='-I%s'" % netcdfinc,
             "NETCDFLIB='-L%s'" % netcdflib,
             self.cfg['buildopts'],


### PR DESCRIPTION
This is only useful together with a patch to plugins/Make-arch
that makes use of TCLLDFLAGS.