### PR TITLE
enhance tbb easyblock to support buuilding on POWER

### DIFF
--- a/easybuild/easyblocks/t/tbb.py
+++ b/easybuild/easyblocks/t/tbb.py
@@ -31,6 +31,7 @@ EasyBuild support for installing the Intel Threading Building Blocks (TBB) libra
 @author: Pieter De Baets (Ghent University)
 @author: Jens Timmerman (Ghent University)
 @author: Lumir Jasiok (IT4Innovations)
+@author: Simon Branford (University of Birmingham)
 """
 
 import glob
@@ -43,7 +44,7 @@ from easybuild.easyblocks.generic.intelbase import INSTALL_MODE_NAME_2015, INSTA
 from easybuild.easyblocks.generic.intelbase import IntelBase, ACTIVATION_NAME_2012, LICENSE_FILE_NAME_2012
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_version
-from easybuild.tools.systemtools import get_gcc_version, get_platform_name
+from easybuild.tools.systemtools import POWER, get_cpu_architecture, get_gcc_version, get_platform_name
 
 
 def get_tbb_gccprefix():
@@ -76,10 +77,13 @@ class EB_tbb(IntelBase, ConfigureMake):
 
         self.libpath = 'UNKNOWN'
         platform_name = get_platform_name()
+        myarch = get_cpu_architecture()
         if platform_name.startswith('x86_64'):
             self.arch = "intel64"
         elif platform_name.startswith('i386') or platform_name.startswith('i686'):
             self.arch = 'ia32'
+        elif myarch == POWER:
+            self.arch = 'ppc64'
         else:
             raise EasyBuildError("Failed to determine system architecture based on %s", platform_name)
 


### PR DESCRIPTION
I've successfully built https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/t/tbb/tbb-2019_U4-GCCcore-8.2.0.eb and https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/t/tbb/tbb-2019_U9-GCCcore-8.3.0.eb on ppc64le with this change.

And RELION 3.0.8 (which is based on the foss/2019a version in https://github.com/easybuilders/easybuild-easyconfigs/pull/9096) successfully find the required tbb libraries from https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/t/tbb/tbb-2019_U4-GCCcore-8.2.0.eb and compiles against them.