### PR TITLE
openblas: add optional runtest to the catch for FATAL ERRORS

### DIFF
--- a/easybuild/easyblocks/o/openblas.py
+++ b/easybuild/easyblocks/o/openblas.py
@@ -61,16 +61,16 @@ class EB_OpenBLAS(ConfigureMake):
     def test_step(self):
         """ Mandatory test step plus optional runtest"""
 
-        cmd = "%s make tests %s" % (self.cfg['pretestopts'], self.cfg['testopts'])
-        (out, _) = run_cmd(cmd, log_all=True, simple=False, regexp=False)
-
-        # Raise an error if any test failed
-        check_log_for_errors(out, [('FATAL ERROR', ERROR)])
-
-        # Run any optional tests
+        run_tests = ['tests']
         if self.cfg['runtest']:
-            cmd = "%s make %s %s" % (self.cfg['pretestopts'], self.cfg['runtest'], self.cfg['testopts'])
-            run_cmd(cmd, log_all=True, simple=False)
+            run_tests += [self.cfg['runtest']]
+
+        for runtest in run_tests:
+            cmd = "%s make %s %s" % (self.cfg['pretestopts'], runtest, self.cfg['testopts'])
+            (out, _) = run_cmd(cmd, log_all=True, simple=False, regexp=False)
+
+            # Raise an error if any test failed
+            check_log_for_errors(out, [('FATAL ERROR', ERROR)])
 
     def sanity_check_step(self):
         """ Custom sanity check for OpenBLAS """


### PR DESCRIPTION
Optional tests added with the `runtest` option were left out from the catch of `FATAL ERRORS`. However, tests such as `blas-test` can behave in a similar way as the default `make tests`, revealing build errors that are going unnoticed by EB.
This PR fixes this issue by parsing all test outputs and raising an error if `FATAL ERROR` is found in any of them.