### PR TITLE
change various easyblock deriving from CMakeMake to use 'build_type' easyconfig parameter

### DIFF
--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -70,7 +70,8 @@ class EB_Clang(CMakeMake):
 
     @staticmethod
     def extra_options():
-        extra_vars = {
+        extra_vars = CMakeMake.extra_options()
+        extra_vars.update({
             'assertions': [True, "Enable assertions.  Helps to catch bugs in Clang.", CUSTOM],
             'build_targets': [None, "Build targets for LLVM (host architecture if None). Possible values: " +
                                     ', '.join(CLANG_TARGETS), CUSTOM],
@@ -84,9 +85,9 @@ class EB_Clang(CMakeMake):
             'skip_all_tests': [False, "Skip running of tests", CUSTOM],
             # The sanitizer tests often fail on HPC systems due to the 'weird' environment.
             'skip_sanitizer_tests': [True, "Do not run the sanitizer tests", CUSTOM],
-        }
-
-        return CMakeMake.extra_options(extra_vars)
+        })
+        extra_vars['build_type'][0] = 'Release'
+        return extra_vars
 
     def __init__(self, *args, **kwargs):
         """Initialize custom class variables for Clang."""
@@ -226,7 +227,6 @@ class EB_Clang(CMakeMake):
         self.log.debug("Using %s as GCC_INSTALL_PREFIX", gcc_prefix)
 
         # Configure some default options
-        self.cfg.update('configopts', "-DCMAKE_BUILD_TYPE=Release")
         if self.cfg["enable_rtti"]:
             self.cfg.update('configopts', '-DLLVM_REQUIRES_RTTI=ON')
             self.cfg.update('configopts', '-DLLVM_ENABLE_RTTI=ON')

--- a/easybuild/easyblocks/d/dirac.py
+++ b/easybuild/easyblocks/d/dirac.py
@@ -31,9 +31,7 @@ import shutil
 import tempfile
 
 import easybuild.tools.environment as env
-import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
-from easybuild.framework.easyconfig import CUSTOM, MANDATORY
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option
 from easybuild.tools.run import run_cmd
@@ -41,6 +39,12 @@ from easybuild.tools.run import run_cmd
 
 class EB_DIRAC(CMakeMake):
     """Support for building/installing DIRAC."""
+
+    @staticmethod
+    def extra_options():
+        extra_vars = CMakeMake.extra_options()
+        extra_vars['build_type'][0] = 'release'  # TODO: Verify if this is really lowercase
+        return extra_vars
 
     def configure_step(self):
         """Custom configuration procedure for DIRAC."""
@@ -54,7 +58,7 @@ class EB_DIRAC(CMakeMake):
                 raise EasyBuildError("Failed to remove existing install directory %s: %s", self.installdir, err)
 
         self.cfg['separate_build_dir'] = True
-        self.cfg.update('configopts', "-DENABLE_MPI=ON -DCMAKE_BUILD_TYPE=release")
+        self.cfg.update('configopts', "-DENABLE_MPI=ON")
 
         # complete configuration with configure_method of parent
         super(EB_DIRAC, self).configure_step()

--- a/easybuild/easyblocks/d/dolfin.py
+++ b/easybuild/easyblocks/d/dolfin.py
@@ -47,6 +47,12 @@ from easybuild.tools.systemtools import get_shared_lib_ext
 class EB_DOLFIN(CMakePythonPackage):
     """Support for building and installing DOLFIN."""
 
+    @staticmethod
+    def extra_options():
+        extra_vars = CMakePythonPackage.extra_options()
+        extra_vars['build_type'][0] = 'Release'
+        return extra_vars
+
     def __init__(self, *args, **kwargs):
         """Initialize class variables."""
         super(EB_DOLFIN, self).__init__(*args, **kwargs)
@@ -80,9 +86,6 @@ class EB_DOLFIN(CMakePythonPackage):
         self.cfg.update('configopts', '-DCMAKE_CXX_FLAGS="%s"' % cxxflags)
         self.cfg.update('configopts', '-DCMAKE_Fortran_FLAGS="%s"' % fflags)
 
-        # run cmake in debug mode
-        self.cfg.update('configopts', '-DCMAKE_BUILD_TYPE=Debug')
-
         # set correct compilers to be used at runtime
         self.cfg.update('configopts', '-DMPI_C_COMPILER="$MPICC"')
         self.cfg.update('configopts', '-DMPI_CXX_COMPILER="$MPICXX"')
@@ -90,7 +93,7 @@ class EB_DOLFIN(CMakePythonPackage):
         # specify MPI library
         self.cfg.update('configopts', '-DMPI_COMPILER="%s"' % os.getenv('MPICC'))
 
