### PR TITLE
simplify various CMakeMake-based easyblocks by enhancing CMakeMake (w.r.t. CMAKE_BUILD_TYPE, shared vs static libs, fPIC)

### DIFF
--- a/easybuild/easyblocks/a/armadillo.py
+++ b/easybuild/easyblocks/a/armadillo.py
@@ -38,6 +38,13 @@ from easybuild.tools.systemtools import get_shared_lib_ext
 class EB_Armadillo(CMakeMake):
     """Support for building Armadillo."""
 
+    @staticmethod
+    def extra_options():
+        """Extra easyconfig parameters for Armadillo."""
+        extra_vars = CMakeMake.extra_options()
+        extra_vars['separate_build_dir'][0] = True
+        return extra_vars
+
     def configure_step(self):
         """Set some extra environment variables before configuring."""
 

--- a/easybuild/easyblocks/b/bamtools.py
+++ b/easybuild/easyblocks/b/bamtools.py
@@ -28,13 +28,10 @@ EasyBuild support for BamTools, implemented as an easyblock
 @author: Andreas Panteli (The Cyprus Institute)
 @author: Kenneth Hoste (Ghent University)
 """
-import os
 from distutils.version import LooseVersion
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.easyblocks.generic.makecp import MakeCp
 from easybuild.framework.easyconfig import CUSTOM
-from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import mkdir
 from easybuild.tools.systemtools import get_shared_lib_ext
 
 
@@ -45,23 +42,18 @@ class EB_BamTools(MakeCp, CMakeMake):
     def extra_options(extra_vars=None):
         """Extra easyconfig parameters for BamTools."""
         extra_vars = MakeCp.extra_options()
+        extra_vars.update(CMakeMake.extra_options())
 
         # files_to_copy is not mandatory here, since we overwrite it in install_step
         extra_vars['files_to_copy'][2] = CUSTOM
+        # BamTools requires an out of source build
+        extra_vars['separate_build_dir'][0] = True
 
-        return CMakeMake.extra_options(extra_vars=extra_vars)
+        return extra_vars
 
     def configure_step(self):
         """Configure BamTools build."""
-        # BamTools requires an out of source build.
-        builddir = os.path.join(self.cfg['start_dir'], 'build')
-        try:
-            mkdir(builddir)
-            os.chdir(builddir)
-        except OSError as err:
-            raise EasyBuildError("Failed to move to %s: %s", builddir, err)
-
-        CMakeMake.configure_step(self, srcdir='..')
+        CMakeMake.configure_step(self)
 
     def install_step(self):
         """Custom installation procedure for BamTools."""

--- a/easybuild/easyblocks/b/blender.py
+++ b/easybuild/easyblocks/b/blender.py
@@ -39,6 +39,13 @@ from easybuild.tools.systemtools import get_shared_lib_ext
 class EB_Blender(CMakeMake):
     """Support for building Blender."""
 
+    @staticmethod
+    def extra_options():
+        extra_vars = CMakeMake.extra_options()
+        extra_vars['separate_build_dir'][0] = True
+        extra_vars['build_type'][0] = 'Release'
+        return extra_vars
+
     def find_glob_pattern(self, glob_pattern):
         """Find unique file/dir matching glob_pattern (raises error if more than one match is found)"""
         if self.dry_run:
@@ -50,11 +57,8 @@ class EB_Blender(CMakeMake):
 
     def configure_step(self):
         """Set CMake options for Blender"""
-        self.cfg['separate_build_dir'] = True
 
         default_config_opts = {
-            'CMAKE_CXX_FLAGS_RELEASE': '-DNDEBUG',
-            'CMAKE_C_FLAGS_RELEASE': '-DNDEBUG',
             'WITH_BUILDINFO': 'OFF',
             # disable SSE detection to give EasyBuild full control over optimization compiler flags being used
             'WITH_CPU_SSE': 'OFF',

--- a/easybuild/easyblocks/b/blender.py
+++ b/easybuild/easyblocks/b/blender.py
@@ -43,7 +43,6 @@ class EB_Blender(CMakeMake):
     def extra_options():
         extra_vars = CMakeMake.extra_options()
         extra_vars['separate_build_dir'][0] = True
-        extra_vars['build_type'][0] = 'Release'
         return extra_vars
 
     def find_glob_pattern(self, glob_pattern):

--- a/easybuild/easyblocks/c/cgal.py
+++ b/easybuild/easyblocks/c/cgal.py
@@ -42,6 +42,12 @@ from easybuild.tools.systemtools import get_shared_lib_ext
 class EB_CGAL(CMakeMake):
     """Support for building CGAL."""
 
+    @staticmethod
+    def extra_options():
+        extra_vars = CMakeMake.extra_options()
+        extra_vars['separate_build_dir'][0] = True
+        return extra_vars
+
     def configure_step(self):
         """Set some extra environment variables before configuring."""
 

--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -87,6 +87,8 @@ class EB_Clang(CMakeMake):
             'skip_sanitizer_tests': [True, "Do not run the sanitizer tests", CUSTOM],
         })
         extra_vars['build_type'][0] = 'Release'
+        # disable regular out-of-source build, too simplistic for Clang to work
+        extra_vars['separate_build_dir'][0] = False
         return extra_vars
 
     def __init__(self, *args, **kwargs):

--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -70,7 +70,8 @@ class EB_Clang(CMakeMake):
 
     @staticmethod
     def extra_options():
-        extra_vars = {
+        extra_vars = CMakeMake.extra_options()
+        extra_vars.update({
             'assertions': [True, "Enable assertions.  Helps to catch bugs in Clang.", CUSTOM],
             'build_targets': [None, "Build targets for LLVM (host architecture if None). Possible values: " +
                                     ', '.join(CLANG_TARGETS), CUSTOM],
@@ -84,9 +85,9 @@ class EB_Clang(CMakeMake):
             'skip_all_tests': [False, "Skip running of tests", CUSTOM],
             # The sanitizer tests often fail on HPC systems due to the 'weird' environment.
             'skip_sanitizer_tests': [True, "Do not run the sanitizer tests", CUSTOM],
-        }
-
-        return CMakeMake.extra_options(extra_vars)
+        })
+        extra_vars['build_type'][0] = 'Release'
+        return extra_vars
 
     def __init__(self, *args, **kwargs):
         """Initialize custom class variables for Clang."""
@@ -226,7 +227,6 @@ class EB_Clang(CMakeMake):
         self.log.debug("Using %s as GCC_INSTALL_PREFIX", gcc_prefix)
 
         # Configure some default options
-        self.cfg.update('configopts', "-DCMAKE_BUILD_TYPE=Release")
         if self.cfg["enable_rtti"]:
             self.cfg.update('configopts', '-DLLVM_REQUIRES_RTTI=ON')
             self.cfg.update('configopts', '-DLLVM_ENABLE_RTTI=ON')

--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -333,6 +333,7 @@ class EB_Clang(CMakeMake):
         options += "-DCMAKE_C_COMPILER='%s' " % CC
         options += "-DCMAKE_CXX_COMPILER='%s' " % CXX
         options += self.cfg['configopts']
+        options += "-DCMAKE_BUILD_TYPE=%s" % self.build_type
 
         self.log.info("Configuring")
         run_cmd("cmake %s %s" % (options, self.llvm_src_dir), log_all=True)

--- a/easybuild/easyblocks/d/dirac.py
+++ b/easybuild/easyblocks/d/dirac.py
@@ -31,9 +31,7 @@ import shutil
 import tempfile
 
 import easybuild.tools.environment as env
-import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
-from easybuild.framework.easyconfig import CUSTOM, MANDATORY
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option
 from easybuild.tools.run import run_cmd
@@ -41,6 +39,12 @@ from easybuild.tools.run import run_cmd
 
 class EB_DIRAC(CMakeMake):
     """Support for building/installing DIRAC."""
+
+    @staticmethod
+    def extra_options():
+        extra_vars = CMakeMake.extra_options()
+        extra_vars['build_type'][0] = 'release'  # TODO: Verify if this is really lowercase
+        return extra_vars
 
     def configure_step(self):
         """Custom configuration procedure for DIRAC."""
@@ -54,7 +58,7 @@ class EB_DIRAC(CMakeMake):
                 raise EasyBuildError("Failed to remove existing install directory %s: %s", self.installdir, err)
 
         self.cfg['separate_build_dir'] = True
-        self.cfg.update('configopts', "-DENABLE_MPI=ON -DCMAKE_BUILD_TYPE=release")
+        self.cfg.update('configopts', "-DENABLE_MPI=ON")
 
         # complete configuration with configure_method of parent
         super(EB_DIRAC, self).configure_step()

--- a/easybuild/easyblocks/d/dirac.py
+++ b/easybuild/easyblocks/d/dirac.py
@@ -43,7 +43,7 @@ class EB_DIRAC(CMakeMake):
     @staticmethod
     def extra_options():
         extra_vars = CMakeMake.extra_options()
-        extra_vars['build_type'][0] = 'release'  # TODO: Verify if this is really lowercase
+        extra_vars['separate_build_dir'][0] = True
         return extra_vars
 
     def configure_step(self):
@@ -57,7 +57,6 @@ class EB_DIRAC(CMakeMake):
             except OSError as err:
                 raise EasyBuildError("Failed to remove existing install directory %s: %s", self.installdir, err)
 
-        self.cfg['separate_build_dir'] = True
         self.cfg.update('configopts', "-DENABLE_MPI=ON")
 
         # complete configuration with configure_method of parent

--- a/easybuild/easyblocks/d/dolfin.py
+++ b/easybuild/easyblocks/d/dolfin.py
@@ -50,7 +50,7 @@ class EB_DOLFIN(CMakePythonPackage):
     @staticmethod
     def extra_options():
         extra_vars = CMakePythonPackage.extra_options()
-        extra_vars['build_type'][0] = 'Release'
+        extra_vars['separate_build_dir'][0] = True
         return extra_vars
 
     def __init__(self, *args, **kwargs):
@@ -59,7 +59,6 @@ class EB_DOLFIN(CMakePythonPackage):
 
         self.boost_dir = None
         self.saved_configopts = None
-        self.cfg['separate_build_dir'] = True
 
     def configure_step(self):
         """Set DOLFIN-specific configure options and configure with CMake."""

--- a/easybuild/easyblocks/d/dolfin.py
+++ b/easybuild/easyblocks/d/dolfin.py
@@ -65,11 +65,6 @@ class EB_DOLFIN(CMakePythonPackage):
 
         shlib_ext = get_shared_lib_ext()
 
-        # compilers
-        self.cfg.update('configopts', "-DCMAKE_C_COMPILER='%s' " % os.getenv('CC'))
-        self.cfg.update('configopts', "-DCMAKE_CXX_COMPILER='%s' " % os.getenv('CXX'))
-        self.cfg.update('configopts', "-DCMAKE_Fortran_COMPILER='%s' " % os.getenv('F90'))
-
         # compiler flags
         cflags = os.getenv('CFLAGS')
         cxxflags = os.getenv('CXXFLAGS')

--- a/easybuild/easyblocks/d/dolfin.py
+++ b/easybuild/easyblocks/d/dolfin.py
@@ -47,6 +47,12 @@ from easybuild.tools.systemtools import get_shared_lib_ext
 class EB_DOLFIN(CMakePythonPackage):
     """Support for building and installing DOLFIN."""
 
+    @staticmethod
+    def extra_options():
+        extra_vars = CMakePythonPackage.extra_options()
+        extra_vars['build_type'][0] = 'Release'
+        return extra_vars
+
     def __init__(self, *args, **kwargs):
         """Initialize class variables."""
         super(EB_DOLFIN, self).__init__(*args, **kwargs)
@@ -80,9 +86,6 @@ class EB_DOLFIN(CMakePythonPackage):
         self.cfg.update('configopts', '-DCMAKE_CXX_FLAGS="%s"' % cxxflags)
         self.cfg.update('configopts', '-DCMAKE_Fortran_FLAGS="%s"' % fflags)
 
-        # run cmake in debug mode
-        self.cfg.update('configopts', '-DCMAKE_BUILD_TYPE=Debug')
-
         # set correct compilers to be used at runtime
         self.cfg.update('configopts', '-DMPI_C_COMPILER="$MPICC"')
         self.cfg.update('configopts', '-DMPI_CXX_COMPILER="$MPICXX"')
@@ -90,7 +93,7 @@ class EB_DOLFIN(CMakePythonPackage):
         # specify MPI library
         self.cfg.update('configopts', '-DMPI_COMPILER="%s"' % os.getenv('MPICC'))
 
-        if  os.getenv('MPI_LIB_SHARED') and os.getenv('MPI_INC_DIR'):
+        if os.getenv('MPI_LIB_SHARED') and os.getenv('MPI_INC_DIR'):
             self.cfg.update('configopts', '-DMPI_LIBRARY="%s"' % os.getenv('MPI_LIB_SHARED'))
             self.cfg.update('configopts', '-DMPI_INCLUDE_PATH="%s"' % os.getenv('MPI_INC_DIR'))
         else:
@@ -126,7 +129,7 @@ class EB_DOLFIN(CMakePythonPackage):
             if not deproot:
                 raise EasyBuildError("Dependency %s not available.", dep)
             else:
-                depsdict.update({dep:deproot})
+                depsdict.update({dep: deproot})
 
         # zlib
         self.cfg.update('configopts', '-DZLIB_INCLUDE_DIR=%s' % os.path.join(depsdict['zlib'], "include"))
@@ -173,7 +176,7 @@ class EB_DOLFIN(CMakePythonPackage):
             '-DCOLAMD_LIBRARY:PATH="%(sp)s/COLAMD/lib/libcolamd.a"'
         ]
 
-        self.cfg.update('configopts', ' '.join(umfpack_params) % {'sp':suitesparse})
+        self.cfg.update('configopts', ' '.join(umfpack_params) % {'sp': suitesparse})
 
         # ParMETIS and SCOTCH
         self.cfg.update('configopts', '-DPARMETIS_DIR="%s"' % depsdict['ParMETIS'])
@@ -272,13 +275,14 @@ class EB_DOLFIN(CMakePythonPackage):
             # exclude Python tests for now, because they 'hang' sometimes (unclear why)
             # they can be reinstated once run_cmd (or its equivalent) has support for timeouts
             # see https://github.com/easybuilders/easybuild-framework/issues/581
-            #for (tmpl, subdir) in [(cmd_template_python, 'python'), (cmd_template_cpp, 'cpp')]]
+            # for (tmpl, subdir) in [(cmd_template_python, 'python'), (cmd_template_cpp, 'cpp')]
 
             # subdomains-poisson has no C++ get_version, only Python
             # Python tests excluded, see above
-            #name = 'subdomains-poisson'
-            #path = os.path.join('demo', 'pde', name, 'python')
-            #cmds += [cmd_template_python % {'dir': path, 'name': name}]
+            if False:
+                name = 'subdomains-poisson'
+                path = os.path.join('demo', 'pde', name, 'python')
+                cmds += [cmd_template_python % {'dir': path, 'name': name}]
 
             # supply empty argument to each command
             for cmd in cmds:
@@ -351,7 +355,7 @@ class EB_DOLFIN(CMakePythonPackage):
         # custom sanity check paths
         custom_paths = {
             'files': ['bin/dolfin-%s' % x for x in ['version', 'convert', 'order', 'plot']] + ['include/dolfin.h'],
-            'dirs':['%s/dolfin' % self.pylibdir],
+            'dirs': ['%s/dolfin' % self.pylibdir],
         }
 
         super(EB_DOLFIN, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/e/eigen.py
+++ b/easybuild/easyblocks/e/eigen.py
@@ -31,13 +31,18 @@ class EB_Eigen(CMakeMake):
     Support for building Eigen.
     """
 
