### PR TITLE
in version 6.0 of TensorRT, libnvinfer.a is renamed libnvinfer_static.a

### DIFF
--- a/easybuild/easyblocks/t/tensorrt.py
+++ b/easybuild/easyblocks/t/tensorrt.py
@@ -26,9 +26,11 @@
 EasyBuild support for building and installing TensorRT, implemented as an easyblock
 
 @author: Ake Sandgren (Umea University)
+@author: Maxime Boissonneault (Universite Laval, Compute Canada)
 """
 import glob
 import os
+from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.binary import Binary
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage, PIP_INSTALL_CMD
@@ -121,9 +123,12 @@ class EB_TensorRT(PythonPackage, Binary):
     def sanity_check_step(self):
         """Custom sanity check for TensorRT."""
         custom_paths = {
-            'files': ['bin/trtexec', 'lib/libnvinfer.a'],
             'dirs': [self.pylibdir],
         }
+        if LooseVersion(self.version) >= LooseVersion('6'):
+            custom_paths['files'] = ['bin/trtexec', 'lib/libnvinfer_static.a']
+        else:
+            custom_paths['files'] = ['bin/trtexec', 'lib/libnvinfer.a']
 
         custom_commands = ["%s -c 'import tensorrt'" % self.python_cmd]
 


### PR DESCRIPTION
For review by @akesandgren probably, since he is the original author