### PR TITLE
enable out of tree build by default in CMakeMake easyblock

### DIFF
--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -81,7 +81,7 @@ class CMakeMake(ConfigureMake):
                                  "Defaults to 'Release' or 'Debug' depending on toolchainopts[debug]", CUSTOM],
             'configure_cmd': [DEFAULT_CONFIGURE_CMD, "Configure command to use", CUSTOM],
             'srcdir': [None, "Source directory location to provide to cmake command", CUSTOM],
-            'separate_build_dir': [False, "Perform build in a separate directory", CUSTOM],
+            'separate_build_dir': [True, "Perform build in a separate directory", CUSTOM],
         })
         return extra_vars
 
@@ -118,7 +118,7 @@ class CMakeMake(ConfigureMake):
 
         setup_cmake_env(self.toolchain)
 
-        if builddir is None and self.cfg.get('separate_build_dir', False):
+        if builddir is None and self.cfg.get('separate_build_dir', True):
             builddir = os.path.join(self.builddir, 'easybuild_obj')
 
         if builddir:

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -94,7 +94,7 @@ class CMakeMake(ConfigureMake):
     def lib_ext(self):
         """Return the extension for libraries build based on `build_shared_libs` or None if that is unset"""
         if self._lib_ext is None:
-            build_shared_libs = self.cfg['build_shared_libs']
+            build_shared_libs = self.cfg.get('build_shared_libs')
             if build_shared_libs:
                 self._lib_ext = get_shared_lib_ext()
             elif build_shared_libs is not None:
@@ -108,7 +108,7 @@ class CMakeMake(ConfigureMake):
     @property
     def build_type(self):
         """Build type set in the EasyConfig with default determined by toolchainopts"""
-        build_type = self.cfg['build_type']
+        build_type = self.cfg.get('build_type')
         if build_type is None:
             build_type = 'Debug' if self.toolchain.options.get('debug', None) else 'Release'
         return build_type
@@ -138,7 +138,7 @@ class CMakeMake(ConfigureMake):
         options = ['-DCMAKE_INSTALL_PREFIX=%s' % self.installdir]
 
         if '-DCMAKE_BUILD_TYPE=' in self.cfg['configopts']:
-            if self.cfg['build_type'] is not None:
+            if self.cfg.get('build_type') is not None:
                 self.log.warning('CMAKE_BUILD_TYPE is set in configopts. Ignoring build_type')
         else:
             options.append('-DCMAKE_BUILD_TYPE=%s' % self.build_type)
@@ -149,7 +149,7 @@ class CMakeMake(ConfigureMake):
 
         # Set flag for shared libs if requested
         # Not adding one allows the project to choose a default
-        build_shared_libs = self.cfg['build_shared_libs']
+        build_shared_libs = self.cfg.get('build_shared_libs')
         if build_shared_libs is not None:
             # Contrary to other options build_shared_libs takes precedence over configopts which may be unexpected.
             # This is to allow self.lib_ext to be determined correctly.

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -130,7 +130,8 @@ class CMakeMake(ConfigureMake):
 
         if srcdir is None:
             if self.cfg.get('srcdir', None) is not None:
-                srcdir = self.cfg['srcdir']
+                # Note that the join returns srcdir if it is absolute
+                srcdir = os.path.join(default_srcdir, self.cfg['srcdir'])
             else:
                 srcdir = default_srcdir
 


### PR DESCRIPTION
This supersedes #616 and includes #1929 which in turn includes an improved version of #616 concerning defaults for out-of-tree builds while this contains the setting only.

Better: It is intended that 1929 is merged first, and this rebased on the merged result (currently it is rebased on 1929) to see the small changes made by this PR. 1929 contains explicit setting of out-of-tree builds where required which is need for this PR to work.

I already did extensive tests with existing EasyConfigs using True as the default. The ECs using CMake are 
[cmakeECs.txt](https://github.com/easybuilders/easybuild-easyblocks/files/4071432/cmakeECs.txt) as found by grepping the ECs and EBs. I chose a subset of those to test excluding ones using old Intel toolchains as I don't have old intel compilers. I previously excluded all intel ECs hence the names below

So:
- Tested ECs: [cmakeECs-non-intel.txt](https://github.com/easybuilders/easybuild-easyblocks/files/4090324/cmakeECs-non-intel.txt)
- Successful ECs: [cmakeECs-OK.txt](https://github.com/easybuilders/easybuild-easyblocks/files/4090325/cmakeECs-OK.txt)
- Failed ECs with reason: [cmakeECs-Error.txt](https://github.com/easybuilders/easybuild-easyblocks/files/4071461/cmakeECs-Error.txt)

From this extensive test the failure introduced was always a build failure so can be easily detected. To the best of my knowledge (according to the tests) there are no failures introduced for existing ECs. Most non-EB ECs should be caught by the changed EasyBlocks that set the out-of-tree build to False where required.

From those results I see no reason NOT to enable it by default. I'm against using the deprecating behavior as this would force all ECs/EBs to include setting the new default which will be rendered superflous, I Included it nonetheless to spark some discussion but would like to remove it.
