### PR TITLE
iccifort: remove LIBRARY_PATH entries already known to icc et al

### DIFF
--- a/easybuild/easyblocks/i/iccifort.py
+++ b/easybuild/easyblocks/i/iccifort.py
@@ -61,4 +61,12 @@ class EB_iccifort(EB_ifort, EB_icc):
         # including it causes problems, e.g. with complex.h and std::complex
         # cfr. https://software.intel.com/en-us/forums/intel-c-compiler/topic/338378
         # whereas EB_ifort adds 'include' but that's only needed if icc and ifort are separate
-        return EB_icc.make_module_req_guess(self)
+        guesses = EB_icc.make_module_req_guess(self)
+
+        # remove entries from LIBRARY_PATH that icc and co already know about at compile time
+        # only do this for iccifort merged installations so that icc can still find ifort
+        # libraries and vice versa for split installations
+        compiler_library_paths = [os.path.join(self.comp_libs_subdir, p)
+                                  for p in ('lib', 'compiler/lib/intel64', 'lib/ia32', 'lib/intel64')]
+        guesses['LIBRARY_PATH'] = [p for p in guesses['LIBRARY_PATH'] if p not in compiler_library_paths]
+        return guesses

--- a/easybuild/easyblocks/i/iccifort.py
+++ b/easybuild/easyblocks/i/iccifort.py
@@ -67,7 +67,8 @@ class EB_iccifort(EB_ifort, EB_icc):
         # remove entries from LIBRARY_PATH that icc and co already know about at compile time
         # only do this for iccifort merged installations so that icc can still find ifort
         # libraries and vice versa for split installations
-        compiler_library_paths = [os.path.join(self.comp_libs_subdir, p)
-                                  for p in ('lib', 'compiler/lib/intel64', 'lib/ia32', 'lib/intel64')]
-        guesses['LIBRARY_PATH'] = [p for p in guesses['LIBRARY_PATH'] if p not in compiler_library_paths]
+        if self.comp_libs_subdir is not None:
+            compiler_library_paths = [os.path.join(self.comp_libs_subdir, p)
+                                      for p in ('lib', 'compiler/lib/intel64', 'lib/ia32', 'lib/intel64')]
+            guesses['LIBRARY_PATH'] = [p for p in guesses['LIBRARY_PATH'] if p not in compiler_library_paths]
         return guesses

--- a/easybuild/easyblocks/i/iccifort.py
+++ b/easybuild/easyblocks/i/iccifort.py
@@ -31,6 +31,7 @@ EasyBuild support for installing the Intel compiler suite, implemented as an eas
 @author: Bart Oldeman (McGill University, Compute Canada)
 """
 
+import os
 from easybuild.easyblocks.icc import EB_icc
 from easybuild.easyblocks.ifort import EB_ifort
 


### PR DESCRIPTION
This makes it consistent with Intel's own script that don't set
LIBRARY_PATH either (except for aux components such as TBB)

But only do this for iccifort (single installation) so that in a split
installation icc can still find ifort's libraries and vice versa.