### PR TITLE
Gurobi licence server modifications

### DIFF
--- a/easybuild/easyblocks/g/gurobi.py
+++ b/easybuild/easyblocks/g/gurobi.py
@@ -27,6 +27,7 @@
 EasyBuild support for installing Gurobi, implemented as an easyblock
 
 @author: Bob Dröge (University of Groningen)
+modified by James Carpenter (University of Birmingham)
 """
 import os
 
@@ -44,19 +45,23 @@ class EB_Gurobi(Tarball):
     def install_step(self):
         """Install Gurobi and license file."""
 
-        # Check if the client license file is already defined in the standard Gurobi variable
-        licfile = os.getenv("GRB_LICENSE_FILE")
+        # Check if the client license file is already defined in the appropriate easyconfig variable
+        licfile = self.cfg['license_file']
         if licfile is None:
-            # make sure license file is available
-            if self.cfg['license_file'] is None or not os.path.exists(self.cfg['license_file']):
-                raise EasyBuildError("No existing license file specified: %s", self.cfg['license_file'])
-        elif not os.path.exists(licfile):
-            raise EasyBuildError("Environment variable GRB_LICENSE_FILE value \"%s\" isn't a valid path", licfile)
+            # Fallback to standard Gurobi license file environment variable
+            licfile = os.getenv('GRB_LICENSE_FILE')
+            if licfile is None:
+                raise EasyBuildError("No license file specified in either the "
+                                     "easyconfig or as GRB_LICENSE_FILE env var")
+
+        if not os.path.exists(licfile):
+            raise EasyBuildError("The provided license_file value \"%s\" is not a valid path", licfile)
 
         super(EB_Gurobi, self).install_step()
 
-        if licfile is None:
-            copy_file(self.cfg['license_file'], os.path.join(self.installdir, 'gurobi.lic'))
+        # Copy the license file to the install dir only if it was specified in the easyconfig
+        if self.cfg['license_file']:
+            copy_file(licfile, os.path.join(self.installdir, 'gurobi.lic'))
 
         if get_software_root('Python'):
             run_cmd("python setup.py install --prefix=%s" % self.installdir)


### PR DESCRIPTION
Modifies block to check for the pre-existence of the `GRB_LICENSE_FILE` env var and uses its value if present, else uses `license_file` value from the easyconfig.