### PR TITLE
Don't set CPATH and LIBRARY_PATH any more for GCC and GCCcore.

### DIFF
--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -691,13 +691,14 @@ class EB_GCC(ConfigureMake):
 
     def make_module_req_guess(self):
         """
-        Make sure all GCC libs are in LD_LIBRARY_PATH
+        GCC can find its own headers and libraries but the .so's need to be in LD_LIBRARY_PATH
         """
         guesses = super(EB_GCC, self).make_module_req_guess()
         guesses.update({
             'PATH': ['bin'],
-            'LD_LIBRARY_PATH': ['lib', 'lib64',
-                                'lib/gcc/%s/%s' % (self.platform_lib, self.cfg['version'])],
+            'CPATH': [],
+            'LIBRARY_PATH': [],
+            'LD_LIBRARY_PATH': ['lib', 'lib64'],
             'MANPATH': ['man', 'share/man']
         })
         return guesses


### PR DESCRIPTION
GCC can find its own headers and libraries: only the .so's need to be in
LD_LIBRARY_PATH, which are only under lib (32bit) and lib64 (64bit).

Intel calls gcc -E and gcc -print-search-dirs to find them.

PGI stores the locations at installation time in configuration files
(localrc etc).