### PR TITLE
define $EB_PYTHON in module for EasyBuild installation, to make sure correct Python version is used at runtime

### DIFF
--- a/easybuild/easyblocks/e/easybuildmeta.py
+++ b/easybuild/easyblocks/e/easybuildmeta.py
@@ -217,6 +217,14 @@ class EB_EasyBuildMeta(PythonPackage):
 
         super(EB_EasyBuildMeta, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
 
+    def make_module_extra(self):
+        """
+        Set $EB_PYTHON to ensure that this EasyBuild installation uses the same Python executable it was installed with.
+        """
+        txt = super(EB_EasyBuildMeta, self).make_module_extra()
+        txt += self.module_generator.set_environment('EB_PYTHON', self.python_cmd)
+        return txt
+
     def make_module_step(self, fake=False):
         """Create module file, before copy of original environment that was tampered with is restored."""
         modpath = super(EB_EasyBuildMeta, self).make_module_step(fake=fake)


### PR DESCRIPTION
If EasyBuild is being installed using `eb` that is running on top of a Python version that is anything else than the system `python` command, we need to make sure `$EB_PYTHON` is set so the `eb` command will use the correct `python` binary (basically the one it was installed with).

It should be OK to simply always define `$EB_PYTHON` in the generated `EasyBuild` module...