+    @staticmethod
+    def extra_options():
+        extra_vars = CMakeMake.extra_options()
+        extra_vars['separate_build_dir'][0] = True
+        return extra_vars
+
     def configure_step(self):
         """Custom configuration procedure for Eigen."""
         # start using CMake for Eigen 3.3.4 and newer versions
         # not done for older versions, since this implies using CMake as a build dependency,
         # which is a bit strange for a header-only library like Eigen...
         if LooseVersion(self.version) >= LooseVersion('3.3.4'):
-            self.cfg['separate_build_dir'] = True
             # avoid that include files are installed into include/eigen3/Eigen, should be include/Eigen
             self.cfg.update('configopts', "-DINCLUDE_INSTALL_DIR=%s" % os.path.join(self.installdir, 'include'))
             CMakeMake.configure_step(self)

--- a/easybuild/easyblocks/e/elsi.py
+++ b/easybuild/easyblocks/e/elsi.py
@@ -51,16 +51,13 @@ class EB_ELSI(CMakeMake):
         extra_vars = CMakeMake.extra_options()
         extra_vars.update({
             'build_internal_pexsi': [None, "Build internal PEXSI solver", CUSTOM],
-            'build_shared_libs': [True, "Build shared libraries instead of static", CUSTOM],
         })
+        extra_vars['build_shared_libs'][0] = True
         extra_vars['separate_build_dir'][0] = True
         return extra_vars
 
     def configure_step(self):
         """Custom configure procedure for ELSI."""
