### PR TITLE
add support to Toolchain generic easyblock for defining $EB* environment variables for toolchain components that use an external module

### DIFF
--- a/easybuild/easyblocks/generic/toolchain.py
+++ b/easybuild/easyblocks/generic/toolchain.py
@@ -65,7 +65,11 @@ class Toolchain(Bundle):
 
                 mod_name = dep['full_mod_name']
                 metadata = dep['external_module_metadata']
-                names, versions = metadata.get('name'), metadata.get('version')
+                names, versions = metadata.get('name', []), metadata.get('version')
+
+                # if no versions are available, use None as version (for every software name)
+                if versions is None:
+                    versions = [None] * len(names)
 
                 if names:
                     self.log.info("Adding environment variables for %s provided by external module %s", names, mod_name)

--- a/easybuild/easyblocks/generic/toolchain.py
+++ b/easybuild/easyblocks/generic/toolchain.py
@@ -91,10 +91,11 @@ class Toolchain(Bundle):
                                 prefix_path = os.path.join(prefix_path, rel_path, '')
 
                             self.log.debug("Derived prefix for software named %s from $%s (rel path: %s): %s",
-                                        name, env_var, rel_path, prefix_path)
+                                           name, env_var, rel_path, prefix_path)
                         else:
                             prefix_path = prefix
-                            self.log.debug("Using specified path as prefix for software named %s: %s", name, prefix_path)
+                            self.log.debug("Using specified path as prefix for software named %s: %s",
+                                           name, prefix_path)
 
                         for name in names:
                             env_var = get_software_root_env_var_name(name)

--- a/easybuild/easyblocks/generic/toolchain.py
+++ b/easybuild/easyblocks/generic/toolchain.py
@@ -34,13 +34,24 @@ EasyBuild support for installing compiler toolchains, implemented as an easybloc
 import os
 
 from easybuild.easyblocks.generic.bundle import Bundle
+from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.modules import get_software_root_env_var_name, get_software_version_env_var_name
 
 
 class Toolchain(Bundle):
