### PR TITLE
add custom easyconfig parameter 'buildtype' to generic CMakeMake easyblock

### DIFF
--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -73,6 +73,8 @@ class CMakeMake(ConfigureMake):
             'abs_path_compilers': [False, "Specify compilers via absolute file path (not via command names)", CUSTOM],
             'allow_system_boost': [False, "Always allow CMake to pick up on Boost installed in OS "
                                           "(even if Boost is included as a dependency)", CUSTOM],
+            'buildtype': [None, "Build type for CMake, e.g. Release or Debug."
+                                "Use None to not specify -DCMAKE_BUILD_TYPE", CUSTOM],
             'configure_cmd': [DEFAULT_CONFIGURE_CMD, "Configure command to use", CUSTOM],
             'srcdir': [None, "Source directory location to provide to cmake command", CUSTOM],
             'separate_build_dir': [False, "Perform build in a separate directory", CUSTOM],
@@ -101,6 +103,10 @@ class CMakeMake(ConfigureMake):
                 srcdir = default_srcdir
 
         options = ['-DCMAKE_INSTALL_PREFIX=%s' % self.installdir]
+
+        if self.cfg['buildtype'] is not None:
+            options.append("-DCMAKE_BUILD_TYPE=%s" % self.cfg['buildtype'])
+
         env_to_options = {
             'CC': 'CMAKE_C_COMPILER',
             'CFLAGS': 'CMAKE_C_FLAGS',


### PR DESCRIPTION
Heavily based on code from Ward Poelmans from #911

IMO setting the buildtype is valuable to not have to work with the quite verbose configopts.

Note that configopts is passed AFTER this option so it can still override CMAKE_BUILD_TYPE and that there is NO change to the default behavior: Nothing is added unless buildtype is set