-        if self.cfg['build_shared_libs']:
-            self.cfg.update('configopts', "-DBUILD_SHARED_LIBS=ON")
-
         if self.cfg['runtest']:
             self.cfg.update('configopts', "-DENABLE_TESTS=ON")
             self.cfg.update('configopts', "-DENABLE_C_TESTS=ON")
@@ -148,10 +145,8 @@ class EB_ELSI(CMakeMake):
             modules.append('elsi_sips')
             libs.append('sips')
 
-        libext = get_shared_lib_ext() if self.cfg['build_shared_libs'] else 'a'
-
         module_paths = [os.path.join('include', '%s.mod' % mod) for mod in modules]
-        lib_paths = [os.path.join('lib', 'lib%s.%s' % (lib, libext)) for lib in libs]
+        lib_paths = [os.path.join('lib', 'lib%s.%s' % (lib, self.lib_ext)) for lib in libs]
 
         custom_paths = {
             'files': module_paths + lib_paths,

--- a/easybuild/easyblocks/e/elsi.py
+++ b/easybuild/easyblocks/e/elsi.py
@@ -48,17 +48,16 @@ class EB_ELSI(CMakeMake):
     @staticmethod
     def extra_options():
         """Define custom easyconfig parameters for ELSI."""
-        extra_vars = {
+        extra_vars = CMakeMake.extra_options()
+        extra_vars.update({
             'build_internal_pexsi': [None, "Build internal PEXSI solver", CUSTOM],
             'build_shared_libs': [True, "Build shared libraries instead of static", CUSTOM],
-        }
-        return CMakeMake.extra_options(extra_vars)
+        })
+        extra_vars['separate_build_dir'][0] = True
+        return extra_vars
 
     def configure_step(self):
         """Custom configure procedure for ELSI."""
-
-        self.cfg['separate_build_dir'] = True
-
         if self.cfg['build_shared_libs']:
             self.cfg.update('configopts', "-DBUILD_SHARED_LIBS=ON")
 

--- a/easybuild/easyblocks/g/gate.py
+++ b/easybuild/easyblocks/g/gate.py
@@ -50,10 +50,13 @@ class EB_GATE(CMakeMake):
 
     @staticmethod
     def extra_options():
-        extra_vars = {
+        extra_vars = CMakeMake.extra_options()
+        extra_vars.update({
             'default_platform': ['openPBS', "Default cluster platform to set", CUSTOM],
-        }
-        return CMakeMake.extra_options(extra_vars)
+        })
+        # Out of source build doesn't work due to sub tools beeing 'make'd
+        extra_vars['separate_build_dir'][0] = False
+        return extra_vars
 
     def __init__(self, *args, **kwargs):
         """Initialise class variables."""

--- a/easybuild/easyblocks/g/geant4.py
+++ b/easybuild/easyblocks/g/geant4.py
@@ -57,14 +57,17 @@ class EB_Geant4(CMakeMake):
         """
         Define extra options needed by Geant4
         """
-        extra_vars = {
+        extra_vars = CMakeMake.extra_options()
+        extra_vars.update({
             'G4ABLAVersion': [None, "G4ABLA version", CUSTOM],
             'G4NDLVersion': [None, "G4NDL version", CUSTOM],
             'G4EMLOWVersion': [None, "G4EMLOW version", CUSTOM],
             'PhotonEvaporationVersion': [None, "PhotonEvaporation version", CUSTOM],
             'G4RadioactiveDecayVersion': [None, "G4RadioactiveDecay version", CUSTOM],
-        }
-        return CMakeMake.extra_options(extra_vars)
+        })
+        # Requires out-of-source build
+        extra_vars['separate_build_dir'][0] = True
+        return extra_vars
 
     def __init__(self, *args, **kwargs):
         """Initialisation of custom class variables for Geant4."""
@@ -80,9 +83,7 @@ class EB_Geant4(CMakeMake):
 
         # Geant4 switched to a CMake build system in version 9.4
         if LooseVersion(self.version) >= LooseVersion("9.4"):
-            mkdir('configdir')
-            os.chdir('configdir')
-            super(EB_Geant4, self).configure_step(srcdir="..")
+            super(EB_Geant4, self).configure_step()
 
         else:
             pwd = self.cfg['start_dir']

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -225,7 +225,7 @@ class EB_GROMACS(CMakeMake):
             else:
                 self.cfg.update('configopts', "-DGMX_PREFER_STATIC_LIBS=ON")
                 if plumed_root:
-                    self.cfg.update('configopts', "-DBUILD_SHARED_LIBS=OFF")
+                    self.cfg['build_shared_libs'] = False
 
             if self.cfg['double_precision']:
                 self.cfg.update('configopts', "-DGMX_DOUBLE=ON")

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -58,14 +58,16 @@ class EB_GROMACS(CMakeMake):
 
     @staticmethod
     def extra_options():
-        extra_vars = {
+        extra_vars = CMakeMake.extra_options()
+        extra_vars.update({
             'double_precision': [False, "Build with double precision enabled (-DGMX_DOUBLE=ON)", CUSTOM],
             'mpisuffix': ['_mpi', "Suffix to append to MPI-enabled executables (only for GROMACS < 4.6)", CUSTOM],
             'mpiexec': ['mpirun', "MPI executable to use when running tests", CUSTOM],
             'mpiexec_numproc_flag': ['-np', "Flag to introduce the number of MPI tasks when running tests", CUSTOM],
             'mpi_numprocs': [0, "Number of MPI tasks to use when running tests", CUSTOM],
-        }
-        return CMakeMake.extra_options(extra_vars)
+        })
+        extra_vars['separate_build_dir'][0] = True
+        return extra_vars
 
     def __init__(self, *args, **kwargs):
         """Initialize GROMACS-specific variables."""
@@ -311,7 +313,6 @@ class EB_GROMACS(CMakeMake):
                     env.setvar('LDFLAGS', "%s -L%s %s" % (ldflags, os.path.join(root, libdir), link_flag))
 
             # complete configuration with configure_method of parent
-            self.cfg['separate_build_dir'] = True
             out = super(EB_GROMACS, self).configure_step()
 
             # for recent GROMACS versions, make very sure that a decent BLAS, LAPACK and FFT is found and used

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -216,9 +216,6 @@ class EB_GROMACS(CMakeMake):
 
                 run_cmd(plumed_cmd, log_all=True, simple=True)
 
-            # Select debug or release build
-            self.cfg['build_type'] = 'Debug' if self.toolchain.options.get('debug', None) else 'Release'
-
             # prefer static libraries, if available
             if self.toolchain.options.get('dynamic', False):
                 self.cfg.update('configopts', "-DGMX_PREFER_STATIC_LIBS=OFF")

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -215,10 +215,7 @@ class EB_GROMACS(CMakeMake):
                 run_cmd(plumed_cmd, log_all=True, simple=True)
 
             # Select debug or release build
-            if self.toolchain.options.get('debug', None):
-                self.cfg.update('configopts', "-DCMAKE_BUILD_TYPE=Debug")
-            else:
-                self.cfg.update('configopts', "-DCMAKE_BUILD_TYPE=Release")
+            self.cfg['build_type'] = 'Debug' if self.toolchain.options.get('debug', None) else 'Release'
 
             # prefer static libraries, if available
             if self.toolchain.options.get('dynamic', False):

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -77,8 +77,8 @@ class CMakeMake(ConfigureMake):
             'build_shared_libs': [None, "Build shared library (instead of static library)"
                                         "Can be overwritten by configopts"
                                         "None can be used to add no flag (usually results in static library)", CUSTOM],
-            'build_type': [None, "Build type for CMake, e.g. Release or Debug."
-                                 "Use None to not specify -DCMAKE_BUILD_TYPE", CUSTOM],
+            'build_type': [None, "Build type for CMake, e.g. Release."
+                                 "Defaults to 'Release' or 'Debug' depending on toolchainopts[debug]", CUSTOM],
             'configure_cmd': [DEFAULT_CONFIGURE_CMD, "Configure command to use", CUSTOM],
             'srcdir': [None, "Source directory location to provide to cmake command", CUSTOM],
             'separate_build_dir': [False, "Perform build in a separate directory", CUSTOM],
@@ -108,8 +108,10 @@ class CMakeMake(ConfigureMake):
 
         options = ['-DCMAKE_INSTALL_PREFIX=%s' % self.installdir]
 
-        if self.cfg['build_type'] is not None:
-            options.append("-DCMAKE_BUILD_TYPE=%s" % self.cfg['build_type'])
+        build_type = self.cfg['build_type']
+        if build_type is None:
+            build_type = 'Debug' if self.toolchain.options.get('debug', None) else 'Release'
+        options.append("-DCMAKE_BUILD_TYPE=%s" % build_type)
 
         # Add -fPIC flag if necessary
         if self.toolchain.options['pic']:

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -102,6 +102,14 @@ class CMakeMake(ConfigureMake):
         else:
             self.lib_ext = None
 
+    @property
+    def build_type(self):
+        """Build type set in the EasyConfig with default determined by toolchainopts"""
+        build_type = self.cfg['build_type']
+        if build_type is None:
+            build_type = 'Debug' if self.toolchain.options.get('debug', None) else 'Release'
+        return build_type
+
     def configure_step(self, srcdir=None, builddir=None):
         """Configure build using cmake"""
 
@@ -129,10 +137,7 @@ class CMakeMake(ConfigureMake):
             if self.cfg['build_type'] is not None:
                 self.log.warning('CMAKE_BUILD_TYPE is set in configopts. Ignoring build_type')
         else:
-            build_type = self.cfg['build_type']
-            if build_type is None:
-                build_type = 'Debug' if self.toolchain.options.get('debug', None) else 'Release'
-            options.append('-DCMAKE_BUILD_TYPE=%s' % build_type)
+            options.append('-DCMAKE_BUILD_TYPE=%s' % self.build_type)
 
         # Add -fPIC flag if necessary
         if self.toolchain.options['pic']:

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -74,7 +74,7 @@ class CMakeMake(ConfigureMake):
             'allow_system_boost': [False, "Always allow CMake to pick up on Boost installed in OS "
                                           "(even if Boost is included as a dependency)", CUSTOM],
             'build_type': [None, "Build type for CMake, e.g. Release or Debug."
-                                "Use None to not specify -DCMAKE_BUILD_TYPE", CUSTOM],
+                                 "Use None to not specify -DCMAKE_BUILD_TYPE", CUSTOM],
             'configure_cmd': [DEFAULT_CONFIGURE_CMD, "Configure command to use", CUSTOM],
             'srcdir': [None, "Source directory location to provide to cmake command", CUSTOM],
             'separate_build_dir': [False, "Perform build in a separate directory", CUSTOM],

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -125,7 +125,10 @@ class CMakeMake(ConfigureMake):
 
         options = ['-DCMAKE_INSTALL_PREFIX=%s' % self.installdir]
 
