### PR TITLE
update TensorFlow easyblock to support TensorFlow 2.0

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -421,6 +421,10 @@ class EB_TensorFlow(PythonPackage):
 
         cmd.append(self.cfg['buildopts'])
 
+        # building TensorFlow v2.0 requires passing --config=v2 to "bazel build" command...
+        if LooseVersion(self.version) >= LooseVersion('2.0'):
+            cmd.append('--config=v2')
+
         if cuda_root:
             cmd.append('--config=cuda')
 

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -514,7 +514,11 @@ class EB_TensorFlow(PythonPackage):
             pythonpath = os.getenv('PYTHONPATH', '')
             env.setvar('PYTHONPATH', os.pathsep.join([os.path.join(self.installdir, self.pylibdir), pythonpath]))
 
-            mnist_pys = ['mnist_with_summaries.py']
+            mnist_pys = []
+
+            if LooseVersion(self.version) < LooseVersion('2.0'):
+                mnist_pys.append('mnist_with_summaries.py')
+
             if LooseVersion(self.version) < LooseVersion('1.13'):
                 # mnist_softmax.py was removed in TensorFlow 1.13.x
                 mnist_pys.append('mnist_softmax.py')


### PR DESCRIPTION
The `mnist_with_summaries.py` tutorial example is broken beyond repair with TensorFlow 2.0 due to significant changes to the API (`tensorflow.contrib.learn` required by this example was deprecated a while ago, and is no longer packaged).

We can consider using the "beginner" quickstart example from https://www.tensorflow.org/tutorials/quickstart/beginner instead as a smoke test (through a patch included in the TensorFlow 2.x easyconfigs so it can be run during sanity check).