-    """
-    Compiler toolchain: generate module file only, nothing to build/install
-    """
+    """Compiler toolchain easyblock: nothing to install, just generate module file."""
+
+    @staticmethod
+    def extra_options(extra_vars=None):
+        """Easyconfig parameters specific to toolchains."""
+        if extra_vars is None:
+            extra_vars = {}
+        extra_vars.update({
+            'set_env_external_modules': [False, "Include setenv statements for toolchain components that use "
+                                                "an external module, based on available metadata", CUSTOM],
+        })
+        return Bundle.extra_options(extra_vars=extra_vars)
+
     def make_module_extra(self):
         """
         Define $EBROOT* and $EBVERSION* environment for toolchain components marked as external module,
@@ -51,43 +62,43 @@ class Toolchain(Bundle):
         # include $EBROOT* and $EBVERSION* definitions for toolchain components marked as external modules (if any)
         # in the generated module file for this toolchain;
         # this is required to let the EasyBuild framework set up the build environment based on the toolchain
-        for dep in [d for d in self.cfg['dependencies'] if d['external_module']]:
+        if self.cfg.get('set_env_external_modules', False):
+            for dep in [d for d in self.cfg['dependencies'] if d['external_module']]:
 
-            mod_name = dep['full_mod_name']
-            metadata = dep['external_module_metadata']
-            names, versions, prefix = metadata.get('name'), metadata.get('version'), metadata.get('prefix')
+                mod_name = dep['full_mod_name']
+                metadata = dep['external_module_metadata']
+                names, versions, prefix = metadata.get('name'), metadata.get('version'), metadata.get('prefix')
 
-            if names:
-                self.log.info("Adding environment variables for %s provided by external module %s", names, mod_name)
+                if names:
+                    self.log.info("Adding environment variables for %s provided by external module %s", names, mod_name)
 
-                # define $EBVERSION* if version is available
-                print mod_name, versions
-                if versions:
-                    for name, version in zip(names, versions):
-                        env_var = get_software_version_env_var_name(name)
-                        self.log.info("Defining $%s for external module %s: %s", env_var, mod_name, version)
-                        txt += self.module_generator.set_environment(env_var, version)
+                    # define $EBVERSION* if version is available
+                    if versions:
+                        for name, version in zip(names, versions):
+                            env_var = get_software_version_env_var_name(name)
+                            self.log.info("Defining $%s for external module %s: %s", env_var, mod_name, version)
+                            txt += self.module_generator.set_environment(env_var, version)
 
-                # define $EBROOT* if prefix is available
-                if prefix:
-                    # prefix can be specified via environment variable (+ subdir) or absolute path
-                    prefix_parts = prefix.split(os.path.sep)
-                    if prefix_parts[0] in os.environ:
-                        env_var = prefix_parts[0]
-                        prefix_path = os.environ[env_var]
-                        rel_path = os.path.sep.join(prefix_parts[1:])
-                        if rel_path:
-                            prefix_path = os.path.join(prefix_path, rel_path, '')
+                    # define $EBROOT* if prefix is available
+                    if prefix:
+                        # prefix can be specified via environment variable (+ subdir) or absolute path
+                        prefix_parts = prefix.split(os.path.sep)
+                        if prefix_parts[0] in os.environ:
+                            env_var = prefix_parts[0]
+                            prefix_path = os.environ[env_var]
+                            rel_path = os.path.sep.join(prefix_parts[1:])
+                            if rel_path:
+                                prefix_path = os.path.join(prefix_path, rel_path, '')
 
-                        self.log.debug("Derived prefix for software named %s from $%s (rel path: %s): %s",
-                                    name, env_var, rel_path, prefix_path)
-                    else:
-                        prefix_path = prefix
-                        self.log.debug("Using specified path as prefix for software named %s: %s", name, prefix_path)
+                            self.log.debug("Derived prefix for software named %s from $%s (rel path: %s): %s",
+                                        name, env_var, rel_path, prefix_path)
+                        else:
+                            prefix_path = prefix
+                            self.log.debug("Using specified path as prefix for software named %s: %s", name, prefix_path)
 
-                    for name in names:
-                        env_var = get_software_root_env_var_name(name)
-                        self.log.info("Defining $%s for external module %s: %s", env_var, mod_name, prefix_path)
-                        txt += self.module_generator.set_environment(env_var, prefix_path)
+                        for name in names:
+                            env_var = get_software_root_env_var_name(name)
+                            self.log.info("Defining $%s for external module %s: %s", env_var, mod_name, prefix_path)
+                            txt += self.module_generator.set_environment(env_var, prefix_path)
 
         return txt

--- a/easybuild/easyblocks/generic/toolchain.py
+++ b/easybuild/easyblocks/generic/toolchain.py
@@ -31,12 +31,63 @@ EasyBuild support for installing compiler toolchains, implemented as an easybloc
 @author: Pieter De Baets (Ghent University)
 @author: Jens Timmerman (Ghent University)
 """
+import os
 
 from easybuild.easyblocks.generic.bundle import Bundle
+from easybuild.tools.modules import get_software_root_env_var_name, get_software_version_env_var_name
 
 
 class Toolchain(Bundle):
     """
     Compiler toolchain: generate module file only, nothing to build/install
     """
