### PR TITLE
Build HDF5 without MPI C++ extension

### DIFF
--- a/easybuild/easyblocks/h/hdf5.py
+++ b/easybuild/easyblocks/h/hdf5.py
@@ -84,6 +84,9 @@ class EB_HDF5(ConfigureMake):
             mpich_mpi_families = [toolchain.INTELMPI, toolchain.MPICH, toolchain.MPICH2, toolchain.MVAPICH2]
             if self.toolchain.mpi_family() in mpich_mpi_families:
                 self.cfg.update('buildopts', 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"')
+            # Skip MPI cxx extensions to avoid hard dependency
+            if self.toolchain.mpi_family() in toolchain.OPENMPI:
+                self.cfg.update('buildopts', 'CXXFLAGS="$CXXFLAGS -DOMPI_SKIP_MPICXX"')
         else:
             self.cfg.update('configopts', "--disable-parallel")
 


### PR DESCRIPTION
This avoids the direct dependency on MPI/MPI cxx for consumers even for C libraries

I verified that this flag is not passed to consumer by means of `h5cc -show` and `h5c++ -show` or in fact anything else (grep used)