### PR TITLE
disable running of 'sudo apt-get update' in GitHub CI config, since it's failing (and we don't really need it)

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -42,7 +42,10 @@ jobs:
 
     - name: install OS & Python packages
       run: |
-        sudo apt-get update
+        # apt-get update is disabled for now, because it was failing in GitHub since Fri Dec 13th 2019,
+        # due to 'Conflicting distribution' issue
+        # sudo apt-get update
+
         # for modules tool
         sudo apt-get install lua5.2 liblua5.2-dev lua-filesystem lua-posix tcl tcl-dev
         # fix for lua-posix packaging issue, see https://bugs.launchpad.net/ubuntu/+source/lua-posix/+bug/1752082


### PR DESCRIPTION
(see also https://github.com/easybuilders/easybuild-easyconfigs/pull/9492)