-    pass
+    def make_module_extra(self):
+        """
+        Define $EBROOT* and $EBVERSION* environment for toolchain components marked as external module,
+        if corresponding metadata is available.
+        """
+        txt = super(Toolchain, self).make_module_extra()
+
+        # include $EBROOT* and $EBVERSION* definitions for toolchain components marked as external modules (if any)
+        # in the generated module file for this toolchain;
+        # this is required to let the EasyBuild framework set up the build environment based on the toolchain
+        for dep in [d for d in self.cfg['dependencies'] if d['external_module']]:
+
+            mod_name = dep['full_mod_name']
+            metadata = dep['external_module_metadata']
+            names, versions, prefix = metadata.get('name'), metadata.get('version'), metadata.get('prefix')
+
+            if names:
+                self.log.info("Adding environment variables for %s provided by external module %s", names, mod_name)
+
+                # define $EBVERSION* if version is available
+                print mod_name, versions
+                if versions:
+                    for name, version in zip(names, versions):
+                        env_var = get_software_version_env_var_name(name)
+                        self.log.info("Defining $%s for external module %s: %s", env_var, mod_name, version)
+                        txt += self.module_generator.set_environment(env_var, version)
+
+                # define $EBROOT* if prefix is available
+                if prefix:
+                    # prefix can be specified via environment variable (+ subdir) or absolute path
+                    prefix_parts = prefix.split(os.path.sep)
+                    if prefix_parts[0] in os.environ:
+                        env_var = prefix_parts[0]
+                        prefix_path = os.environ[env_var]
+                        rel_path = os.path.sep.join(prefix_parts[1:])
+                        if rel_path:
+                            prefix_path = os.path.join(prefix_path, rel_path, '')
+
+                        self.log.debug("Derived prefix for software named %s from $%s (rel path: %s): %s",
+                                    name, env_var, rel_path, prefix_path)
+                    else:
+                        prefix_path = prefix
+                        self.log.debug("Using specified path as prefix for software named %s: %s", name, prefix_path)
+
+                    for name in names:
+                        env_var = get_software_root_env_var_name(name)
+                        self.log.info("Defining $%s for external module %s: %s", env_var, mod_name, prefix_path)
+                        txt += self.module_generator.set_environment(env_var, prefix_path)
+
+        return txt

