### PR TITLE
only read configure script when it's actually there in ConfigureMake easyblock

### DIFF
--- a/easybuild/easyblocks/generic/configuremake.py
+++ b/easybuild/easyblocks/generic/configuremake.py
@@ -218,12 +218,11 @@ class ConfigureMake(EasyBlock):
         # if so, we're at the mercy of the gods
         build_type_option = ''
         host_type_option = ''
+
         # note: reading contents of 'configure' script in bytes mode,
         # to avoid problems when non-UTF-8 characters are included
         # see https://github.com/easybuilders/easybuild-easyblocks/pull/1817
-        configure_txt = read_file(configure_command, mode='rb')
-
-        if os.path.exists(configure_command) and AUTOCONF_GENERATED_MSG in configure_txt:
+        if os.path.exists(configure_command) and AUTOCONF_GENERATED_MSG in read_file(configure_command, mode='rb'):
 
             build_type = self.cfg.get('build_type')
             host_type = self.cfg.get('host_type')


### PR DESCRIPTION
Fix for:

```
== 2019-09-30 14:10:42,908 build_log.py:164 ERROR EasyBuild crashed with an error (at easybuild/base/exceptions.py:124 in __init__): Failed to read ./configure: [Errno 2] No such file or directory: './configure' (at easybuild/tools/filetools.py:191 in read_file)
```

This crept in via #1817