### PR TITLE
add GitHub Actions workflow to run easybuild-easyblocks test suite

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,129 @@
+name: easyblocks unit tests
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        python: [2.7, 3.5, 3.6, 3.7]
+        modules_tool: [Lmod-6.6.3, Lmod-7.8.22, Lmod-8.1.14, modules-tcl-1.147, modules-3.2.10, modules-4.1.4]
+        module_syntax: [Lua, Tcl]
+        # exclude some configuration for non-Lmod modules tool:
+        # - don't test with Lua module syntax (only supported in Lmod)
+        # - don't test with Python 3.5 and 3.7 (only with 2.7 and 3.6), to limit test configurations
+        exclude:
+          - modules_tool: modules-tcl-1.147
+            module_syntax: Lua
+          - modules_tool: modules-3.2.10
+            module_syntax: Lua
+          - modules_tool: modules-4.1.4
+            module_syntax: Lua
+          - modules_tool: modules-tcl-1.147
+            python: 3.5
+          - modules_tool: modules-tcl-1.147
+            python: 3.7
+          - modules_tool: modules-3.2.10
+            python: 3.5
+          - modules_tool: modules-3.2.10
+            python: 3.7
+          - modules_tool: modules-4.1.4
+            python: 3.5
+          - modules_tool: modules-4.1.4
+            python: 3.7
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{matrix.python}}
+        architecture: x64
+
+    - name: install OS & Python packages
+      run: |
+        sudo apt-get update
+        # for modules tool
+        sudo apt-get install lua5.2 liblua5.2-dev lua-filesystem lua-posix tcl tcl-dev
+        # fix for lua-posix packaging issue, see https://bugs.launchpad.net/ubuntu/+source/lua-posix/+bug/1752082
+        sudo ln -s /usr/lib/x86_64-linux-gnu/lua/5.2/posix_c.so /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so
+        # for testing OpenMPI-system*eb we need to have Open MPI installed
+        sudo apt-get install libopenmpi-dev openmpi-bin
+
+    - name: install EasyBuild framework
+      run: |
+          # first determine which branch of easybuild-framework repo to install
+          BRANCH=develop
+          if [ "x$GITHUB_BASE_REF" = 'xmaster' ]; then BRANCH=master; fi
+          if [ "x$GITHUB_BASE_REF" = 'x4.x' ]; then BRANCH=4.x; fi
+          echo "Using easybuild-framework branch $BRANCH (\$GITHUB_BASE_REF $GITHUB_BASE_REF)"
+          git clone -b $BRANCH --depth 10 --single-branch https://github.com/easybuilders/easybuild-framework.git
+          cd easybuild-framework; git log -n 1; cd -
+          pip install $PWD/easybuild-framework
+
+    - name: install modules tool
+      run: |
+          cd $HOME
+          # use install_eb_dep.sh script provided with easybuild-framework
+          export INSTALL_DEP=$(which install_eb_dep.sh)
+          echo "Found install_eb_dep.sh script: $INSTALL_DEP"
+
+          # install modules tool
+          source $INSTALL_DEP ${{matrix.modules_tool}} $HOME
+
+          # changes in environment are not passed to other steps, so need to create files...
+          echo $MOD_INIT > mod_init
+          echo $PATH > path
+          if [ ! -z $MODULESHOME ]; then echo $MODULESHOME > moduleshome; fi
+
+    - name: install sources
+      run: |
+          # install from source distribution tarball, to test release as published on PyPI
+          python setup.py sdist
+          ls dist
+          export PREFIX=/tmp/$USER/$GITHUB_SHA
+          pip install --prefix $PREFIX dist/easybuild-easyblocks*tar.gz
+
+    - name: run test suite
+      env:
+        EB_VERBOSE: 1
+        EASYBUILD_MODULE_SYNTAX: ${{matrix.module_syntax}}
+      run: |
+          # initialize environment for modules tool
+          if [ -f $HOME/moduleshome ]; then export MODULESHOME=$(cat $HOME/moduleshome); fi
+          source $(cat $HOME/mod_init); type module
+
+          # make sure 'eb' is available via $PATH, and that $PYTHONPATH is set (some tests expect that);
+          # also pick up changes to $PATH set by sourcing $MOD_INIT
+          export PREFIX=/tmp/$USER/$GITHUB_SHA
+          export PATH=$PREFIX/bin:$(cat $HOME/path)
+          export PYTHONPATH=$PREFIX/lib/python${{matrix.python}}/site-packages:$PYTHONPATH
+
+          # tell EasyBuild which modules tool is available
+          if [[ ${{matrix.modules_tool}} =~ ^modules-tcl- ]]; then
+            export EASYBUILD_MODULES_TOOL=EnvironmentModulesTcl
+          elif [[ ${{matrix.modules_tool}} =~ ^modules-3 ]]; then
+            export EASYBUILD_MODULES_TOOL=EnvironmentModulesC
+          elif [[ ${{matrix.modules_tool}} =~ ^modules-4 ]]; then
+            export EASYBUILD_MODULES_TOOL=EnvironmentModules
+          else
+            export EASYBUILD_MODULES_TOOL=Lmod
+          fi
+
+          eb --version
+          eb --show-config
+          # gather some useful info on test system
+          eb --show-system-info
+
+          # actively break "import setuptools" and "import pkg_resources",
+          # since EasyBuild should not have a runtime requirement on setuptools
+          echo 'raise ImportError("setuptools should no longer be relied on")' > $PREFIX/setuptools.py
+          echo 'raise ImportError("setuptools should no longer be relied on")' > $PREFIX/pkg_resources.py
+          export PYTHONPATH=$PREFIX:$PYTHONPATH
+
+          # run test suite
+          python -O -m test.easyblocks.suite
+          # check output of --list-easyblocks
+          eb --list-easyblocks > eb_list_easyblocks.out
+          grep 'ConfigureMake\>' eb_list_easyblocks.out
+          grep EB_GCC eb_list_easyblocks.out


### PR DESCRIPTION
Equivalent to the `easybuild-framework` repo (cfr. https://github.com/easybuilders/easybuild-framework/pull/3039), this PR add the configuration file to run the easyblocks test suite in the native GitHub CI, next to Travis

The long term goal is to stop relying on Travis (which we'll keep using as is for now, and soon only for running the tests on top of Python 2.6).

General availability for GitHub Actions is planned for mid November, it's probably worth waiting until shortly after before fully relying on it...