--- a/test/easyblocks/easyblock_specific.py
+++ b/test/easyblocks/easyblock_specific.py
@@ -1,0 +1,211 @@
+##
+# Copyright 2019-2019 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+Unit tests for specific easyblocks.
+
+@author: Kenneth Hoste (Ghent University)
+"""
+import copy
+import os
+import sys
+import tempfile
+from unittest import TestCase, TestLoader, TextTestRunner
+from test.easyblocks.module import cleanup
+
+import easybuild.tools.options as eboptions
+from easybuild.easyblocks.generic.toolchain import Toolchain
+from easybuild.framework.easyblock import get_easyblock_instance
+from easybuild.framework.easyconfig.easyconfig import process_easyconfig
+from easybuild.tools import config
+from easybuild.tools.config import get_module_syntax
+from easybuild.tools.environment import modify_env
+from easybuild.tools.filetools import remove_dir, write_file
+from easybuild.tools.modules import modules_tool
+from easybuild.tools.options import set_tmpdir
+from easybuild.tools.py2vs3 import StringIO
+
+
+class EasyBlockSpecificTest(TestCase):
+    """ Baseclass for easyblock testcases """
+
+    def setUp(self):
+        """Test setup."""
+        super(EasyBlockSpecificTest, self).setUp()
+        self.tmpdir = tempfile.mkdtemp()
+
+        self.orig_sys_stdout = sys.stdout
+        self.orig_sys_stderr = sys.stderr
+        self.orig_environ = copy.deepcopy(os.environ)
+
+    def tearDown(self):
+        """Test cleanup."""
+        remove_dir(self.tmpdir)
+
+        sys.stdout = self.orig_sys_stdout
+        sys.stderr = self.orig_sys_stderr
+
+        # restore original environment
+        modify_env(os.environ, self.orig_environ, verbose=False)
+
+        super(EasyBlockSpecificTest, self).tearDown()
+
+    def mock_stdout(self, enable):
+        """Enable/disable mocking stdout."""
+        sys.stdout.flush()
+        if enable:
+            sys.stdout = StringIO()
+        else:
+            sys.stdout = self.orig_sys_stdout
+
+    def get_stdout(self):
+        """Return output captured from stdout until now."""
+        return sys.stdout.getvalue()
+
+    def test_toolchain_external_modules(self):
+        """Test use of Toolchain easyblock with external modules."""
+
+        external_modules = ['gcc/8.3.0', 'openmpi/4.0.2', 'openblas/0.3.7', 'fftw/3.3.8', 'scalapack/2.0.2']
+        external_modules_metadata = {
+            # all metadata for gcc/8.3.0
+            'gcc/8.3.0': {
+                'name': ['GCC'],
+                'version': ['8.3.0'],
+                'prefix': '/software/gcc/8.3.0',
+            },
+            # only name/version for openmpi/4.0.2
+            'openmpi/4.0.2': {
+                'name': ['OpenMPI'],
+                'version': ['4.0.2'],
+            },
+            # only name/prefix for openblas/0.3.7
+            'openblas/0.3.7': {
+                'name': ['OpenBLAS'],
+                'prefix': '/software/openblas/0.3.7',
+            },
+            # only version/prefix for fftw/3.3.8 (no name)
+            'fftw/3.3.8': {
+                'version': ['3.3.8'],
+                'prefix': '/software/fftw/3.3.8',
+            },
+            # no metadata for scalapack/2.0.2
+        }
+
+        # initialize configuration
+        cleanup()
+        eb_go = eboptions.parse_options(args=['--installpath=%s' % self.tmpdir])
+        config.init(eb_go.options, eb_go.get_options_by_section('config'))
+        build_options = {
+            'external_modules_metadata': external_modules_metadata,
+            'valid_module_classes': config.module_classes(),
+        }
+        config.init_build_options(build_options=build_options)
+        set_tmpdir()
+        del eb_go
+
+        modtool = modules_tool()
+
+        # make sure no $EBROOT* or $EBVERSION* environment variables are set in current environment
+        for key in os.environ:
+            if any(key.startswith(x) for x in ['EBROOT', 'EBVERSION']):
+                del os.environ[key]
+
+        # create dummy module file for each of the external modules
+        test_mod_path = os.path.join(self.tmpdir, 'modules', 'all')
+        for mod in external_modules:
+            write_file(os.path.join(test_mod_path, mod), "#%Module")
+
+        modtool.use(test_mod_path)
+
+        # test easyconfig file to install toolchain that uses external modules,
+        # and enables set_env_external_modules
+        test_ec_path = os.path.join(self.tmpdir, 'test.eb')
+        test_ec_txt = '\n'.join([
+            "easyblock = 'Toolchain'",
+            "name = 'test-toolchain'",
+            "version = '1.2.3'",
+            "homepage = 'https://example.com'",
+            "description = 'just a test'",
+            "toolchain = SYSTEM",
+            "dependencies = [",
+            "   ('gcc/8.3.0', EXTERNAL_MODULE),",
+            "   ('openmpi/4.0.2', EXTERNAL_MODULE),",
+            "   ('openblas/0.3.7', EXTERNAL_MODULE),",
+            "   ('fftw/3.3.8', EXTERNAL_MODULE),",
+            "   ('scalapack/2.0.2', EXTERNAL_MODULE),",
+            "]",
+            "set_env_external_modules = True",
+            "moduleclass = 'toolchain'",
+        ])
+        write_file(test_ec_path, test_ec_txt)
+        test_ec = process_easyconfig(test_ec_path)[0]
+
+        # create easyblock & install module via run_all_steps
+        tc_inst = get_easyblock_instance(test_ec)
+        self.assertTrue(isinstance(tc_inst, Toolchain))
+        self.mock_stdout(True)
+        tc_inst.run_all_steps(False)
+        self.mock_stdout(False)
+
+        # make sure expected module file exists
+        test_mod = os.path.join(test_mod_path, 'test-toolchain', '1.2.3')
+        if get_module_syntax() == 'Lua':
+            test_mod += '.lua'
+        self.assertTrue(os.path.exists(test_mod))
+
+        # load test-toolchain/1.2.3 module to get environment variable to check for defined
+        modtool.load(['test-toolchain/1.2.3'])
+
+        # check whether expected environment variables are defined
+        self.assertEqual(os.environ.pop('EBROOTGCC'), '/software/gcc/8.3.0')
+        self.assertEqual(os.environ.pop('EBVERSIONGCC'), '8.3.0')
+        self.assertEqual(os.environ.pop('EBVERSIONOPENMPI'), '4.0.2')
+        self.assertEqual(os.environ.pop('EBROOTOPENBLAS'), '/software/openblas/0.3.7')
+        undefined_env_vars = [
+            'EBROOTOPENMPI',  # no prefix in metadata
+            'EBVERSIONOPENBLAS'  # no version in metadata
+            'EBROOTFFTW', 'EBVERSIONFFTW',  # no name in metadata
+            'EBROOTSCALAPACK', 'EBVERSIONSCALAPACK',  # no metadata
+        ]
+        for env_var in undefined_env_vars:
+            self.assertTrue(os.getenv(env_var) is None)
+
+        # make sure no unexpected $EBROOT* or $EBVERSION* environment variables were defined
+        del os.environ['EBROOTTESTMINTOOLCHAIN']
+        del os.environ['EBVERSIONTESTMINTOOLCHAIN']
+        extra_eb_env_vars = []
+        for key in os.environ:
+            if any(key.startswith(x) for x in ['EBROOT', 'EBVERSION']):
+                extra_eb_env_vars.append(key)
+        self.assertEqual(extra_eb_env_vars, [])
+
+
+def suite():
+    """Return all easyblock-specific tests."""
+    return TestLoader().loadTestsFromTestCase(EasyBlockSpecificTest)
+
+
+if __name__ == '__main__':
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/easyblocks/suite.py
+++ b/test/easyblocks/suite.py
@@ -25,7 +25,7 @@
 ##
 """
 This script is a collection of all the testcases for easybuild-easyblocks.