-        if '-DCMAKE_BUILD_TYPE=' not in self.cfg['configopts']:
+        if '-DCMAKE_BUILD_TYPE=' in self.cfg['configopts']:
+            if self.cfg['build_type'] is not None:
+                self.log.warning('CMAKE_BUILD_TYPE is set in configopts. Ignoring build_type')
+        else:
             build_type = self.cfg['build_type']
             if build_type is None:
                 build_type = 'Debug' if self.toolchain.options.get('debug', None) else 'Release'

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -107,6 +107,10 @@ class CMakeMake(ConfigureMake):
         if self.cfg['build_type'] is not None:
             options.append("-DCMAKE_BUILD_TYPE=%s" % self.cfg['build_type'])
 
+        # Add -fPIC flag if necessary
+        if self.toolchain.options['pic']:
+            options.append('-DCMAKE_POSITION_INDEPENDENT_CODE=ON')
+
         env_to_options = {
             'CC': 'CMAKE_C_COMPILER',
             'CFLAGS': 'CMAKE_C_FLAGS',

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -86,21 +86,24 @@ class CMakeMake(ConfigureMake):
         return extra_vars
 
     def __init__(self, *args, **kwargs):
-        """
-        Constructor for CMakeMake easyblock:
-        set self.lib_ext based on whether shared libraries are built or not
-        """
-
+        """Constructor for CMakeMake easyblock"""
         super(CMakeMake, self).__init__(*args, **kwargs)
+        self._lib_ext = None
 
-        # set self.lib_ext according to 'build_shared_libs' easyconfig parameter (if it's set)
-        build_shared_libs = self.cfg['build_shared_libs']
-        if build_shared_libs:
-            self.lib_ext = get_shared_lib_ext()
-        elif build_shared_libs is not None:
-            self.lib_ext = 'a'
-        else:
-            self.lib_ext = None
+    @property
+    def lib_ext(self):
+        """Return the extension for libraries build based on `build_shared_libs` or None if that is unset"""
+        if self._lib_ext is None:
+            build_shared_libs = self.cfg['build_shared_libs']
+            if build_shared_libs:
+                self._lib_ext = get_shared_lib_ext()
+            elif build_shared_libs is not None:
+                self._lib_ext = 'a'
+        return self._lib_ext
+
+    @lib_ext.setter
+    def lib_ext(self, value):
+        self._lib_ext = value
 
     @property
     def build_type(self):

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -42,6 +42,7 @@ from easybuild.tools.filetools import change_dir, mkdir, which
 from easybuild.tools.environment import setvar
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
+from easybuild.tools.systemtools import get_shared_lib_ext
 from easybuild.tools.utilities import nub
 
 
@@ -73,6 +74,9 @@ class CMakeMake(ConfigureMake):
             'abs_path_compilers': [False, "Specify compilers via absolute file path (not via command names)", CUSTOM],
             'allow_system_boost': [False, "Always allow CMake to pick up on Boost installed in OS "
                                           "(even if Boost is included as a dependency)", CUSTOM],
+            'build_shared_libs': [None, "Build shared library (instead of static library)"
+                                        "Can be overwritten by configopts"
+                                        "None can be used to add no flag (usually results in static library)", CUSTOM],
             'build_type': [None, "Build type for CMake, e.g. Release or Debug."
                                  "Use None to not specify -DCMAKE_BUILD_TYPE", CUSTOM],
             'configure_cmd': [DEFAULT_CONFIGURE_CMD, "Configure command to use", CUSTOM],
@@ -110,6 +114,17 @@ class CMakeMake(ConfigureMake):
         # Add -fPIC flag if necessary
         if self.toolchain.options['pic']:
             options.append('-DCMAKE_POSITION_INDEPENDENT_CODE=ON')
+
+        # Set flag for shared libs if requested
+        # Not adding one allows the project to choose a default
+        # If build_shared_libs is set, then self.lib_ext will be set accordingly for use in e.g. sanity checks
+        build_shared_libs = self.cfg['build_shared_libs']
+        if build_shared_libs:
+            self.cfg.update('configopts', '-DBUILD_SHARED_LIBS=ON')
+            self.lib_ext = get_shared_lib_ext()
+        elif build_shared_libs is not None:
+            self.cfg.update('configopts', '-DBUILD_SHARED_LIBS=OFF')
+            self.lib_ext = 'a'
 
         env_to_options = {
             'CC': 'CMAKE_C_COMPILER',

--- a/easybuild/easyblocks/generic/cmakepythonpackage.py
+++ b/easybuild/easyblocks/generic/cmakepythonpackage.py
@@ -50,7 +50,10 @@ class CMakePythonPackage(CMakeMake, PythonPackage):
     def extra_options(extra_vars=None):
         """Easyconfig parameters specific to Python packages thar are configured/built/installed via CMake"""
         extra_vars = PythonPackage.extra_options(extra_vars=extra_vars)
-        return CMakeMake.extra_options(extra_vars=extra_vars)
+        extra_vars = CMakeMake.extra_options(extra_vars=extra_vars)
+        # enable out-of-source build
+        extra_vars['separate_build_dir'][0] = True
+        return extra_vars
 
     def __init__(self, *args, **kwargs):
         """Initialize with PythonPackage."""

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -103,6 +103,7 @@ class EB_LAMMPS(CMakeMake):
             'user_packages': [None, "List user packages without `PKG_USER-` prefix.", MANDATORY],
         })
         extra_vars['separate_build_dir'][0] = False
