### PR TITLE
[Python] Remove obsolete configure args, build with optimizations + build with LTO for GCC >= 8.0

### DIFF
--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -109,6 +109,7 @@ class EB_Python(ConfigureMake):
         extra_vars = {
             'ulimit_unlimited': [False, "Ensure stack size limit is set to '%s' during build" % UNLIMITED, CUSTOM],
             'ebpythonprefixes': [True, "Create sitecustomize.py and allow use of $EBPYTHONPREFIXES", CUSTOM],
+            'optimized': [True, "Enable expensive, stable optimizations (PGO, etc)", CUSTOM],
         }
         return ConfigureMake.extra_options(extra_vars)
 
@@ -156,6 +157,10 @@ class EB_Python(ConfigureMake):
                 self.cfg.update('configopts', "--enable-unicode=ucs2")
             else:
                 raise EasyBuildError("Unknown maxunicode value for your python: %d" % sys.maxunicode)
+
+        # Enable further optimizations at the cost of a longer build
+        if self.cfg['optimized'] and LooseVersion(self.version) >= LooseVersion('3.5.3'):
+            self.cfg.update('configopts', "--enable-optimizations")
 
         modules_setup_dist = os.path.join(self.cfg['start_dir'], 'Modules', 'Setup.dist')
 

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -141,15 +141,21 @@ class EB_Python(ConfigureMake):
 
     def configure_step(self):
         """Set extra configure options."""
-        self.cfg.update('configopts', "--with-threads --enable-shared")
+        self.cfg.update('configopts', "--enable-shared")
 
+        # Explicitely enable thread support on < 3.7 (always on 3.7+)
+        if LooseVersion(self.version) < LooseVersion('3.7'):
+            self.cfg.update('configopts', "--with-threads")
+
+        # Explicitely enable unicode on Python 2, always on for Python 3
         # Need to be careful to match the unicode settings to the underlying python
-        if sys.maxunicode == 1114111:
-            self.cfg.update('configopts', "--enable-unicode=ucs4")
-        elif sys.maxunicode == 65535:
-            self.cfg.update('configopts', "--enable-unicode=ucs2")
-        else:
-            raise EasyBuildError("Unknown maxunicode value for your python: %d" % sys.maxunicode)
+        if LooseVersion(self.version) < LooseVersion('3.0'):
+            if sys.maxunicode == 1114111:
+                self.cfg.update('configopts', "--enable-unicode=ucs4")
+            elif sys.maxunicode == 65535:
+                self.cfg.update('configopts', "--enable-unicode=ucs2")
+            else:
+                raise EasyBuildError("Unknown maxunicode value for your python: %d" % sys.maxunicode)
 
         modules_setup_dist = os.path.join(self.cfg['start_dir'], 'Modules', 'Setup.dist')
 

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -49,6 +49,7 @@ from easybuild.tools.modules import get_software_libdir, get_software_root, get_
 from easybuild.tools.filetools import symlink, write_file
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
+import easybuild.tools.toolchain as toolchain
 
 
 EXTS_FILTER_PYTHON_PACKAGES = ('python -c "import %(ext_name)s"', "")
@@ -109,7 +110,11 @@ class EB_Python(ConfigureMake):
         extra_vars = {
             'ulimit_unlimited': [False, "Ensure stack size limit is set to '%s' during build" % UNLIMITED, CUSTOM],
             'ebpythonprefixes': [True, "Create sitecustomize.py and allow use of $EBPYTHONPREFIXES", CUSTOM],
-            'use_lto': [False, "Build with Link Time Optimization. Potentially unstable on some toolchains", CUSTOM],
+            'use_lto': [
+                None,
+                "Build with Link Time Optimization. Potentially unstable on some toolchains. Default: Auto-detect",
+                CUSTOM
+                ],
             'optimized': [True, "Enable expensive, stable optimizations (PGO, etc)", CUSTOM],
         }
         return ConfigureMake.extra_options(extra_vars)
@@ -141,6 +146,17 @@ class EB_Python(ConfigureMake):
                 self.log.debug(msg, param, self.cfg[param])
             self.cfg[param] = ''
 
