### PR TITLE
derive easyblock for iccifort only from icc easyblock (not ifort)

### DIFF
--- a/easybuild/easyblocks/i/iccifort.py
+++ b/easybuild/easyblocks/i/iccifort.py
@@ -35,7 +35,11 @@ from easybuild.easyblocks.icc import EB_icc
 from easybuild.easyblocks.ifort import EB_ifort
 
 
-class EB_iccifort(EB_ifort, EB_icc):
+# EB_icc is derived from because its make_module_req_guess deliberately omits 'include' for CPATH:
+# including it causes problems, e.g. with complex.h and std::complex
+# cfr. https://software.intel.com/en-us/forums/intel-c-compiler/topic/338378
+# EB_ifort adds 'include' there but only needed if icc and ifort are separate
+class EB_iccifort(EB_icc):
     """
     Class that can be used to install iccifort
     """

--- a/easybuild/easyblocks/i/iccifort.py
+++ b/easybuild/easyblocks/i/iccifort.py
@@ -35,11 +35,7 @@ from easybuild.easyblocks.icc import EB_icc
 from easybuild.easyblocks.ifort import EB_ifort
 
 
-# EB_icc is derived from because its make_module_req_guess deliberately omits 'include' for CPATH:
-# including it causes problems, e.g. with complex.h and std::complex
-# cfr. https://software.intel.com/en-us/forums/intel-c-compiler/topic/338378
-# EB_ifort adds 'include' there but only needed if icc and ifort are separate
-class EB_iccifort(EB_icc):
+class EB_iccifort(EB_ifort, EB_icc):
     """
     Class that can be used to install iccifort
     """
@@ -59,3 +55,10 @@ class EB_iccifort(EB_icc):
         txt += self.module_generator.set_environment('EBVERSIONIFORT', self.version)
 
         return txt
+
+    def make_module_req_guess(self):
+        # Use EB_icc because its make_module_req_guess deliberately omits 'include' for CPATH:
+        # including it causes problems, e.g. with complex.h and std::complex
+        # cfr. https://software.intel.com/en-us/forums/intel-c-compiler/topic/338378
+        # whereas EB_ifort adds 'include' but that's only needed if icc and ifort are separate
+        return EB_icc.make_module_req_guess(self)


### PR DESCRIPTION
EB_ifort is problematic since the module guesses include
$EBROOTICCIFORT/include which should not be added to CPATH
for a joint icc/ifort installation.