+        extra_vars['build_shared_libs'][0] = True
         return extra_vars
 
     def prepare_step(self, *args, **kwargs):
@@ -128,10 +129,7 @@ class EB_LAMMPS(CMakeMake):
         self.cfg['srcdir'] = os.path.join(self.start_dir, 'cmake')
 
         # Enable following packages, if not configured in easycofig
-        default_options = [
-            'BUILD_DOC', 'BUILD_EXE', 'BUILD_LIB',
-            'BUILD_SHARED_LIBS', 'BUILD_TOOLS',
-        ]
+        default_options = ['BUILD_DOC', 'BUILD_EXE', 'BUILD_LIB', 'BUILD_TOOLS']
         for option in default_options:
             if "-D%s=" % option not in self.cfg['configopts']:
                 self.cfg.update('configopts', '-D%s=on' % option)

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -102,7 +102,7 @@ class EB_LAMMPS(CMakeMake):
             'kokkos_arch': [None, "Set kokkos processor arch manually, if auto-detection doesn't work.", CUSTOM],
             'user_packages': [None, "List user packages without `PKG_USER-` prefix.", MANDATORY],
         })
-        extra_vars['separate_build_dir'][0] = False
+        extra_vars['separate_build_dir'][0] = True
         return extra_vars
 
     def prepare_step(self, *args, **kwargs):

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -93,16 +93,17 @@ class EB_LAMMPS(CMakeMake):
     @staticmethod
     def extra_options(**kwargs):
         """Custom easyconfig parameters for LAMMPS"""
