### PR TITLE
fix intel and netcdf libdirs in NCL easyblock

### DIFF
--- a/easybuild/easyblocks/n/ncl.py
+++ b/easybuild/easyblocks/n/ncl.py
@@ -78,10 +78,10 @@ class EB_NCL(EasyBlock):
         ctof_libs = ''
         ifort = get_software_root('ifort')
         if ifort:
-            if LooseVersion(get_software_version('ifort')) < LooseVersion('2011.4'):
-                ctof_libs = '-lm -L%s/lib/intel64 -lifcore -lifport' % ifort
+            if os.path.exists('%s/lib/intel64/' % ifort) and os.access('%s/lib/intel64/' % ifort, os.R_OK):
+                ctof_libs += '-lm -L%s/lib/intel64/ -lifcore -lifport' % ifort
             else:
-                ctof_libs = '-lm -L%s/compilers_and_libraries/linux/lib/intel64/ -lifcore -lifport' % ifort
+                self.log.warning("Can't find a libdir for ifortran libraries -lifcore -lifport: %s/lib/intel64 doesn't exist or is not accessible." % (ifort, ifort))
         elif get_software_root('GCC'):
             ctof_libs = '-lgfortran -lm'
 

--- a/easybuild/easyblocks/n/ncl.py
+++ b/easybuild/easyblocks/n/ncl.py
@@ -81,8 +81,10 @@ class EB_NCL(EasyBlock):
             if os.path.exists('%s/lib/intel64/' % ifort) and os.access('%s/lib/intel64/' % ifort, os.R_OK):
                 ctof_libs += '-lm -L%s/lib/intel64/ -lifcore -lifport' % ifort
             else:
-                self.log.warning("Can't find a libdir for ifortran libraries -lifcore -lifport: "
-                "%s/lib/intel64 doesn't exist or is not accessible." % (ifort, ifort))
+                self.log.warning(
+                    "Can't find a libdir for ifortran libraries -lifcore -lifport: "
+                    "%s/lib/intel64 doesn't exist or is not accessible." % (ifort, ifort)
+                )
         elif get_software_root('GCC'):
             ctof_libs = '-lgfortran -lm'
 
@@ -144,8 +146,9 @@ class EB_NCL(EasyBlock):
             elif os.path.exists('%s/lib64' % root) and os.access('%s/lib64' % root, os.R_OK):
                 libs += ' -L%s/lib64 ' % root
             else:
-                self.log.warning("Can't find a libdir for dependency %s: "
-                "%s/lib and %s/lib64 don't exist." % (dep, root, root))
+                self.log.warning(
+                    "Can't find a libdir for dependency %s: %s/lib and %s/lib64 don't exist." % (dep, root, root)
+                )
 
             if os.path.exists('%s/include' % root) and os.access('%s/include' % root, os.R_OK):
                 includes += ' -I%s/include ' % root
@@ -166,13 +169,15 @@ class EB_NCL(EasyBlock):
                 elif os.path.exists('%s/lib64' % root) and os.access('%s/lib64' % root, os.R_OK):
                     libs += ' -L%s/lib64 %s ' % (root, libs_map[dep])
                 else:
-                    self.log.warning("Can't find a libdir for dependency %s: "
-                    "%s/lib and %s/lib64 don't exist." % (dep, root, root))
+                    self.log.warning(
+                        "Can't find a libdir for dependency %s: %s/lib and %s/lib64 don't exist." % (dep, root, root)
+                    )
 
                 if os.path.exists('%s/include' % root) and os.access('%s/include' % root, os.R_OK):
                     includes += ' -I%s/include ' % root
