### PR TITLE
Add custom easyblock to install iccifort as self-contained software.

### DIFF
--- a/easybuild/easyblocks/i/iccifort.py
+++ b/easybuild/easyblocks/i/iccifort.py
@@ -1,0 +1,46 @@
+##
+# Copyright 2019-2019 Bart Oldeman, McGill University, Compute Canada
+#
+# This file is triple-licensed under GPLv2 (see below), MIT, and
+# BSD three-clause licenses.
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for installing the Intel compiler suite, implemented as an easyblock
+
+@author: Bart Oldeman (McGill University, Compute Canada)
+"""
+
+from easybuild.easyblocks.icc import EB_icc
+from easybuild.easyblocks.ifort import EB_ifort
+
+
+class EB_iccifort(EB_ifort, EB_icc):
+    """
+    Class that can be used to install iccifort
+    """
+
+    def sanity_check_step(self):
+        """Custom sanity check paths for iccifort."""
+        EB_icc.sanity_check_step(self)
+        EB_ifort.sanity_check_step(self)

--- a/easybuild/easyblocks/i/iccifort.py
+++ b/easybuild/easyblocks/i/iccifort.py
@@ -31,11 +31,12 @@ EasyBuild support for installing the Intel compiler suite, implemented as an eas
 @author: Bart Oldeman (McGill University, Compute Canada)
 """
 
+from easybuild.easyblocks.generic.intelbase import IntelBase
 from easybuild.easyblocks.icc import EB_icc
 from easybuild.easyblocks.ifort import EB_ifort
 
 
-class EB_iccifort(EB_ifort, EB_icc):
+class EB_iccifort(EB_ifort, EB_icc, IntelBase):
     """
     Class that can be used to install iccifort
     """

--- a/easybuild/easyblocks/i/iccifort.py
+++ b/easybuild/easyblocks/i/iccifort.py
@@ -31,12 +31,11 @@ EasyBuild support for installing the Intel compiler suite, implemented as an eas
 @author: Bart Oldeman (McGill University, Compute Canada)
 """
 
-from easybuild.easyblocks.generic.intelbase import IntelBase
 from easybuild.easyblocks.icc import EB_icc
 from easybuild.easyblocks.ifort import EB_ifort
 
 
-class EB_iccifort(EB_ifort, EB_icc, IntelBase):
+class EB_iccifort(EB_ifort, EB_icc):
     """
     Class that can be used to install iccifort
     """
@@ -45,3 +44,14 @@ class EB_iccifort(EB_ifort, EB_icc, IntelBase):
         """Custom sanity check paths for iccifort."""
         EB_icc.sanity_check_step(self)
         EB_ifort.sanity_check_step(self)
+
+    def make_module_extra(self):
+        txt = super(EB_iccifort, self).make_module_extra()
+
+        # also define $EBROOT* and $EBVERSION* for icc/ifort
+        txt += self.module_generator.set_environment('EBROOTICC', self.installdir)
+        txt += self.module_generator.set_environment('EBROOTIFORT', self.installdir)
+        txt += self.module_generator.set_environment('EBVERSIONICC', self.version)
+        txt += self.module_generator.set_environment('EBVERSIONIFORT', self.version)
+
+        return txt

--- a/test/easyblocks/module.py
+++ b/test/easyblocks/module.py
@@ -218,7 +218,10 @@ def template_module_only_test(self, easyblock, name='foo', version='1.3.2', extr
         app_class = get_easyblock_class(ebname)
 
         # easyblocks deriving from IntelBase require a license file to be found for --module-only
-        if app_class == IntelBase or IntelBase in app_class.__bases__:
+        bases = list(app_class.__bases__)
+        for base in copy.copy(bases):
+            bases.extend(base.__bases__)
+        if app_class == IntelBase or IntelBase in bases:
             os.environ['INTEL_LICENSE_FILE'] = os.path.join(tmpdir, 'intel.lic')
             write_file(os.environ['INTEL_LICENSE_FILE'], '# dummy license')
 


### PR DESCRIPTION
It inherits everything from ifort, except for the sanity check for
which it calls both icc's and then ifort's sanity check.