### PR TITLE
fix version checks in OpenFOAM easyblock that are not compatible with Python 3

### DIFF
--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -69,7 +69,7 @@ class EB_OpenFOAM(EasyBlock):
 
         # version may start with 'v' for some variants of OpenFOAM
         # we need to strip this off to avoid problems when comparing LooseVersion instances in Python 3
-        self.looseversion = LooseVersion(self.version.lstrip('v'))
+        self.looseversion = LooseVersion(self.version.strip('v+'))
 
         if 'extend' in self.name.lower():
             if self.looseversion >= LooseVersion('3.0'):
@@ -312,7 +312,7 @@ class EB_OpenFOAM(EasyBlock):
             run_cmd_qa(cmd_tmpl % 'Allwmake.firstInstall', qa, no_qa=noqa, log_all=True, simple=True, maxhits=500)
         else:
             cmd = 'Allwmake'
-            if LooseVersion(self.version.strip('v+')) > LooseVersion('1606'):
+            if self.looseversion > LooseVersion('1606'):
                 # use Allwmake -log option if possible since this can be useful during builds, but also afterwards
                 cmd += ' -log'
             run_cmd(cmd_tmpl % cmd, log_all=True, simple=True, log_output=True)
@@ -367,7 +367,7 @@ class EB_OpenFOAM(EasyBlock):
                                                     'modifyMesh', 'refineMesh']]
 
         # only include Boussinesq and sonic since for OpenFOAM < 7, since those solvers have been deprecated
-        if LooseVersion(self.version) < LooseVersion('7'):
+        if self.looseversion < LooseVersion('7'):
             bins.extend([
                 os.path.join(toolsdir, "buoyantBoussinesqSimpleFoam"),
                 os.path.join(toolsdir, "sonicFoam")


### PR DESCRIPTION
Somehow missed these in #1794...

```
== 2019-09-19 06:44:00,480 easyblock.py:3307 INFO <easybuild.easyblocks.openfoam.EB_OpenFOAM object at 0x2af57c03ae48> crashed with an error during fase: sanitycheck, error: Traceback (most recent call last):
  File "/lib/python2.7/site-packages/easybuild_framework-4.0.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 3286, in build_easyconfigs
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/lib/python2.7/site-packages/easybuild_framework-4.0.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2959, in run_all_steps
    self.run_step(step_name, step_methods)
  File "/lib/python2.7/site-packages/easybuild_framework-4.0.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2829, in run_step
    step_method(self)()
  File "/lib/python2.7/site-packages/easybuild_easyblocks-4.0.0.dev0-py2.7.egg/easybuild/easyblocks/o/openfoam.py", line 370, in sanity_check_step
    if LooseVersion(self.version) < LooseVersion('7'):
  File "/usr/lib64/python3.6/distutils/version.py", line 52, in __lt__
    c = self._cmp(other)
  File "/usr/lib64/python3.6/distutils/version.py", line 337, in _cmp
    if self.version < other.version:
TypeError: '<' not supported between instances of 'str' and 'int'
```