### PR TITLE
make sure $LIBLAPACK_MT is set before using it in ESMF easyblock

### DIFF
--- a/easybuild/easyblocks/e/esmf.py
+++ b/easybuild/easyblocks/e/esmf.py
@@ -73,11 +73,11 @@ class EB_ESMF(ConfigureMake):
         # specify decent LAPACK lib
         env.setvar('ESMF_LAPACK', 'user')
         ldflags = os.getenv('LDFLAGS')
-        liblapack_mt = os.getenv('LIBLAPACK_MT')
-        if liblapack_mt is None:
-            raise EasyBuildError("$LIBLAPACK_MT not defined, no BLAS/LAPACK in %s toolchain?", self.toolchain.name)
+        liblapack = os.getenv('LIBLAPACK_MT') or os.getenv('LIBLAPACK')
+        if liblapack is None:
+            raise EasyBuildError("$LIBLAPACK(_MT) not defined, no BLAS/LAPACK in %s toolchain?", self.toolchain.name)
         else:
-            env.setvar('ESMF_LAPACK_LIBS', ldflags + ' ' + liblapack_mt)
+            env.setvar('ESMF_LAPACK_LIBS', ldflags + ' ' + liblapack)
 
         # specify netCDF
         netcdf = get_software_root('netCDF')

--- a/easybuild/easyblocks/e/esmf.py
+++ b/easybuild/easyblocks/e/esmf.py
@@ -29,13 +29,12 @@ EasyBuild support for building and installing ESMF, implemented as an easyblock
 @author: Damian Alvarez (Forschungszentrum Juelich GmbH)
 """
 import os
+from distutils.version import LooseVersion
 
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain
-from distutils.version import LooseVersion
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
-from easybuild.framework.easyblock import EasyBlock
-from easybuild.framework.easyconfig import BUILD
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
@@ -73,7 +72,12 @@ class EB_ESMF(ConfigureMake):
 
         # specify decent LAPACK lib
         env.setvar('ESMF_LAPACK', 'user')
-        env.setvar('ESMF_LAPACK_LIBS', '%s %s' % (os.getenv('LDFLAGS'), os.getenv('LIBLAPACK_MT')))
+        ldflags = os.getenv('LDFLAGS')
+        liblapack_mt = os.getenv('LIBLAPACK_MT')
+        if liblapack_mt is None:
+            raise EasyBuildError("$LIBLAPACK_MT not defined, no BLAS/LAPACK in %s toolchain?", self.toolchain.name)
+        else:
+            env.setvar('ESMF_LAPACK_LIBS', ldflags + ' ' + liblapack_mt)
 
         # specify netCDF
         netcdf = get_software_root('netCDF')
@@ -109,12 +113,11 @@ class EB_ESMF(ConfigureMake):
 
     def sanity_check_step(self):
         """Custom sanity check for ESMF."""
-        shlib_ext = get_shared_lib_ext()
 
+        binaries = ['ESMF_Info', 'ESMF_InfoC', 'ESMF_RegridWeightGen', 'ESMF_WebServController']
+        libs = ['libesmf.a', 'libesmf.%s' % get_shared_lib_ext()]
         custom_paths = {
-            'files':
-                [os.path.join('bin', x) for x in ['ESMF_Info', 'ESMF_InfoC', 'ESMF_RegridWeightGen', 'ESMF_WebServController']] +
-                [os.path.join('lib', x) for x in ['libesmf.a', 'libesmf.%s' % shlib_ext]],
+            'files': [os.path.join('bin', x) for x in binaries] + [os.path.join('lib', x) for x in libs],
             'dirs': ['include', 'mod'],
         }
 


### PR DESCRIPTION
When looking into a new easyconfig for the latest version of ESMF, I tried installing it with the `iimpi` toolchain which led to a confusing compilation problem involving `None`.

The problem was that `$LIBLAPACK_MT` was not defined in the environment, but the ESMF easyblock was using the value obtained via `os.getenv('LIBLAPACK_MT')` (which yields `None` if `$LIBLAPACK_MT` is not defined) without checking it...