-        if  os.getenv('MPI_LIB_SHARED') and os.getenv('MPI_INC_DIR'):
+        if os.getenv('MPI_LIB_SHARED') and os.getenv('MPI_INC_DIR'):
             self.cfg.update('configopts', '-DMPI_LIBRARY="%s"' % os.getenv('MPI_LIB_SHARED'))
             self.cfg.update('configopts', '-DMPI_INCLUDE_PATH="%s"' % os.getenv('MPI_INC_DIR'))
         else:
@@ -126,7 +129,7 @@ class EB_DOLFIN(CMakePythonPackage):
             if not deproot:
                 raise EasyBuildError("Dependency %s not available.", dep)
             else:
-                depsdict.update({dep:deproot})
+                depsdict.update({dep: deproot})
 
         # zlib
         self.cfg.update('configopts', '-DZLIB_INCLUDE_DIR=%s' % os.path.join(depsdict['zlib'], "include"))
@@ -173,7 +176,7 @@ class EB_DOLFIN(CMakePythonPackage):
             '-DCOLAMD_LIBRARY:PATH="%(sp)s/COLAMD/lib/libcolamd.a"'
         ]
 
-        self.cfg.update('configopts', ' '.join(umfpack_params) % {'sp':suitesparse})
+        self.cfg.update('configopts', ' '.join(umfpack_params) % {'sp': suitesparse})
 
         # ParMETIS and SCOTCH
         self.cfg.update('configopts', '-DPARMETIS_DIR="%s"' % depsdict['ParMETIS'])
@@ -272,13 +275,14 @@ class EB_DOLFIN(CMakePythonPackage):
             # exclude Python tests for now, because they 'hang' sometimes (unclear why)
             # they can be reinstated once run_cmd (or its equivalent) has support for timeouts
             # see https://github.com/easybuilders/easybuild-framework/issues/581
-            #for (tmpl, subdir) in [(cmd_template_python, 'python'), (cmd_template_cpp, 'cpp')]]
+            # for (tmpl, subdir) in [(cmd_template_python, 'python'), (cmd_template_cpp, 'cpp')]
 
             # subdomains-poisson has no C++ get_version, only Python
             # Python tests excluded, see above
-            #name = 'subdomains-poisson'
-            #path = os.path.join('demo', 'pde', name, 'python')
-            #cmds += [cmd_template_python % {'dir': path, 'name': name}]
+            if False:
+                name = 'subdomains-poisson'
+                path = os.path.join('demo', 'pde', name, 'python')
+                cmds += [cmd_template_python % {'dir': path, 'name': name}]
 
             # supply empty argument to each command
             for cmd in cmds:
@@ -351,7 +355,7 @@ class EB_DOLFIN(CMakePythonPackage):
         # custom sanity check paths
         custom_paths = {
             'files': ['bin/dolfin-%s' % x for x in ['version', 'convert', 'order', 'plot']] + ['include/dolfin.h'],
-            'dirs':['%s/dolfin' % self.pylibdir],
+            'dirs': ['%s/dolfin' % self.pylibdir],
         }
 
         super(EB_DOLFIN, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -215,10 +215,7 @@ class EB_GROMACS(CMakeMake):
                 run_cmd(plumed_cmd, log_all=True, simple=True)
 
             # Select debug or release build
-            if self.toolchain.options.get('debug', None):
-                self.cfg.update('configopts', "-DCMAKE_BUILD_TYPE=Debug")
-            else:
-                self.cfg.update('configopts', "-DCMAKE_BUILD_TYPE=Release")
+            self.cfg['build_type'] = 'Debug' if self.toolchain.options.get('debug', None) else 'Release'
 
             # prefer static libraries, if available
             if self.toolchain.options.get('dynamic', False):

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -74,7 +74,7 @@ class CMakeMake(ConfigureMake):
             'allow_system_boost': [False, "Always allow CMake to pick up on Boost installed in OS "
                                           "(even if Boost is included as a dependency)", CUSTOM],
             'build_type': [None, "Build type for CMake, e.g. Release or Debug."
-                                "Use None to not specify -DCMAKE_BUILD_TYPE", CUSTOM],
+                                 "Use None to not specify -DCMAKE_BUILD_TYPE", CUSTOM],
             'configure_cmd': [DEFAULT_CONFIGURE_CMD, "Configure command to use", CUSTOM],
             'srcdir': [None, "Source directory location to provide to cmake command", CUSTOM],
             'separate_build_dir': [False, "Perform build in a separate directory", CUSTOM],

--- a/easybuild/easyblocks/n/netcdf.py
+++ b/easybuild/easyblocks/n/netcdf.py
@@ -68,10 +68,7 @@ class EB_netCDF(CMakeMake):
             ConfigureMake.configure_step(self)
 
         else:
