### PR TITLE
override set_pylibdirs method in VersionIndependentPythonPackage to hard set self.pylibdir to 'lib'

### DIFF
--- a/easybuild/easyblocks/generic/versionindependentpythonpackage.py
+++ b/easybuild/easyblocks/generic/versionindependentpythonpackage.py
@@ -47,10 +47,11 @@ class VersionIndependentPythonPackage(PythonPackage):
         """No build procedure."""
         pass
 
-    def prepare_step(self, *args, **kwargs):
-        """Set pylibdir"""
+    def set_pylibdirs(self):
+        """Set pylibdir."""
+        super(VersionIndependentPythonPackage, self).set_pylibdirs()
         self.pylibdir = 'lib'
-        super(VersionIndependentPythonPackage, self).prepare_step(*args, **kwargs)
+        self.all_pylibdirs = ['lib']
 
     def install_step(self):
         """Custom install procedure to skip selection of python package versions."""


### PR DESCRIPTION
fixes #1846