### PR TITLE
get_tbb_gccprefix: support GCCcore and gcc4.8 (if that dir exists)

### DIFF
--- a/easybuild/easyblocks/i/icc.py
+++ b/easybuild/easyblocks/i/icc.py
@@ -187,7 +187,7 @@ class EB_icc(IntelBase):
                 'ipp/lib/intel64',
                 'mkl/lib/intel64',
                 'mpi/intel64',
-                'tbb/lib/intel64/%s' % get_tbb_gccprefix(),
+                'tbb/lib/intel64/%s' % get_tbb_gccprefix(os.path.join(self.installdir, 'tbb/lib/intel64')),
             ])
 
             if LooseVersion(self.version) < LooseVersion('2016'):


### PR DESCRIPTION
This fixes the issue that icc/iccifort/recent tbb installations may no longer set LD_LIBRARY_PATH and LIBRARY_PATH, since the library files may now be in a `gcc4.8` subdirectory.

This fix is as minimal as possible, though I doubt that gcc<4.4 is relevant any more.
