### PR TITLE
fix for conda packages that rely on particular versions of Python

### DIFF
--- a/easybuild/easyblocks/generic/conda.py
+++ b/easybuild/easyblocks/generic/conda.py
@@ -84,25 +84,24 @@ class Conda(Binary):
             run_cmd(cmd, log_all=True, simple=True)
 
         else:
-            cmd = "%s conda create --force -y -p %s" % (self.cfg['preinstallopts'], self.installdir)
-            run_cmd(cmd, log_all=True, simple=True)
 
+	    self.set_conda_env()
             if self.cfg['requirements']:
-                self.set_conda_env()
 
                 install_args = "-y %s " % self.cfg['requirements']
                 if self.cfg['channels']:
                     install_args += ' '.join('-c ' + chan for chan in self.cfg['channels'])
 
-                cmd = "conda install %s" % (install_args)
-                run_cmd(cmd, log_all=True, simple=True)
-
                 self.log.info("Installed conda requirements")
+
+            cmd = "%s conda create --force -y -p %s %s" % (self.cfg['preinstallopts'], self.installdir, install_args)
+            run_cmd(cmd, log_all=True, simple=True)
 
     def make_module_extra(self):
         """Add the install directory to the PATH."""
         txt = super(Conda, self).make_module_extra()
         txt += self.module_generator.set_environment('CONDA_ENV', self.installdir)
+        txt += self.module_generator.set_environment('CONDA_PREFIX', self.installdir)
         txt += self.module_generator.set_environment('CONDA_DEFAULT_ENV', self.installdir)
         self.log.debug("make_module_extra added this: %s", txt)
         return txt

--- a/easybuild/easyblocks/generic/conda.py
+++ b/easybuild/easyblocks/generic/conda.py
@@ -57,11 +57,6 @@ class Conda(Binary):
         if self.src:
             super(Conda, self).extract_step()
 
-    def set_conda_env(self):
-        """Set up environment for using 'conda'."""
-        env.setvar('CONDA_ENV', self.installdir)
-        env.setvar('CONDA_DEFAULT_ENV', self.installdir)
-
     def install_step(self):
         """Install software using 'conda env create' or 'conda create' & 'conda install'."""
 
@@ -77,15 +72,12 @@ class Conda(Binary):
             else:
                 env_spec = self.cfg['remote_environment']
 
-            self.set_conda_env()
-
             # use --force to ignore existing installation directory
             cmd = "%s conda env create --force %s -p %s" % (self.cfg['preinstallopts'], env_spec, self.installdir)
             run_cmd(cmd, log_all=True, simple=True)
 
         else:
 
-	    self.set_conda_env()
             if self.cfg['requirements']:
 
                 install_args = "-y %s " % self.cfg['requirements']


### PR DESCRIPTION
Hi, @boegel!

I made a rather bone headed error when I was figuring out the logic for conda installs. There doesn't need to be two separate commands for first creating the conda env and then installing the requirement. It should be one, or else you run into errors.

An example error would be if you have a build dep of `Miniconda3/4.7.10` along with the following easyconfig - 

```
##
# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
##

easyblock = 'Conda'

name = "hisat2"
version = "2.1.0"

homepage = 'https://bioconda.github.io/recipes/hisat2/README.html'
description = """graph-based alignment of next generation sequencing reads to a population of genomes"""

toolchain = SYSTEM

requirements = "%(name)s=%(version)s"
channels = ['bioconda', 'conda-forge']

builddependencies = [('Miniconda3', '4.7.10')]

sanity_check_paths = {
    'files': ['bin/python'],
    'dirs': ['bin']
}

moduleclass = 'tools'
```