+    def auto_detect_lto_support(self):
+        """Return True, if LTO should be enabled for current toolchain"""
+        result = False
+        # GCC >= 8 should be stable enough for LTO
+        if self.toolchain.comp_family() == toolchain.GCC:
+            gcc_ver = get_software_version('GCCcore') or get_software_version('GCC')
+            if gcc_ver and LooseVersion(gcc_ver) >= LooseVersion('8.0'):
+                self.log.info("Auto-enabling LTO since GCC >= v8.0 is used as toolchain compiler")
+                result = True
+        return result
+
     def configure_step(self):
         """Set extra configure options."""
         self.cfg.update('configopts', "--enable-shared")
@@ -159,11 +175,17 @@ class EB_Python(ConfigureMake):
             else:
                 raise EasyBuildError("Unknown maxunicode value for your python: %d" % sys.maxunicode)
 
-        if self.cfg['use_lto'] and LooseVersion(self.version) >= LooseVersion('3.7.0'):
-            self.cfg.update('configopts', "--with-lto")
+        # LTO introduced in 3.7.0
+        if LooseVersion(self.version) >= LooseVersion('3.7.0'):
+            use_lto = self.cfg['use_lto']
+            if use_lto is None:
+                use_lto = self.auto_detect_lto_support()
+            if use_lto:
+                self.cfg.update('configopts', "--with-lto")
 
         # Enable further optimizations at the cost of a longer build
-        if self.cfg['optimized'] and LooseVersion(self.version) >= LooseVersion('3.5.3'):
+        # Introduced in 3.5.3, fixed in 3.5.4: https://docs.python.org/3.5/whatsnew/changelog.html
+        if self.cfg['optimized'] and LooseVersion(self.version) >= LooseVersion('3.5.4'):
             self.cfg.update('configopts', "--enable-optimizations")
 
         modules_setup_dist = os.path.join(self.cfg['start_dir'], 'Modules', 'Setup.dist')

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -109,6 +109,7 @@ class EB_Python(ConfigureMake):
         extra_vars = {
             'ulimit_unlimited': [False, "Ensure stack size limit is set to '%s' during build" % UNLIMITED, CUSTOM],
             'ebpythonprefixes': [True, "Create sitecustomize.py and allow use of $EBPYTHONPREFIXES", CUSTOM],
+            'use_lto': [False, "Build with Link Time Optimization. Potentially unstable on some toolchains", CUSTOM],
             'optimized': [True, "Enable expensive, stable optimizations (PGO, etc)", CUSTOM],
         }
         return ConfigureMake.extra_options(extra_vars)
@@ -157,6 +158,9 @@ class EB_Python(ConfigureMake):
                 self.cfg.update('configopts', "--enable-unicode=ucs2")
             else:
                 raise EasyBuildError("Unknown maxunicode value for your python: %d" % sys.maxunicode)
+
+        if self.cfg['use_lto'] and LooseVersion(self.version) >= LooseVersion('3.7.0'):
+            self.cfg.update('configopts', "--with-lto")
 
         # Enable further optimizations at the cost of a longer build
         if self.cfg['optimized'] and LooseVersion(self.version) >= LooseVersion('3.5.3'):


### PR DESCRIPTION
Current Python versions (3.0+ for unicode, 3.7+ for threads) include the asked features and removed the configure options resulting in `configure: WARNING: unrecognized options: --enable-unicode`

This PR removes those for the relevant python versions (checked on source checkouts)

Additionally Python 3.5.3 introduced optimized builds employing PGO and LTO for faster runtimes. Users report 5-30% improvement (see https://github.com/deadsnakes/python3.6/pull/1) As EB is HPC centric using an optimized Python-runtime makes sense to me.

On the downside this adds 1h to the build time on our power machine due to the double build and test runs.

I added options to both enable the optimized build as well as `--with-lto` which does not use profiling to speed up runtime but cross-object-optimizations. That will be easier on build time (expected slight increase) but with less performance benefit. Both can be combined

As a follow-up I'd suggest making output like "WARNING: unrecognized options: " a hard failure to detect changed configure arguments. Imagine this was an important option or e.g. a rename (as happened from `--with-optimizations` to `--enable-optimizations`)