### PR TITLE
Improved configuration for netcdf and netcdf4_python

### DIFF
--- a/easybuild/easyblocks/n/netcdf.py
+++ b/easybuild/easyblocks/n/netcdf.py
@@ -68,7 +68,10 @@ class EB_netCDF(CMakeMake):
             ConfigureMake.configure_step(self)
 
         else:
-            self.cfg.update('configopts', '-DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_C_FLAGS_RELEASE="-DNDEBUG " ')
+            if self.toolchain.options['debug']:
+                self.cfg.update('configopts', '-DCMAKE_BUILD_TYPE=DEBUG ')
+            else:
+                self.cfg.update('configopts', '-DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_C_FLAGS_RELEASE="-DNDEBUG " ')
 
             for (dep, libname) in [('cURL', 'curl'), ('HDF5', 'hdf5'), ('Szip', 'sz'), ('zlib', 'z'),
                                    ('PnetCDF', 'pnetcdf')]:

--- a/easybuild/easyblocks/n/netcdf.py
+++ b/easybuild/easyblocks/n/netcdf.py
@@ -69,7 +69,8 @@ class EB_netCDF(CMakeMake):
 
         else:
             self.cfg.update('configopts', '-DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_C_FLAGS_RELEASE="-DNDEBUG " ')
-            for (dep, libname) in [('cURL', 'curl'), ('HDF5', 'hdf5'), ('Szip', 'sz'), ('zlib', 'z')]:
+            for (dep, libname) in [('cURL', 'curl'), ('HDF5', 'hdf5'), ('Szip', 'sz'), ('zlib', 'z'),
+                                   ('PnetCDF', 'pnetcdf')]:
                 dep_root = get_software_root(dep)
                 dep_libdir = get_software_libdir(dep)
                 if dep_root:
@@ -81,6 +82,8 @@ class EB_netCDF(CMakeMake):
                         self.cfg.update('configopts', '-DHDF5_LIB=%s ' % libhdf5)
                         libhdf5_hl = os.path.join(dep_root, dep_libdir, 'libhdf5_hl.%s' % shlib_ext)
                         self.cfg.update('configopts', '-DHDF5_HL_LIB=%s ' % libhdf5_hl)
+                    elif dep == 'PnetCDF':
+                        self.cfg.update('configopts', '-DENABLE_PNETCDF=ON')
                     else:
                         libso = os.path.join(dep_root, dep_libdir, 'lib%s.%s' % (libname, shlib_ext))
                         self.cfg.update('configopts', '-D%s_LIBRARY=%s ' % (dep.upper(), libso))

--- a/easybuild/easyblocks/n/netcdf.py
+++ b/easybuild/easyblocks/n/netcdf.py
@@ -78,10 +78,11 @@ class EB_netCDF(CMakeMake):
                     self.cfg.update('configopts', '-D%s_INCLUDE_DIR=%s ' % (dep.upper(), incdir))
                     if dep == 'HDF5':
                         env.setvar('HDF5_ROOT', dep_root)
+                        self.cfg.update('configopts', '-DUSE_HDF5=ON')
                         libhdf5 = os.path.join(dep_root, dep_libdir, 'libhdf5.%s' % shlib_ext)
-                        self.cfg.update('configopts', '-DHDF5_LIB=%s ' % libhdf5)
+                        self.cfg.update('configopts', '-DHDF5_C_LIBRARY=%s ' % libhdf5)
                         libhdf5_hl = os.path.join(dep_root, dep_libdir, 'libhdf5_hl.%s' % shlib_ext)
-                        self.cfg.update('configopts', '-DHDF5_HL_LIB=%s ' % libhdf5_hl)
+                        self.cfg.update('configopts', '-DHDF5_HL_LIBRARY=%s ' % libhdf5_hl)
                     elif dep == 'PnetCDF':
                         self.cfg.update('configopts', '-DENABLE_PNETCDF=ON')
                     else:

--- a/easybuild/easyblocks/n/netcdf.py
+++ b/easybuild/easyblocks/n/netcdf.py
@@ -87,6 +87,7 @@ class EB_netCDF(CMakeMake):
                         self.cfg.update('configopts', '-DUSE_HDF5=ON')
 
                         hdf5cmvars = {
+                            # library name: (cmake option suffix in netcdf<4.4, cmake option suffix in netcfd>=4.4)
                             'hdf5': ('LIB', 'C_LIBRARY'),
                             'hdf5_hl': ('HL_LIB', 'HL_LIBRARY'),
                         }

--- a/easybuild/easyblocks/n/netcdf4_python.py
+++ b/easybuild/easyblocks/n/netcdf4_python.py
@@ -56,6 +56,14 @@ class EB_netcdf4_minus_python(PythonPackage):
         if netcdf:
             env.setvar('NETCDF4_DIR', netcdf)
 
+        libjpeg = get_software_root('libjpeg-turbo')
+        if libjpeg:
+            env.setvar('JPEG_DIR', libjpeg)
+
+        curl = get_software_root('cURL')
+        if curl:
+            env.setvar('CURL_DIR', curl)
+
         super(EB_netcdf4_minus_python, self).configure_step()
 
     def test_step(self):


### PR DESCRIPTION
Currently `netcdf` sets wrong CMake variables for configuring the build with HDF5. Even though we can find the following comment in `CMakeLists.txt` 

> Accommodate developers who have hdf5 libraries and
> headers on their system, but do not have a the hdf
> .cmake files.  If this is the case, they should
> specify HDF5_HL_LIB, HDF5_LIB, HDF5_INCLUDE_DIR manually.

The variables are actually called `HDF5_C_LIBRARY` and `HDF5_HL_LIBRARY`. This PR fixes those variables and also adds support for building `netCDF` with `PnetCDF`.

These fixes for `netcdf` have been tested with
* netCDF-4.4.1-foss-2016b.eb
* netCDF-4.5.0-foss-2017b.eb
* netCDF-4.6.0-foss-2018a.eb
* netCDF-4.6.1-foss-2018b.eb
* netCDF-4.6.2-gompi-2019a.eb

Additionally, `netcdf4_python` is updated to properly handle external `cURL` and `JPEG` libraries.