### PR TITLE
don't use sys.maxint in easyblocks (not compatible with Python 3)

### DIFF
--- a/easybuild/easyblocks/c/cp2k.py
+++ b/easybuild/easyblocks/c/cp2k.py
@@ -699,7 +699,7 @@ class EB_CP2K(EasyBlock):
                 self.log.info("No reference output found for regression test, just continuing without it...")
 
             # prefer using 4 cores, since some tests require/prefer square (n^2) numbers or powers of 2 (2^n)
-            test_core_cnt = min(self.cfg.get('parallel', sys.maxint), 4)
+            test_core_cnt = min(self.cfg['parallel'], 4)
             if get_avail_core_count() < test_core_cnt:
                 raise EasyBuildError("Cannot run MPI tests as not enough cores (< %s) are available", test_core_cnt)
             else:

--- a/test/easyblocks/init_easyblocks.py
+++ b/test/easyblocks/init_easyblocks.py
@@ -126,6 +126,8 @@ def template_init_test(self, easyblock, name='foo', version='1.3.2'):
         re.compile(r"[^\w]basestring([^\w]|$)"),
         # check for use of '.iteritems()', which is Python 2.x only (should use .items instead)
         re.compile(r"\.iteritems\(\)"),
+        # sys.maxint is no longer there in Python 3
+        re.compile(r"sys\.maxint"),
     ]
     for regexp in regexps:
         self.assertFalse(regexp.search(txt), "No match for '%s' in %s" % (regexp.pattern, easyblock))


### PR DESCRIPTION
fixes #1785

It's safe to assume that `self.cfg['parallel']` is already properly defined, no need to use `sys.maxint` as a fallback at all in CP2K easyblock...