### PR TITLE
change Bazel easyblock to prefer using Java dependency rather than includued JDK (fix for POWER9)

### DIFF
--- a/easybuild/easyblocks/b/bazel.py
+++ b/easybuild/easyblocks/b/bazel.py
@@ -96,7 +96,15 @@ class EB_Bazel(EasyBlock):
             self.log.info("Not patching Bazel build scripts, installation prefix for binutils/GCC not found")
 
         # enable building in parallel
-        env.setvar('EXTRA_BAZEL_ARGS', '--jobs=%d' % self.cfg['parallel'])
+        bazel_args = '--jobs=%d' % self.cfg['parallel']
+
+        # Bazel provides a JDK by itself for some architectures
+        # We want to enforce it using the JDK we provided via modules
+        # This is required for Power where Bazel does not have a JDK, but requires it for building itself
+        # See https://github.com/bazelbuild/bazel/issues/10377
+        bazel_args += ' --host_javabase=@local_jdk//:jdk'
+
+        env.setvar('EXTRA_BAZEL_ARGS', bazel_args)
 
     def build_step(self):
         """Custom build procedure for Bazel."""


### PR DESCRIPTION
Bazel fails to install on Power9 because it tried to download and install an (internal?) JDK but does not provide one for PPC.

This fixes the installation by using the "local jdk", supposedly the one in the current environment which is probably even the right thing to do for EB (or Java could be made a build dependency)

Related issues: https://github.com/easybuilders/easybuild-easyconfigs/issues/9450 and https://github.com/bazelbuild/bazel/issues/10377