### PR TITLE
add export to preinstallopts instead of install_script path in CUDA easyblock

### DIFF
--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -115,7 +115,7 @@ class EB_CUDA(Binary):
                 }
 
         # Use C locale to avoid localized questions and crash on CUDA 10.1
-        install_script = "export LANG=C && " + install_script
+        self.cfg.update('preinstallopts', "export LANG=C && ")
 
         cmd = "%(preinstallopts)s %(interpreter)s %(script)s %(installopts)s" % {
             'preinstallopts': self.cfg['preinstallopts'],


### PR DESCRIPTION
otherwise it somewhere gets injected in the middle of the absolute path to the install script

```
Failed to read /tmp/mdiascosta/easybuild/build/CUDA/10.0.130/system-system/export LANG=C && cuda-installer.pl: [Errno 2] No such file or directory: '/tmp/mdiascosta/easybuild/build/CUDA/10.0.130/system-system/export LANG=C && cuda-installer.pl'
```