-                    self.log.warning("Can't find an include dir for dependency %s: "
-                    "%s/include doesn't exist." % (dep, root))
+                    self.log.warning(
+                        "Can't find an include dir for dependency %s: %s/include doesn't exist." % (dep, root)
+                    )
 
         cfgtxt="""#ifdef FirstSite
 #endif /* FirstSite */

--- a/easybuild/easyblocks/n/ncl.py
+++ b/easybuild/easyblocks/n/ncl.py
@@ -81,12 +81,13 @@ class EB_NCL(EasyBlock):
             if LooseVersion(get_software_version('ifort')) < LooseVersion('2011.4'):
                 ctof_libs = '-lm -L%s/lib/intel64 -lifcore -lifport' % ifort
             else:
-                ctof_libs = '-lm -L%s/compiler/lib/intel64 -lifcore -lifport' % ifort
+                ctof_libs = '-lm -L%s/compilers_and_libraries/linux/lib/intel64/ -lifcore -lifport' % ifort
         elif get_software_root('GCC'):
             ctof_libs = '-lgfortran -lm'
 
         macrodict = {
             'CCompiler': os.getenv('CC'),
+            'CxxCompiler': os.getenv('CXX'),
             'FCompiler': os.getenv('F90'),
             'CcOptions': '-ansi %s' % os.getenv('CFLAGS'),
             'FcOptions': os.getenv('FFLAGS'),
@@ -135,8 +136,19 @@ class EB_NCL(EasyBlock):
             root = get_software_root(dep)
             if not root:
                 raise EasyBuildError("%s not available", dep)
-            libs += ' -L%s/lib ' % root
-            includes += ' -I%s/include ' % root
+
+            # try %s/lib, if it doesn't exist, try %s/lib64
+            if os.path.exists('%s/lib' % root) and os.access('%s/lib' % root, os.R_OK):
+                libs += ' -L%s/lib ' % root
+            elif os.path.exists('%s/lib64' % root) and os.access('%s/lib64' % root, os.R_OK):
+                libs += ' -L%s/lib64 ' % root
+            else:
+                self.log.warning("Can't find a libdir for dependency %s: %s/lib and %s/lib64 don't exist." % (dep, root, root))
+
+            if os.path.exists('%s/include' % root) and os.access('%s/include' % root, os.R_OK):
+                includes += ' -I%s/include ' % root
+            else:
+                self.log.warning("Can't find an include dir for dependency %s: %s/include doesn't exist." % (dep, root))
 
         opt_deps = ["netCDF-Fortran", "GDAL"]
         libs_map = {
@@ -146,8 +158,17 @@ class EB_NCL(EasyBlock):
         for dep in opt_deps:
             root = get_software_root(dep)
             if root:
-                libs += ' -L%s/lib %s ' % (root, libs_map[dep])
-                includes += ' -I%s/include ' % root
+                # try %s/lib, if it doesn't exist, try %s/lib64
+                if os.path.exists('%s/lib' % root) and os.access('%s/lib' % root, os.R_OK):
+                    libs += ' -L%s/lib %s ' % (root, libs_map[dep])
+                elif os.path.exists('%s/lib64' % root) and os.access('%s/lib64' % root, os.R_OK):
+                    libs += ' -L%s/lib64 %s ' % (root, libs_map[dep])
+                else:
+                    self.log.warning("Can't find a libdir for dependency %s: %s/lib and %s/lib64 don't exist." % (dep, root, root))
+
+                if os.path.exists('%s/include' % root) and os.access('%s/include' % root, os.R_OK):
+                    includes += ' -I%s/include ' % root
+                    self.log.warning("Can't find an include dir for dependency %s: %s/include doesn't exist." % (dep, root))
 
         cfgtxt="""#ifdef FirstSite
 #endif /* FirstSite */

--- a/easybuild/easyblocks/n/ncl.py
+++ b/easybuild/easyblocks/n/ncl.py
@@ -81,7 +81,8 @@ class EB_NCL(EasyBlock):
             if os.path.exists('%s/lib/intel64/' % ifort) and os.access('%s/lib/intel64/' % ifort, os.R_OK):
                 ctof_libs += '-lm -L%s/lib/intel64/ -lifcore -lifport' % ifort
             else:
-                self.log.warning("Can't find a libdir for ifortran libraries -lifcore -lifport: %s/lib/intel64 doesn't exist or is not accessible." % (ifort, ifort))
+                self.log.warning("Can't find a libdir for ifortran libraries -lifcore -lifport: "
+                "%s/lib/intel64 doesn't exist or is not accessible." % (ifort, ifort))
         elif get_software_root('GCC'):
             ctof_libs = '-lgfortran -lm'
 
@@ -143,7 +144,8 @@ class EB_NCL(EasyBlock):
             elif os.path.exists('%s/lib64' % root) and os.access('%s/lib64' % root, os.R_OK):
                 libs += ' -L%s/lib64 ' % root
             else:
-                self.log.warning("Can't find a libdir for dependency %s: %s/lib and %s/lib64 don't exist." % (dep, root, root))
+                self.log.warning("Can't find a libdir for dependency %s: "
+                "%s/lib and %s/lib64 don't exist." % (dep, root, root))
 
             if os.path.exists('%s/include' % root) and os.access('%s/include' % root, os.R_OK):
                 includes += ' -I%s/include ' % root
@@ -164,11 +166,13 @@ class EB_NCL(EasyBlock):
                 elif os.path.exists('%s/lib64' % root) and os.access('%s/lib64' % root, os.R_OK):
                     libs += ' -L%s/lib64 %s ' % (root, libs_map[dep])
                 else:
-                    self.log.warning("Can't find a libdir for dependency %s: %s/lib and %s/lib64 don't exist." % (dep, root, root))
+                    self.log.warning("Can't find a libdir for dependency %s: "
+                    "%s/lib and %s/lib64 don't exist." % (dep, root, root))
 
                 if os.path.exists('%s/include' % root) and os.access('%s/include' % root, os.R_OK):
                     includes += ' -I%s/include ' % root
-                    self.log.warning("Can't find an include dir for dependency %s: %s/include doesn't exist." % (dep, root))
+                    self.log.warning("Can't find an include dir for dependency %s: "
+                    "%s/include doesn't exist." % (dep, root))
 
         cfgtxt="""#ifdef FirstSite
 #endif /* FirstSite */

--- a/easybuild/easyblocks/n/ncl.py
+++ b/easybuild/easyblocks/n/ncl.py
@@ -83,7 +83,7 @@ class EB_NCL(EasyBlock):
             else:
                 self.log.warning(
                     "Can't find a libdir for ifortran libraries -lifcore -lifport: "
-                    "%s/lib/intel64 doesn't exist or is not accessible." % (ifort, ifort)
+                    "%s/lib/intel64 doesn't exist or is not accessible." % ifort
                 )
         elif get_software_root('GCC'):
             ctof_libs = '-lgfortran -lm'


### PR DESCRIPTION
This PR fixes the

```
libnetcdf.so.13 => not found
libiomp5.so => not found
libifcore.so.5 => not found
libifport.so.5 => not found
```

errors for the RPATH sanity check of NCL-6.6.2 (i.e. this issue: https://github.com/easybuilders/easybuild-easyblocks/issues/1858)