-
-        extra_vars = {
+        extra_vars = CMakeMake.extra_options()
+        extra_vars.update({
             # see https://developer.nvidia.com/cuda-gpus
             'cuda_compute_capabilities': [[], "List of CUDA compute capabilities to build with", CUSTOM],
             'general_packages': [None, "List of general packages without `PKG_` prefix.", MANDATORY],
             'kokkos': [True, "Enable kokkos build.", CUSTOM],
             'kokkos_arch': [None, "Set kokkos processor arch manually, if auto-detection doesn't work.", CUSTOM],
             'user_packages': [None, "List user packages without `PKG_USER-` prefix.", MANDATORY],
-        }
-        return CMakeMake.extra_options(extra_vars)
+        })
+        extra_vars['separate_build_dir'][0] = False
+        return extra_vars
 
     def prepare_step(self, *args, **kwargs):
         """Custom prepare step for LAMMPS."""
@@ -124,7 +125,6 @@ class EB_LAMMPS(CMakeMake):
         cuda_cc = check_cuda_compute_capabilities(cfg_cuda_cc, ec_cuda_cc)
 
         # cmake has its own folder
-        self.cfg['separate_build_dir'] = True
         self.cfg['srcdir'] = os.path.join(self.start_dir, 'cmake')
 
         # Enable following packages, if not configured in easycofig

--- a/easybuild/easyblocks/n/netcdf.py
+++ b/easybuild/easyblocks/n/netcdf.py
@@ -68,10 +68,7 @@ class EB_netCDF(CMakeMake):
             ConfigureMake.configure_step(self)
 
         else:
-            if self.toolchain.options['debug']:
-                self.cfg.update('configopts', '-DCMAKE_BUILD_TYPE=DEBUG ')
-            else:
-                self.cfg.update('configopts', '-DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_C_FLAGS_RELEASE="-DNDEBUG " ')
+            self.cfg['build_type'] = 'Debug' if self.toolchain.options.get('debug', None) else 'Release'
 
             for (dep, libname) in [('cURL', 'curl'), ('HDF5', 'hdf5'), ('Szip', 'sz'), ('zlib', 'z'),
                                    ('PnetCDF', 'pnetcdf')]:

--- a/easybuild/easyblocks/n/netcdf.py
+++ b/easybuild/easyblocks/n/netcdf.py
@@ -47,6 +47,12 @@ from easybuild.tools.systemtools import get_shared_lib_ext
 class EB_netCDF(CMakeMake):
     """Support for building/installing netCDF"""
 
+    @staticmethod
+    def extra_options():
+        extra_vars = CMakeMake.extra_options()
+        extra_vars['separate_build_dir'][0] = True
+        return extra_vars
+
     def configure_step(self):
         """Configure build: set config options and configure"""
 

--- a/easybuild/easyblocks/n/netcdf.py
+++ b/easybuild/easyblocks/n/netcdf.py
@@ -74,8 +74,6 @@ class EB_netCDF(CMakeMake):
             ConfigureMake.configure_step(self)
 
         else:
-            self.cfg['build_type'] = 'Debug' if self.toolchain.options.get('debug', None) else 'Release'
-
             for (dep, libname) in [('cURL', 'curl'), ('HDF5', 'hdf5'), ('Szip', 'sz'), ('zlib', 'z'),
                                    ('PnetCDF', 'pnetcdf')]:
                 dep_root = get_software_root(dep)

--- a/easybuild/easyblocks/o/openbabel.py
+++ b/easybuild/easyblocks/o/openbabel.py
@@ -57,7 +57,6 @@ class EB_OpenBabel(CMakeMake):
         self.with_python = False
 
     def configure_step(self):
-
         """Custom configure procedure for OpenBabel."""
 
         self.cfg['configopts'] += "-DENABLE_TESTS=ON "

--- a/easybuild/easyblocks/o/openbabel.py
+++ b/easybuild/easyblocks/o/openbabel.py
@@ -44,10 +44,12 @@ class EB_OpenBabel(CMakeMake):
 
     @staticmethod
     def extra_options():
-        extra_vars = {
+        extra_vars = CMakeMake.extra_options()
+        extra_vars.update({
             'with_python_bindings': [True, "Try to build Open Babel's Python bindings. (-DPYTHON_BINDINGS=ON)", CUSTOM],
-        }
-        return CMakeMake.extra_options(extra_vars)
+        })
+        extra_vars['separate_build_dir'][0] = True
+        return extra_vars
 
     def __init__(self, *args, **kwargs):
         """Initialize OpenBabel-specific variables."""
@@ -56,8 +58,7 @@ class EB_OpenBabel(CMakeMake):
 
     def configure_step(self):
 
-        # Use separate build directory
-        self.cfg['separate_build_dir'] = True
+        """Custom configure procedure for OpenBabel."""
 
         self.cfg['configopts'] += "-DENABLE_TESTS=ON "
         # Needs wxWidgets

