### PR TITLE
openblas: remove tests from build_step and raise error on failed tests

### DIFF
--- a/easybuild/easyblocks/o/openblas.py
+++ b/easybuild/easyblocks/o/openblas.py
@@ -47,6 +47,13 @@ class EB_OpenBLAS(ConfigureMake):
                 build_parts += ['re_lapack']
         build_parts += ['shared']
 
+        # Pass CFLAGS through command line to avoid redefinitions (issue xianyi/OpenBLAS#818)
+        cflags = 'CFLAGS'
+        if os.environ[cflags]:
+            self.cfg.update('buildopts', "%s='%s'" % (cflags, os.environ[cflags]))
+            del os.environ[cflags]
+            self.log.info("Environment variable %s unset and passed through command line" % cflags)
+
         cmd = "%s make %s %s" % (self.cfg['prebuildopts'], ' '.join(build_parts), self.cfg['buildopts'])
         run_cmd(cmd, log_all=True, simple=True)
 

--- a/easybuild/easyblocks/o/openblas.py
+++ b/easybuild/easyblocks/o/openblas.py
@@ -51,13 +51,18 @@ class EB_OpenBLAS(ConfigureMake):
         run_cmd(cmd, log_all=True, simple=True)
 
     def test_step(self):
-        """ Mandatory test step """
+        """ Mandatory test step plus optional runtest"""
 
         cmd = "%s make tests %s" % (self.cfg['pretestopts'], self.cfg['testopts'])
-        (out, ec) = run_cmd(cmd, log_all=True, simple=False, regexp=False)
+        (out, _) = run_cmd(cmd, log_all=True, simple=False, regexp=False)
 
         # Raise an error if any test failed
         check_log_for_errors(out, [('FATAL ERROR', ERROR)])
+
+        # Run any optional tests
+        if self.cfg['runtest']:
+            cmd = "%s make %s %s" % (self.cfg['pretestopts'], self.cfg['runtest'], self.cfg['testopts'])
+            run_cmd(cmd, log_all=True, simple=False)
 
     def sanity_check_step(self):
         """ Custom sanity check for OpenBLAS """

--- a/easybuild/easyblocks/o/openblas.py
+++ b/easybuild/easyblocks/o/openblas.py
@@ -8,6 +8,8 @@ from distutils.version import LooseVersion
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.systemtools import POWER, get_cpu_architecture, get_shared_lib_ext
 from easybuild.tools.build_log import print_warning
+from easybuild.tools.config import ERROR
+from easybuild.tools.run import run_cmd, check_log_for_errors
 
 
 class EB_OpenBLAS(ConfigureMake):
@@ -29,11 +31,32 @@ class EB_OpenBLAS(ConfigureMake):
             default_opts['TARGET'] = 'POWER8'
 
         for key in sorted(default_opts.keys()):
-            for opts_key in ['buildopts', 'installopts']:
+            for opts_key in ['buildopts', 'testopts', 'installopts']:
                 if '%s=' % key not in self.cfg[opts_key]:
                     self.cfg.update(opts_key, "%s='%s'" % (key, default_opts[key]))
 
         self.cfg.update('installopts', 'PREFIX=%s' % self.installdir)
+
+    def build_step(self):
+        """ Custom build step excluding the tests """
+
+        # Equivalent to `make all` without the tests
+        build_parts = ['libs', 'netlib']
+        if 'BUILD_RELAPACK' in self.cfg['buildopts']:
+            build_parts += ['re_lapack']
+        build_parts += ['shared']
+
+        cmd = "%s make %s %s" % (self.cfg['prebuildopts'], ' '.join(build_parts), self.cfg['buildopts'])
+        run_cmd(cmd, log_all=True, simple=True)
+
+    def test_step(self):
+        """ Mandatory test step """
+
+        cmd = "%s make tests %s" % (self.cfg['pretestopts'], self.cfg['testopts'])
+        (out, ec) = run_cmd(cmd, log_all=True, simple=False, regexp=False)
+
+        # Raise an error if any test failed
+        check_log_for_errors(out, [('FATAL ERROR', ERROR)])
 
     def sanity_check_step(self):
         """ Custom sanity check for OpenBLAS """

--- a/easybuild/easyblocks/o/openblas.py
+++ b/easybuild/easyblocks/o/openblas.py
@@ -42,8 +42,9 @@ class EB_OpenBLAS(ConfigureMake):
 
         # Equivalent to `make all` without the tests
         build_parts = ['libs', 'netlib']
-        if 'BUILD_RELAPACK' in self.cfg['buildopts']:
-            build_parts += ['re_lapack']
+        for buildopt in self.cfg['buildopts'].split():
+            if 'BUILD_RELAPACK' in buildopt and '1' in buildopt:
+                build_parts += ['re_lapack']
         build_parts += ['shared']
 
         cmd = "%s make %s %s" % (self.cfg['prebuildopts'], ' '.join(build_parts), self.cfg['buildopts'])


### PR DESCRIPTION
Update for `openblas` easyblock to detect and raise an error on failed tests. Currently OpenBLAS is running its tests in the build step and the installation proceed regardless of their result.

* `build_step` will run a custom make command that is equivalent to `make all` but without the tests
* `test_step` will run the tests and raise an exception if any test fails.

Additional issues to be solved:
* (already present in current easyblock) many compilation variables are redefined. Example
> gcc -O2 -ftree-vectorize -march=native -fno-math-errno -O2 -DMAX_STACK_ALLOC=2048 -fopenmp -Wall -m64 -DF_INTERFACE_GFORT -fPIC -      DSMP_SERVER -DUSE_OPENMP -DNO_WARMUP -DMAX_CPU_NUMBER=24 -DMAX_PARALLEL_NUMBER=1 -DVERSION=\"0.3.7\" -march=skylake-avx512 **-DASMNAME= -DASMFNAME=_ -DNAME=_ -DCNAME= -DCHAR_NAME=\"_\" -DCHAR_CNAME=\"\"** -DNO_AFFINITY -I. *-O2 -DMAX_STACK_ALLOC=2048 -fopenmp -Wall -m64 -DF_INTERFACE_GFORT -fPIC -DSMP_SERVER -DUSE_OPENMP -DNO_WARMUP -DMAX_CPU_NUMBER=24 -DMAX_PARALLEL_NUMBER=1 -DVERSION=\"0.3.7\" -march=skylake-avx512 **-DASMNAME=cblas_isamax -DASMFNAME=cblas_isamax_ -DNAME=cblas_isamax_ -DCNAME=cblas_isamax -DCHAR_NAME=\"cblas_isamax_\" -DCHAR_CNAME=\"cblas_isamax\"** -DNO_AFFINITY -I.. -I. -UDOUBLE  -UCOMPLEX -DCBLAS -c -DUSE_ABS -UUSE_MIN imax.c -o cblas_isamax.o
* (introduced by this PR) Header file `lapack.h` is not installed