### PR TITLE
update $PYTHONPATH + add "python -c 'import mrtrix3'" as sanity check command for recent MRtrix versions

### DIFF
--- a/easybuild/easyblocks/m/mrtrix.py
+++ b/easybuild/easyblocks/m/mrtrix.py
@@ -93,7 +93,12 @@ class EB_MRtrix(EasyBlock):
         also consider 'scripts' subdirectory for $PATH
         """
         guesses = super(EB_MRtrix, self).make_module_req_guess()
+
         guesses['PATH'].append('scripts')
+
+        if LooseVersion(self.version) >= LooseVersion('3.0'):
+            guesses.setdefault('PYTHONPATH', []).append('lib')
+
         return guesses
 
     def sanity_check_step(self):
@@ -108,4 +113,9 @@ class EB_MRtrix(EasyBlock):
             'files': [os.path.join('lib', libso)],
             'dirs': ['bin'],
         }
-        super(EB_MRtrix, self).sanity_check_step(custom_paths=custom_paths)
+
+        custom_commands = []
+        if LooseVersion(self.version) >= LooseVersion('3.0'):
+            custom_commands.append("python -c 'import mrtrix3'")
+
+        super(EB_MRtrix, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)


### PR DESCRIPTION
Several of the scripts installed with `MRtrix` are not usable now because we're not updating `$PYTHONPATH` such that the Python bindings work out of the box...