### PR TITLE
imkl: remove useless PATH entries, add PKG_CONFIG_PATH

### DIFF
--- a/easybuild/easyblocks/i/imkl.py
+++ b/easybuild/easyblocks/i/imkl.py
@@ -144,11 +144,12 @@ class EB_imkl(IntelBase):
                 raise EasyBuildError("32-bit not supported yet for IMKL v%s (>= 10.3)", self.version)
             else:
                 retdict = {
-                    'PATH': ['bin', 'mkl/bin', 'mkl/bin/intel64', 'composerxe-2011/bin'],
+                    'PATH': [],
                     'LD_LIBRARY_PATH': ['lib/intel64', 'mkl/lib/intel64'],
                     'LIBRARY_PATH': ['lib/intel64', 'mkl/lib/intel64'],
                     'MANPATH': ['man', 'man/en_US'],
                     'CPATH': ['mkl/include', 'mkl/include/fftw'],
+                    'PKG_CONFIG_PATH': ['mkl/bin/pkgconfig'],
                 }
                 if LooseVersion(self.version) >= LooseVersion('11.0'):
                     if LooseVersion(self.version) >= LooseVersion('11.3'):


### PR DESCRIPTION
MKL has no binaries, just useless (in easybuild context) scripts.
On the other hand it does have pkg-config entries that could be
useful:
https://software.intel.com/en-us/articles/intel-math-kernel-library-intel-mkl-and-pkg-config-tool