--- a/easybuild/easyblocks/o/opencv.py
+++ b/easybuild/easyblocks/o/opencv.py
@@ -48,10 +48,12 @@ class EB_OpenCV(CMakeMake):
     @staticmethod
     def extra_options():
         """Custom easyconfig parameters specific to OpenCV."""
-        extra_vars = {
+        extra_vars = CMakeMake.extra_options()
+        extra_vars.update({
             'cpu_dispatch': ['NONE', "Value to pass to -DCPU_DISPATCH configuration option", CUSTOM],
-        }
-        return CMakeMake.extra_options(extra_vars)
+        })
+        extra_vars['build_type'][0] = 'Release'
+        return extra_vars
 
     def __init__(self, *args, **kwargs):
         """Initialisation of custom class variables for OpenCV."""
@@ -89,9 +91,6 @@ class EB_OpenCV(CMakeMake):
 
     def configure_step(self):
         """Custom configuration procedure for OpenCV."""
-
-        if 'CMAKE_BUILD_TYPE' not in self.cfg['configopts']:
-            self.cfg.update('configopts', '-DCMAKE_BUILD_TYPE=Release')
 
         # enable Python support if unspecified and Python is a dependency
         if 'BUILD_PYTHON_SUPPORT' not in self.cfg['configopts']:

--- a/easybuild/easyblocks/o/opencv.py
+++ b/easybuild/easyblocks/o/opencv.py
@@ -52,7 +52,7 @@ class EB_OpenCV(CMakeMake):
         extra_vars.update({
             'cpu_dispatch': ['NONE', "Value to pass to -DCPU_DISPATCH configuration option", CUSTOM],
         })
-        extra_vars['build_type'][0] = 'Release'
+        extra_vars['separate_build_dir'][0] = True
         return extra_vars
 
     def __init__(self, *args, **kwargs):
@@ -61,8 +61,6 @@ class EB_OpenCV(CMakeMake):
 
         # can't be set before prepare_step is run
         self.pylibdir = None
-
-        self.cfg['separate_build_dir'] = True
 
     def prepare_step(self, *args, **kwargs):
         """Prepare environment for installing OpenCV."""

--- a/easybuild/easyblocks/p/psi.py
+++ b/easybuild/easyblocks/p/psi.py
@@ -60,12 +60,13 @@ class EB_PSI(CMakeMake):
     @staticmethod
     def extra_options():
         """Extra easyconfig parameters specific to PSI."""
