### PR TITLE
Do not sanity check on MATLAB compiler

### DIFF
--- a/easybuild/easyblocks/m/matlab.py
+++ b/easybuild/easyblocks/m/matlab.py
@@ -168,9 +168,8 @@ class EB_MATLAB(PackedBinary):
     def sanity_check_step(self):
         """Custom sanity check for MATLAB."""
         custom_paths = {
-            'files': ["bin/matlab", "bin/glnxa64/MATLAB",
-                      "runtime/glnxa64/libmwmclmcrrt.%s" % get_shared_lib_ext(), "toolbox/local/classpath.txt"],
-            'dirs': ["java/jar", "toolbox/compiler"],
+            'files': ["bin/matlab", "bin/glnxa64/MATLAB", "toolbox/local/classpath.txt"],
+            'dirs': ["java/jar"],
         }
         super(EB_MATLAB, self).sanity_check_step(custom_paths=custom_paths)
 


### PR DESCRIPTION
I would suggest removing the sanity checks on the MATLAB compiler, since it is a separate license (which for example is not included at my institution).