### PR TITLE
handle incorrect regex better in generic CmdCp easyblock

### DIFF
--- a/easybuild/easyblocks/generic/cmdcp.py
+++ b/easybuild/easyblocks/generic/cmdcp.py
@@ -67,11 +67,11 @@ class CmdCp(MakeCp):
             # determine command to use
             # find (first) regex match, then complete matching command template
             cmd = None
-            for regex, regex_cmd in self.cfg['cmds_map']:
+            for pattern, regex_cmd in self.cfg['cmds_map']:
                 try:
-                    regex = re.compile(regex)
+                    regex = re.compile(pattern)
                 except re.error as err:
-                    raise EasyBuildError("Failed to compile regular expression '%s': %s", regex, err)
+                    raise EasyBuildError("Failed to compile regular expression '%s': %s", pattern, err)
 
                 if regex.match(os.path.basename(src)):
                     cmd = regex_cmd % {'source': src, 'target': target}

--- a/easybuild/easyblocks/generic/cmdcp.py
+++ b/easybuild/easyblocks/generic/cmdcp.py
@@ -68,7 +68,12 @@ class CmdCp(MakeCp):
             # find (first) regex match, then complete matching command template
             cmd = None
             for regex, regex_cmd in self.cfg['cmds_map']:
-                if re.match(regex, os.path.basename(src)):
+                try:
+                    regex = re.compile(regex)
+                except re.error as err:
+                    raise EasyBuildError("Failed to compile regular expression '%s': %s", regex, err)
+
+                if regex.match(os.path.basename(src)):
                     cmd = regex_cmd % {'source': src, 'target': target}
                     break
             if cmd is None:


### PR DESCRIPTION
If an incorrect regular expression like `'*'` (should be `'.*'`) is used in `cmds_map`, we get a nast traceback:

```
== building...
ERROR: Traceback (most recent call last):
  File "/work/lib/python2.7/site-packages/easybuild_framework-4.0.2.dev0-py2.7.egg/easybuild/main.py", line 112, in build_and_install_software
    (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env)
  File "/work/lib/python2.7/site-packages/easybuild_framework-4.0.2.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 3090, in build_and_install_one
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/work/lib/python2.7/site-packages/easybuild_framework-4.0.2.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2998, in run_all_steps
    self.run_step(step_name, step_methods)
  File "/work/lib/python2.7/site-packages/easybuild_framework-4.0.2.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2868, in run_step
    step_method(self)()
  File "/work/lib/python2.7/site-packages/easybuild_easyblocks-4.0.2.dev0-py2.7.egg/easybuild/easyblocks/generic/cmdcp.py", line 71, in build_step
    if re.match(regex, os.path.basename(src)):
  File "/usr/lib64/python2.7/re.py", line 137, in match
    return _compile(pattern, flags).match(string)
  File "/usr/lib64/python2.7/re.py", line 242, in _compile
    raise error, v # invalid expression
error: nothing to repeat
```

with this fix, a nicer error is reported:

```
== FAILED: Installation ended unsuccessfully (build directory: /tmp/easybuild_build/test/1.2.3):
build failed (first 300 chars): Failed to compile regular expression '*': nothing to repeat (took 20 sec)
```