### PR TITLE
don't require 'python' command to install libxml2 without Python bindings

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -215,6 +215,7 @@ class PythonPackage(ExtensionEasyBlock):
         self.testcmd = None
         self.unpack_options = self.cfg['unpack_options']
 
+        self.require_python = True
         self.python_cmd = None
         self.pylibdir = UNKNOWN
         self.all_pylibdirs = [UNKNOWN]
@@ -341,11 +342,14 @@ class PythonPackage(ExtensionEasyBlock):
         if python:
             self.python_cmd = python
             self.log.info("Python command being used: %s", self.python_cmd)
-        else:
+        elif self.require_python:
             raise EasyBuildError("Failed to pick Python command to use")
+        else:
+            self.log.warning("No Python command found!")
 
-        # set Python lib directories
-        self.set_pylibdirs()
+        if self.python_cmd:
+            # set Python lib directories
+            self.set_pylibdirs()
 
     def compose_install_command(self, prefix, extrapath=None, installopts=None):
         """Compose full install command."""
@@ -674,7 +678,7 @@ class PythonPackage(ExtensionEasyBlock):
         # if this Python package was installed for multiple Python versions
         if self.multi_python:
             txt += self.module_generator.prepend_paths(EBPYTHONPREFIXES, '')
-        else:
+        elif self.python_cmd:
             self.set_pylibdirs()
             for path in self.all_pylibdirs:
                 fullpath = os.path.join(self.installdir, path)

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -678,7 +678,7 @@ class PythonPackage(ExtensionEasyBlock):
         # if this Python package was installed for multiple Python versions
         if self.multi_python:
             txt += self.module_generator.prepend_paths(EBPYTHONPREFIXES, '')
-        elif self.python_cmd:
+        elif self.require_python:
             self.set_pylibdirs()
             for path in self.all_pylibdirs:
                 fullpath = os.path.join(self.installdir, path)

--- a/easybuild/easyblocks/l/libxml2.py
+++ b/easybuild/easyblocks/l/libxml2.py
@@ -57,6 +57,7 @@ class EB_libxml2(ConfigureMake, PythonPackage):
         """
         PythonPackage.__init__(self, *args, **kwargs)
         self.with_python_bindings = False
+        self.require_python = False
 
     def configure_step(self):
         """
@@ -66,6 +67,7 @@ class EB_libxml2(ConfigureMake, PythonPackage):
         python = get_software_root('Python')
         if python:
             self.with_python_bindings = True
+            self.require_python = True
 
         if not self.toolchain.is_system_toolchain():
             self.cfg.update('configopts', "CC='%s' CXX='%s'" % (os.getenv('CC'), os.getenv('CXX')))


### PR DESCRIPTION
On a system where the `python` and `python2` commands are not available (e.g. a fresh CentOS 8 installation where EasyBuild is using `python3`), installing `libxml2-2.9.9-GCCcore-8.3.0.eb` fails with:

```
Failed to pick Python command to use
```

That's because the `EB_libxml2` derives from `PythonPackage` to (optionally) install `libxml2` with Python bindings. `PythonPackage` prepares by looking for the `python` command to use, and fails with an error when both `python` and `python2` are not available.

This change avoids the strict need, restoring support for installing `libxml2` without Python bindings.