-            if self.toolchain.options['debug']:
-                self.cfg.update('configopts', '-DCMAKE_BUILD_TYPE=DEBUG ')
-            else:
-                self.cfg.update('configopts', '-DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_C_FLAGS_RELEASE="-DNDEBUG " ')
+            self.cfg['build_type'] = 'Debug' if self.toolchain.options.get('debug', None) else 'Release'
 
             for (dep, libname) in [('cURL', 'curl'), ('HDF5', 'hdf5'), ('Szip', 'sz'), ('zlib', 'z'),
                                    ('PnetCDF', 'pnetcdf')]:

--- a/easybuild/easyblocks/o/opencv.py
+++ b/easybuild/easyblocks/o/opencv.py
@@ -48,10 +48,12 @@ class EB_OpenCV(CMakeMake):
     @staticmethod
     def extra_options():
         """Custom easyconfig parameters specific to OpenCV."""
-        extra_vars = {
+        extra_vars = CMakeMake.extra_options()
+        extra_vars.update({
             'cpu_dispatch': ['NONE', "Value to pass to -DCPU_DISPATCH configuration option", CUSTOM],
-        }
-        return CMakeMake.extra_options(extra_vars)
+        })
+        extra_vars['build_type'][0] = 'Release'
+        return extra_vars
 
     def __init__(self, *args, **kwargs):
         """Initialisation of custom class variables for OpenCV."""
@@ -89,9 +91,6 @@ class EB_OpenCV(CMakeMake):
 
     def configure_step(self):
         """Custom configuration procedure for OpenCV."""
-
-        if 'CMAKE_BUILD_TYPE' not in self.cfg['configopts']:
-            self.cfg.update('configopts', '-DCMAKE_BUILD_TYPE=Release')
 
         # enable Python support if unspecified and Python is a dependency
         if 'BUILD_PYTHON_SUPPORT' not in self.cfg['configopts']:

--- a/easybuild/easyblocks/p/psi.py
+++ b/easybuild/easyblocks/p/psi.py
@@ -60,12 +60,13 @@ class EB_PSI(CMakeMake):
     @staticmethod
     def extra_options():
         """Extra easyconfig parameters specific to PSI."""
-
-        extra_vars = {
+        extra_vars = CMakeMake.extra_options()
+        extra_vars.update({
             # always include running PSI unit tests (takes about 2h or less)
             'runtest': ["tests TESTFLAGS='-u -q'", "Run tests included with PSI, without interruption.", BUILD],
-        }
-        return CMakeMake.extra_options(extra_vars)
+        })
+        extra_vars['build_type'][0] = 'Release'
+        return extra_vars
 
     def configure_step(self):
         """
@@ -143,9 +144,7 @@ class EB_PSI(CMakeMake):
             if self.name == 'PSI4' and LooseVersion(self.version) >= LooseVersion("1.2"):
                 self.log.info("Remove the CMAKE_BUILD_TYPE test in PSI4 source and the downloaded dependencies!")
                 self.log.info("Use PATCH_COMMAND in the corresponding CMakeLists.txt")
-                self.cfg.update('configopts', ' -DCMAKE_BUILD_TYPE=EasyBuildRelease')
-            else:
-                self.cfg.update('configopts', ' -DCMAKE_BUILD_TYPE=Release')
+                self.cfg['build_type'] = 'EasyBuildRelease'
 
             if self.toolchain.options.get('usempi', None):
                 self.cfg.update('configopts', " -DENABLE_MPI=ON")

--- a/easybuild/easyblocks/t/trilinos.py
+++ b/easybuild/easyblocks/t/trilinos.py
@@ -98,11 +98,8 @@ class EB_Trilinos(CMakeMake):
         else:
             self.cfg.update('configopts', "-DBUILD_SHARED_LIBS:BOOL=OFF")
 
-        # release or debug get_version
-        if self.toolchain.options['debug']:
-            self.cfg.update('configopts', "-DCMAKE_BUILD_TYPE:STRING=DEBUG")
-        else:
-            self.cfg.update('configopts', "-DCMAKE_BUILD_TYPE:STRING=RELEASE")
+        # release or debug gversion
+        self.cfg['build_type'] = 'Debug' if self.toolchain.options.get('debug', None) else 'Release'
 
         # enable full testing
         self.cfg.update('configopts', "-DTrilinos_ENABLE_TESTS:BOOL=ON")


### PR DESCRIPTION
This replaces raw usages of `-DCMAKE_BUILD_TYPE=...` in other ECs

I also added a commit which renames the option to build_type because the base class ConfigureMake has this and having both might be confusing to users. This lets the last one win, in this case CMake