### PR TITLE
fixes for TensorFlow easyblocks w.r.t. Bazel build options & __init__ in top-level google-protobuf package dir

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -433,12 +433,10 @@ class EB_TensorFlow(PythonPackage):
 
         cmd.append(self.cfg['buildopts'])
 
-        # building TensorFlow v2.0 requires passing --config=v2 to "bazel build" command...
-        if LooseVersion(self.version) >= LooseVersion('2.0'):
-            cmd.append('--config=v2')
-
-        if cuda_root:
-            cmd.append('--config=cuda')
+        # TF 2 (final) sets this in configure
+        if LooseVersion(self.version) < LooseVersion('2.0'):
+            if cuda_root:
+                cmd.append('--config=cuda')
 
         # if mkl-dnn is listed as a dependency it is used. Otherwise downloaded if with_mkl_dnn is true
         mkl_root = get_software_root('mkl-dnn')


### PR DESCRIPTION
Fix the warning 

> WARNING: The following configs were expanded more than once: [v2, cuda, using_cuda]. For repeatable flags, repeats are counted twice and may lead to unexpected behavior. 

in TF 2 (see https://github.com/easybuilders/easybuild-easyblocks/commit/7f62330e84710626ed87ef404d2c9a170cfbd729#diff-925e7942309e22e4c64cb2d99b50c206) and remove `google/__init__.py` for Python 3.3 (see https://github.com/easybuilders/easybuild-easyconfigs/issues/9207)