### PR TITLE
add prebuildopts to bazel build command

### DIFF
--- a/easybuild/easyblocks/b/bazel.py
+++ b/easybuild/easyblocks/b/bazel.py
@@ -100,7 +100,8 @@ class EB_Bazel(EasyBlock):
 
     def build_step(self):
         """Custom build procedure for Bazel."""
-        run_cmd('./compile.sh', log_all=True, simple=True, log_ok=True)
+        cmd = '%s ./compile.sh' % self.cfg['prebuildopts']
+        run_cmd(cmd, log_all=True, simple=True, log_ok=True)
 
     def install_step(self):
         """Custom install procedure for Bazel."""


### PR DESCRIPTION
While building `Bazel-0.25.2-GCCcore-8.2.0.eb` on POWER9 we had need to set
```
EXTRA_BAZEL_ARGS="--host_javabase=@local_jdk//:jdk" '
```
and I did this by passing it from the easyconfig using `prebuildopts` to get it to detect the JDK. This allowed us to beuild TensorFlow 1.14.0 (foss/fosscuda 2019a) on POWER9 and it does not break the build of Bazel 0.25.2 or TensorFlow 1.14.0 on Haswell.