### PR TITLE
skip patch step in Bundle generic easyblock (per-component patches are still applied)

### DIFF
--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -175,6 +175,10 @@ class Bundle(EasyBlock):
 
         return checksum_issues
 
+    def patch_step(self):
+        """Patch step must be a no-op for bundle, since there are no top-level sources/patches."""
+        pass
+
     def configure_step(self):
         """Collect altroot/altversion info."""
         # pick up altroot/altversion, if they are defined


### PR DESCRIPTION
requires because of changes in #1897, to avoid breaking easyconfigs that include a component that has one or more patch files (like `X11-20171023-GCCcore-6.4.0.eb`):

```
ERROR: Build of /easybuild-easyconfigs/easybuild/easyconfigs/x/X11/X11-20171023-GCCcore-6.4.0.eb failed (err: "build failed (first 300 chars):
Can't determine patch level for patch /easybuild-easyconfigs/easybuild/easyconfigs/x/X11/libxcb-1.12_indent.patch from directory /tmp/build/X11/20171023/GCCcore-6.4.0/util-macros-1.19.1")
```