### PR TITLE
prepend -L$EBROOTZLIB/lib to LDFLAGS in SCOTCH easyblock

### DIFF
--- a/easybuild/easyblocks/s/scotch.py
+++ b/easybuild/easyblocks/s/scotch.py
@@ -81,6 +81,8 @@ class EB_SCOTCH(EasyBlock):
             (r"^CCD\s*=.*$", "CCD\t= $(MPICC)"),
             # append -lpthread to LDFLAGS
             (r"^LDFLAGS\s*=(?P<ldflags>.*$)", "LDFLAGS\t=\g<ldflags> -lpthread"),
+            # prepend -L${EBROOTZLIB}/lib to LDFLAGS
+            (r"^LDFLAGS\s*=(?P<ldflags>.*$)", "LDFLAGS\t=-L${EBROOTZLIB}/lib \g<ldflags>"),
         ]
         apply_regex_substitutions(makefile_inc, regex_subs)
 


### PR DESCRIPTION
I needed this to avoid picking up the system libz in a system with zlib-devel installed