### PR TITLE
enhance TensorFlow easyblock to support installing TF 1.14.0 with CUDA and MPI support

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -220,9 +220,15 @@ class EB_TensorFlow(PythonPackage):
             cuda_version = get_software_version('CUDA')
             cuda_maj_min_ver = '.'.join(cuda_version.split('.')[:2])
 
+            # $GCC_HOST_COMPILER_PATH should be set to path of the actual compiler (not the MPI compiler wrapper)
+            if use_mpi:
+                compiler_path = which(os.getenv('CC_SEQ'))
+            else:
+                compiler_path = which(os.getenv('CC'))
+
             config_env_vars.update({
                 'CUDA_TOOLKIT_PATH': cuda_root,
-                'GCC_HOST_COMPILER_PATH': which(os.getenv('CC')),
+                'GCC_HOST_COMPILER_PATH': compiler_path,
                 'TF_CUDA_COMPUTE_CAPABILITIES': ','.join(self.cfg['cuda_compute_capabilities']),
                 'TF_CUDA_VERSION': cuda_maj_min_ver,
             })

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -217,16 +217,22 @@ class EB_TensorFlow(PythonPackage):
             'TF_NEED_KAFKA': '0',  # Amazon Kafka Platform
         }
         if cuda_root:
+            cuda_version = get_software_version('CUDA')
+            cuda_maj_min_ver = '.'.join(cuda_version.split('.')[:2])
+
             config_env_vars.update({
                 'CUDA_TOOLKIT_PATH': cuda_root,
                 'GCC_HOST_COMPILER_PATH': which(os.getenv('CC')),
                 'TF_CUDA_COMPUTE_CAPABILITIES': ','.join(self.cfg['cuda_compute_capabilities']),
-                'TF_CUDA_VERSION': get_software_version('CUDA'),
+                'TF_CUDA_VERSION': cuda_maj_min_ver,
             })
             if cudnn_root:
+                cudnn_version = get_software_version('cuDNN')
+                cudnn_maj_min_patch_ver = '.'.join(cudnn_version.split('.')[:3])
+
                 config_env_vars.update({
                     'CUDNN_INSTALL_PATH': cudnn_root,
-                    'TF_CUDNN_VERSION': get_software_version('cuDNN'),
+                    'TF_CUDNN_VERSION': cudnn_maj_min_patch_ver,
                 })
             else:
                 raise EasyBuildError("TensorFlow has a strict dependency on cuDNN if CUDA is enabled")


### PR DESCRIPTION
This fixes the following issue when trying to install TensorFlow 1.14.0 with CUDA 10.1.243:

```
Could not find any cuda.h matching version '10.1.243' in any subdirectory
```

Changes were made in TensorFlow 1.14.0 that require both `$TF_CUDA_VERSION` and `$TF_CUDNN_VERSION` to only include the correct number of digits, so `10.1` rather than `10.1.243` for `CUDA`.
In older TensorFlow versions, the value specified in `$TF_CUDA_VERSION` was stripped down first to just `<major>.<minor>`, but this got lost in TF 1.14.0.
For `cuDNN`, it expects `<major>.<minor>.<patch>` (so 3, not 4 as in the `cuDNN` version we use).

It turns out that we've been doing it incorrectly all along, since even with these changes installing `TensorFlow-1.8.0-fosscuda-2017b-Python-2.7.14.eb` still works fine...