### PR TITLE
fix compatibility of XCrySDen easyblock with Python 3 (+ some cleanup)

### DIFF
--- a/easybuild/easyblocks/x/xcrysden.py
+++ b/easybuild/easyblocks/x/xcrysden.py
@@ -101,7 +101,7 @@ class EB_XCrySDen(ConfigureMake):
         for line in fileinput.input(makesys_file, inplace=1, backup='.orig'):
             # set config parameters
             for (key, value) in list(settings.items()):
-                regexp = re.compile('^%s(\s+=).*' % key)
+                regexp = re.compile(r'^%s(\s+=).*' % key)
                 if regexp.search(line):
                     line = regexp.sub('%s\\1 %s' % (key, value), line)
                     # remove replaced key/value pairs

--- a/easybuild/easyblocks/x/xcrysden.py
+++ b/easybuild/easyblocks/x/xcrysden.py
@@ -35,6 +35,7 @@ import sys
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.filetools import read_file, write_file
 from easybuild.tools.modules import get_software_root, get_software_version
 
 
@@ -99,21 +100,19 @@ class EB_XCrySDen(ConfigureMake):
 
         for line in fileinput.input(makesys_file, inplace=1, backup='.orig'):
             # set config parameters
-            for (k, v) in settings.items():
-                regexp = re.compile('^%s(\s+=).*'% k)
+            for (key, value) in list(settings.items()):
+                regexp = re.compile('^%s(\s+=).*' % key)
                 if regexp.search(line):
-                    line = regexp.sub('%s\\1 %s' % (k, v), line)
+                    line = regexp.sub('%s\\1 %s' % (key, value), line)
                     # remove replaced key/value pairs
-                    settings.pop(k)
+                    settings.pop(key)
             sys.stdout.write(line)
 
-        f = open(makesys_file, "a")
         # append remaining key/value pairs
-        for (k, v) in settings.items():
-            f.write("%s = %s\n" % (k, v))
-        f.close()
+        makesys_file_txt = '\n'.join("%s = %s" % s for s in sorted(settings.items()))
+        write_file(makesys_file, makesys_file_txt, append=True)
 
-        self.log.debug("Patched Make.sys: %s" % open(makesys_file, "r").read())
+        self.log.debug("Patched Make.sys: %s" % read_file(makesys_file))
 
         # set make target to 'xcrysden', such that dependencies are not downloaded/built
         self.cfg.update('buildopts', 'xcrysden')
@@ -126,15 +125,16 @@ class EB_XCrySDen(ConfigureMake):
     def sanity_check_step(self):
         """Custom sanity check for XCrySDen."""
 
-        custom_paths = {'files': ["bin/%s" % x for x in ["ptable", "pwi2xsf", "pwo2xsf", "unitconv", "xcrysden"]] +
-                                 ["lib/%s-%s/%s" % (self.name.lower(), self.version, x)
-                                  for x in ["atomlab", "calplane", "cube2xsf", "fhi_coord2xcr", "fhi_inpini2ftn34",
-                                            "fracCoor", "fsReadBXSF", "ftnunit", "gengeom", "kPath", "multislab",
-                                            "nn", "pwi2xsf", "pwi2xsf_old", "pwKPath", "recvec", "savestruct",
-                                            "str2xcr", "wn_readbakgen", "wn_readbands", "xcrys", "xctclsh",
-                                            "xsf2xsf"]],
-                        'dirs':[]
-                       }
+        binfiles = [os.path.join('bin', x) for x in ['ptable', 'pwi2xsf', 'pwo2xsf', 'unitconv', 'xcrysden']]
+        libfiles = ['atomlab', 'calplane', 'cube2xsf', 'fhi_coord2xcr', 'fhi_inpini2ftn34',
+                    'fracCoor', 'fsReadBXSF', 'ftnunit', 'gengeom', 'kPath', 'multislab',
+                    'nn', 'pwi2xsf', 'pwi2xsf_old', 'pwKPath', 'recvec', 'savestruct',
+                    'str2xcr', 'wn_readbakgen', 'wn_readbands', 'xcrys', 'xctclsh', 'xsf2xsf']
+
+        custom_paths = {
+            'files': binfiles + [os.path.join('lib', self.name.lower() + '-' + self.version, x) for x in libfiles],
+            'dirs': [],
+        }
 
         super(EB_XCrySDen, self).sanity_check_step(custom_paths=custom_paths)
 


### PR DESCRIPTION
fix for:

```
== 2019-09-18 17:24:59,162 easyblock.py:3310 INFO <easybuild.easyblocks.xcrysden.EB_XCrySDen object at 0x2b8ad441ae80> crashed with an error during fase: configure, error: Traceback (most recent call last):
  File "/lib/python2.7/site-packages/easybuild_framework-4.0.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 3289, in build_easyconfigs
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/lib/python2.7/site-packages/easybuild_framework-4.0.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2959, in run_all_steps
    self.run_step(step_name, step_methods)
  File "/lib/python2.7/site-packages/easybuild_framework-4.0.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2829, in run_step
    step_method(self)()
  File "/lib/python2.7/site-packages/easybuild_easyblocks-4.0.0.dev0-py2.7.egg/easybuild/easyblocks/x/xcrysden.py", line 102, in configure_step
    for (k, v) in settings.items():
RuntimeError: dictionary changed size during iteration
```