-Usage: "python -m easybuild.easyblocks.test.suite.py" or "./easybuild/easyblocks/test/suite.py"
+Usage: "python -m test.easyblocks.suite" or "python test/easyblocks/suite.py"
 
 @author: Toon Willems (Ghent University)
 @author: Kenneth Hoste (Ghent University)
@@ -41,6 +41,7 @@ from easybuild.base import fancylogger
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.options import set_tmpdir
 
+import test.easyblocks.easyblock_specific as e
 import test.easyblocks.general as g
 import test.easyblocks.init_easyblocks as i
 import test.easyblocks.module as m
@@ -62,7 +63,7 @@ except EasyBuildError as err:
 os.environ['EASYBUILD_TMP_LOGDIR'] = tempfile.mkdtemp(prefix='easyblocks_test_')
 
 # call suite() for each module and then run them all
-SUITE = unittest.TestSuite([x.suite() for x in [g, i, m]])
+SUITE = unittest.TestSuite([x.suite() for x in [g, i, m, e]])
 res = unittest.TextTestRunner().run(SUITE)
 
 fancylogger.logToFile(log_fn, enable=False)


### PR DESCRIPTION
This is required to construct a toolchain using external modules (provided by OpenHPC packages, for example).

The metadata for external modules is only picked up for dependencies, not for the toolchain (partially because that would require access to the easyconfig file rather than just an existing module for the toolchain itself).

In addition, the installation prefix & version for the toolchain components must be available via the corresponding `$EBROOT*` and `$EBVERSION*` environment variables when setting up the build environment.
For EasyBuild-generated modules those environment variables are set by the module files, but for external modules we must leverage the metadata files to take care of that ourselves.

cc @koomie @adrianreber

edit: requires ~~https://github.com/easybuilders/easybuild-framework/pull/3088~~