### PR TITLE
use major/minor version of Python command being used if req_py_majver/req_py_minver are not specified

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -211,8 +211,8 @@ class PythonPackage(ExtensionEasyBlock):
             'download_dep_fail': [None, "Fail if downloaded dependencies are detected", CUSTOM],
             'install_target': ['install', "Option to pass to setup.py", CUSTOM],
             'pip_ignore_installed': [True, "Let pip ignore installed Python packages (i.e. don't remove them)", CUSTOM],
-            'req_py_majver': [2, "Required major Python version (only relevant when using system Python)", CUSTOM],
-            'req_py_minver': [6, "Required minor Python version (only relevant when using system Python)", CUSTOM],
+            'req_py_majver': [None, "Required major Python version (only relevant when using system Python)", CUSTOM],
+            'req_py_minver': [None, "Required minor Python version (only relevant when using system Python)", CUSTOM],
             'sanity_pip_check': [False, "Run 'pip check' to ensure all required Python packages are installed", CUSTOM],
             'runtest': [True, "Run unit tests.", CUSTOM],  # overrides default
             'unpack_sources': [True, "Unpack sources prior to build/install", CUSTOM],
@@ -347,9 +347,9 @@ class PythonPackage(ExtensionEasyBlock):
 
     def prepare_python(self):
         """Python-specific preperations."""
+
         # pick 'python' command to use
         python = None
-
         python_root = get_software_root('Python')
         # keep in mind that Python may be listed as an allowed system dependency,
         # so just checking Python root is not sufficient
@@ -361,8 +361,17 @@ class PythonPackage(ExtensionEasyBlock):
                 self.log.debug("Retaining 'python' command for Python dependency: %s", python)
 
         if python is None:
+            # if no Python version requirements are specified,
+            # use major/minor version of Python being used in this EasyBuild session
+            req_py_majver = self.cfg['req_py_majver']
+            if req_py_majver is None:
+                req_py_majver = sys.version_info[0]
+            req_py_minver = self.cfg['req_py_minver']
+            if req_py_minver is None:
+                req_py_minver = sys.version_info[1]
+
             # if using system Python, go hunting for a 'python' command that satisfies the requirements
-            python = pick_python_cmd(req_maj_ver=self.cfg['req_py_majver'], req_min_ver=self.cfg['req_py_minver'])
+            python = pick_python_cmd(req_maj_ver=req_py_majver, req_min_ver=req_py_minver)
 
         if python:
             self.python_cmd = python


### PR DESCRIPTION
Important note: the part of the code being changed here is only relevant if `Python` is *not* included as a dependency, so it only affects a very limited amount of easyconfigs for Python software (mostly `EasyBuild` itself, but also `PyYAML` easyconfigs using the `system` toolchain, `ReFrame`, etc.).

The changes here fix the issue reported in https://github.com/easybuilders/easybuild-easyconfigs/issues/9151, where installing an `EasyBuild` easyconfig (for example via `eb --install-latest-eb-release`) fails in the sanity check, because the installation is performed using the system `python` command, while the sanity check paths are derived using the Python version that is used to run EasyBuild with (basically because `SYS_PYTHON_VERSION` is used in `allow_system_deps` in the `EasyBuild` easyconfigs).

By specifying that the major/minor Python version of the Python being used by EasyBuild itself (via `sys.version_info`) as requirement when picking the `python` command, the correct `python` command is picked, and things work out correctly...

We're changing the default value for `req_py_majver` and `req_py_minver` here, but that's OK to do imho since i) this doesn't affect easyconfigs which already set a different major/minor version (see `ReFrame` easyconfigs for example), and ii) the current default of requiring Python 2.6 was sort of dodgy anyway (it worked well while EasyBuild only supported Python 2, but not anymore).

This not only fixes the issue for `EasyBuild` reported in https://github.com/easybuilders/easybuild-easyconfigs/issues/9151, but also for `PyYAML-3.13.eb` for example (when the system `python` is Python 2.7, but EasyBuild itself is being run with Python 3.x).