-
-        extra_vars = {
+        extra_vars = CMakeMake.extra_options()
+        extra_vars.update({
             # always include running PSI unit tests (takes about 2h or less)
             'runtest': ["tests TESTFLAGS='-u -q'", "Run tests included with PSI, without interruption.", BUILD],
-        }
-        return CMakeMake.extra_options(extra_vars)
+        })
+        extra_vars['build_type'][0] = 'Release'
+        return extra_vars
 
     def configure_step(self):
         """
@@ -143,9 +144,7 @@ class EB_PSI(CMakeMake):
             if self.name == 'PSI4' and LooseVersion(self.version) >= LooseVersion("1.2"):
                 self.log.info("Remove the CMAKE_BUILD_TYPE test in PSI4 source and the downloaded dependencies!")
                 self.log.info("Use PATCH_COMMAND in the corresponding CMakeLists.txt")
-                self.cfg.update('configopts', ' -DCMAKE_BUILD_TYPE=EasyBuildRelease')
-            else:
-                self.cfg.update('configopts', ' -DCMAKE_BUILD_TYPE=Release')
+                self.cfg['build_type'] = 'EasyBuildRelease'
 
             if self.toolchain.options.get('usempi', None):
                 self.cfg.update('configopts', " -DENABLE_MPI=ON")

--- a/easybuild/easyblocks/p/psi.py
+++ b/easybuild/easyblocks/p/psi.py
@@ -65,7 +65,8 @@ class EB_PSI(CMakeMake):
             # always include running PSI unit tests (takes about 2h or less)
             'runtest': ["tests TESTFLAGS='-u -q'", "Run tests included with PSI, without interruption.", BUILD],
         })
-        extra_vars['build_type'][0] = 'Release'
+        # Doesn't work with out-of-source build
+        extra_vars['separate_build_dir'][0] = False
         return extra_vars
 
     def configure_step(self):

--- a/easybuild/easyblocks/r/root.py
+++ b/easybuild/easyblocks/r/root.py
@@ -45,10 +45,12 @@ class EB_ROOT(CMakeMake):
         """
         Define extra options needed by Geant4
         """
-        extra_vars = {
+        extra_vars = CMakeMake.extra_options()
+        extra_vars.update({
             'arch': [None, "Target architecture", CUSTOM],
-        }
-        return CMakeMake.extra_options(extra_vars)
+        })
+        extra_vars['separate_build_dir'][0] = True
+        return extra_vars
 
     def configure_step(self):
         """Custom configuration for ROOT, add configure options."""
@@ -87,7 +89,6 @@ class EB_ROOT(CMakeMake):
             if get_software_root('X11'):
                 self.cfg.update('configopts', '-Dx11=ON')
 
-            self.cfg['separate_build_dir'] = True
             CMakeMake.configure_step(self)
         else:
             if self.cfg['arch'] is None:

--- a/easybuild/easyblocks/s/superlu.py
+++ b/easybuild/easyblocks/s/superlu.py
@@ -32,9 +32,7 @@ import os
 from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
-from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.systemtools import get_shared_lib_ext
 from easybuild.tools.modules import get_software_root, get_software_version, get_software_libdir
 
 
@@ -46,9 +44,7 @@ class EB_SuperLU(CMakeMake):
     @staticmethod
     def extra_options():
         extra_vars = CMakeMake.extra_options()
-        extra_vars.update({
-            'build_shared_libs': [False, "Build shared library (instead of static library)", CUSTOM],
-        })
+        extra_vars['build_shared_libs'][0] = False
         extra_vars['separate_build_dir'][0] = True
         return extra_vars
 
@@ -56,13 +52,6 @@ class EB_SuperLU(CMakeMake):
         """
         Set the CMake options for SuperLU
         """
-        if self.cfg['build_shared_libs']:
-            self.cfg.update('configopts', '-DBUILD_SHARED_LIBS=ON')
-            self.lib_ext = get_shared_lib_ext()
-        else:
-            self.cfg.update('configopts', '-DBUILD_SHARED_LIBS=OFF')
-            self.lib_ext = 'a'
-
         # Make sure not to build the slow BLAS library included in the package
         self.cfg.update('configopts', '-Denable_blaslib=OFF')
 

--- a/easybuild/easyblocks/s/superlu.py
+++ b/easybuild/easyblocks/s/superlu.py
@@ -63,10 +63,6 @@ class EB_SuperLU(CMakeMake):
             self.cfg.update('configopts', '-DBUILD_SHARED_LIBS=OFF')
             self.lib_ext = 'a'
 
-        # Add -fPIC flag if necessary
-        pic_flag = ('OFF', 'ON')[self.toolchain.options['pic']]
-        self.cfg.update('configopts', '-DCMAKE_POSITION_INDEPENDENT_CODE=%s' % pic_flag)
-
         # Make sure not to build the slow BLAS library included in the package
         self.cfg.update('configopts', '-Denable_blaslib=OFF')
 

--- a/easybuild/easyblocks/s/superlu.py
+++ b/easybuild/easyblocks/s/superlu.py
@@ -45,24 +45,20 @@ class EB_SuperLU(CMakeMake):
 
     @staticmethod
     def extra_options():
-        """
-        Define custom easyconfig parameters for SuperLU.
-        """
-        extra_vars = {
+        extra_vars = CMakeMake.extra_options()
+        extra_vars.update({
             'build_shared_libs': [False, "Build shared library (instead of static library)", CUSTOM],
-        }
-        return CMakeMake.extra_options(extra_vars)
+        })
+        extra_vars['separate_build_dir'][0] = True
+        return extra_vars
 
     def configure_step(self):
         """
         Set the CMake options for SuperLU
         """
-        self.cfg['separate_build_dir'] = True
-
         if self.cfg['build_shared_libs']:
             self.cfg.update('configopts', '-DBUILD_SHARED_LIBS=ON')
             self.lib_ext = get_shared_lib_ext()
-
         else:
             self.cfg.update('configopts', '-DBUILD_SHARED_LIBS=OFF')
             self.lib_ext = 'a'

--- a/easybuild/easyblocks/t/trilinos.py
+++ b/easybuild/easyblocks/t/trilinos.py
@@ -60,6 +60,14 @@ class EB_Trilinos(CMakeMake):
         }
         return CMakeMake.extra_options(extra_vars)
 
+    def __init__(self, *args, **kwargs):
+        """Constructor of custom easyblock for Trilinos."""
+        super(EB_Trilinos, self).__init__(*args, **kwargs)
+
+        if self.cfg['shared_libs'] is not None:
+            self.log.deprecated("Use 'build_shared_libs' instead of 'shared_libs' easyconfig parameter", '5.0')
+            self.cfg['build_shared_libs'] = self.cfg['shared_libs']
+
     def configure_step(self):
         """Set some extra environment variables before configuring."""
 
@@ -91,11 +99,6 @@ class EB_Trilinos(CMakeMake):
         # MPI
         if self.toolchain.options.get('usempi', None):
             self.cfg.update('configopts', "-DTPL_ENABLE_MPI:BOOL=ON")
-
-        # shared libraries
-        if self.cfg['shared_libs'] is not None:
-            self.log.deprecated("Use 'build_shared_libs' instead of 'shared_libs' easyconfig parameter", '5.0')
-            self.cfg['build_shared_libs'] = self.cfg['shared_libs']
 
         # enable full testing
         self.cfg.update('configopts', "-DTrilinos_ENABLE_TESTS:BOOL=ON")

--- a/easybuild/easyblocks/t/trilinos.py
+++ b/easybuild/easyblocks/t/trilinos.py
@@ -97,9 +97,6 @@ class EB_Trilinos(CMakeMake):
             self.log.deprecated("Use 'build_shared_libs' instead of 'shared_libs' easyconfig parameter", '5.0')
             self.cfg['build_shared_libs'] = self.cfg['shared_libs']
 
-        # release or debug gversion
-        self.cfg['build_type'] = 'Debug' if self.toolchain.options.get('debug', None) else 'Release'
-
         # enable full testing
         self.cfg.update('configopts', "-DTrilinos_ENABLE_TESTS:BOOL=ON")
         self.cfg.update('configopts', "-DTrilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES:BOOL=ON")

--- a/easybuild/easyblocks/t/trilinos.py
+++ b/easybuild/easyblocks/t/trilinos.py
@@ -98,11 +98,8 @@ class EB_Trilinos(CMakeMake):
         else:
             self.cfg.update('configopts', "-DBUILD_SHARED_LIBS:BOOL=OFF")
 
-        # release or debug get_version
-        if self.toolchain.options['debug']:
-            self.cfg.update('configopts', "-DCMAKE_BUILD_TYPE:STRING=DEBUG")
-        else:
-            self.cfg.update('configopts', "-DCMAKE_BUILD_TYPE:STRING=RELEASE")
+        # release or debug gversion
+        self.cfg['build_type'] = 'Debug' if self.toolchain.options.get('debug', None) else 'Release'
 
         # enable full testing
         self.cfg.update('configopts', "-DTrilinos_ENABLE_TESTS:BOOL=ON")

--- a/easybuild/easyblocks/t/trilinos.py
+++ b/easybuild/easyblocks/t/trilinos.py
@@ -52,7 +52,7 @@ class EB_Trilinos(CMakeMake):
     def extra_options():
         """Add extra config options specific to Trilinos."""
         extra_vars = {
-            'shared_libs': [False, "Build shared libs; if False, build static libs", CUSTOM],
+            'shared_libs': [None, "Deprecated. Use build_shared_libs", CUSTOM],
             'openmp': [True, "Enable OpenMP support", CUSTOM],
             'all_exts': [True, "Enable all Trilinos packages", CUSTOM],
             'skip_exts': [[], "List of Trilinos packages to skip", CUSTOM],
@@ -93,10 +93,9 @@ class EB_Trilinos(CMakeMake):
             self.cfg.update('configopts', "-DTPL_ENABLE_MPI:BOOL=ON")
 
         # shared libraries
-        if self.cfg['shared_libs']:
-            self.cfg.update('configopts', "-DBUILD_SHARED_LIBS:BOOL=ON")
-        else:
-            self.cfg.update('configopts', "-DBUILD_SHARED_LIBS:BOOL=OFF")
+        if self.cfg['shared_libs'] is not None:
+            self.log.deprecated("Use 'build_shared_libs' instead of 'shared_libs' easyconfig parameter", '5.0')
+            self.cfg['build_shared_libs'] = self.cfg['shared_libs']
 
         # release or debug gversion
         self.cfg['build_type'] = 'Debug' if self.toolchain.options.get('debug', None) else 'Release'


### PR DESCRIPTION
This now contains (is rebased on) https://github.com/easybuilders/easybuild-easyblocks/pull/1921

 I worked on some more parameters in the CMakeMake EB.

- out of source builds: `separate_build_dir` gets now set by EasyBlocks that require it
- fPIC: Honor toolchainopts
- new EasyConfig parameter `build_shared_libs` to unify existing practice
- `build_type` honors toolchainopts (defaults to Release)

See individual commits