### PR TITLE
fix compatibility of SuiteSparse easyblock with Python 3

### DIFF
--- a/easybuild/easyblocks/s/suitesparse.py
+++ b/easybuild/easyblocks/s/suitesparse.py
@@ -110,7 +110,7 @@ class EB_SuiteSparse(ConfigureMake):
 
         try:
             for line in fileinput.input(fp, inplace=1, backup='.orig'):
-                for (var, val) in cfgvars.items():
+                for (var, val) in list(cfgvars.items()):
                     orig_line = line
                     # for variables in cfgvars, substiture lines assignment
                     # in the file, whatever they are, by assignments to the


### PR DESCRIPTION
We need to force using a copy of `cfgvars.items()` when iterating over it, because of the `cfgvars.pop` being used in the `for` loop...

This is only a problem with Python 3, where `.items()` returns an iterator, while in Python 2 it's already a cope of keys & values in the dictionary (so changing the dictionary while iterating over it is not a problem there).

(fixes #1784)