### PR TITLE
don't load modules for dependencies in CrayToolchain.prepare_step

### DIFF
--- a/easybuild/easyblocks/generic/craytoolchain.py
+++ b/easybuild/easyblocks/generic/craytoolchain.py
@@ -41,6 +41,13 @@ class CrayToolchain(Bundle):
     """
     Compiler toolchain: generate module file only, nothing to build/install
     """
+    def prepare_step(self, *args, **kwargs):
+        """Prepare build environment (skip loaded of dependencies)."""
+
+        kwargs['load_tc_deps_modules'] = False
+
+        super(CrayToolchain, self).prepare_step(*args, **kwargs)
+
     def make_module_dep(self):
         """
         Generate load/swap statements for dependencies in the module file


### PR DESCRIPTION
requires https://github.com/easybuilders/easybuild-framework/pull/3008

This should have been there all along, rather than relying on using `dummy` as a version for the `dummy` toolchain (which is deprecated in EasyBuild v4.0).

See also https://github.com/eth-cscs/production/pull/1174#pullrequestreview-255440220

cc @victorusu, @gppezzi, @lucamar