### PR TITLE
add NCDF_PARALLEL and METIS support to Siesta easyblock

### DIFF
--- a/easybuild/easyblocks/s/siesta.py
+++ b/easybuild/easyblocks/s/siesta.py
@@ -177,7 +177,7 @@ class EB_Siesta(ConfigureMake):
             if netcdff_loc:
                 regex_subs.extend([
                     (r"^(LIBS\s*=.*)$", r"\1 $(NETCDF_LIBS)"),
-                    (r"^(FPPFLAGS\s*:?=.*)$", r"\1 -DCDF -DNCDF -DNCDF_4 $(NETCDF_INCLUDE)"),
+                    (r"^(FPPFLAGS\s*:?=.*)$", r"\1 -DCDF -DNCDF -DNCDF_4 -DNCDF_PARALLEL $(NETCDF_INCLUDE)"),
                     (r"^(COMP_LIBS\s*=.*)$", r"\1 libncdf.a libfdict.a"),
                 ])
                 netcdf_lib_and_inc = "NETCDF_LIBS = -lnetcdff\nNETCDF_INCLUDE = -I%s/include" % netcdff_loc
@@ -218,6 +218,13 @@ class EB_Siesta(ConfigureMake):
                     (r"^(FPPFLAGS\s*:?=.*)$", r"\1 -DSIESTA__ELSI"),
                     (r"^(FPPFLAGS\s*:?=.*)$", r"\1 -I%s/include" % elsi),
                     (r"^(LIBS\s*=.*)$", r"\1 $(FFTW_LIBS) -L%s/lib -lelsi" % elsi),
+                ])
+
+            metis = get_software_root('METIS')
+            if metis:
+                regex_subs.extend([
+                    (r"^(FPPFLAGS\s*:?=.*)$", r"\1 -DSIESTA__METIS"),
+                    (r"^(LIBS\s*=.*)$", r"\1 -L%s/lib -lmetis" % metis),
                 ])
 
         apply_regex_substitutions(arch_make, regex_subs)

--- a/easybuild/easyblocks/s/siesta.py
+++ b/easybuild/easyblocks/s/siesta.py
@@ -319,12 +319,16 @@ class EB_Siesta(ConfigureMake):
                 'SiestaSubroutine/FmixMD/Src/para',
                 'SiestaSubroutine/FmixMD/Src/simple',
                 'STM/ol-stm/Src/stm', 'STM/simple-stm/plstm',
-                'VCA/fractional', 'VCA/mixps',
                 'Vibra/Src/fcbuild', 'Vibra/Src/vibra',
-                'WFS/info_wfsx',
                 'WFS/readwf', 'WFS/readwfx', 'WFS/wfs2wfsx',
                 'WFS/wfsnc2wfsx', 'WFS/wfsx2wfs',
             ]
+
+            # skip broken utils in 4.1-MaX-1.0 release, hopefully will be fixed later
+            if self.version != '4.1-MaX-1.0':
+                expected_utils.extend([
+                    'VCA/fractional', 'VCA/mixps',
+                ])
 
             if loose_ver >= LooseVersion('3.2'):
                 expected_utils.extend([
@@ -332,21 +336,26 @@ class EB_Siesta(ConfigureMake):
                 ])
 
             if loose_ver >= LooseVersion('4.0'):
+                if self.version != '4.1-MaX-1.0':
+                    expected_utils.extend([
+                        'SiestaSubroutine/ProtoNEB/Src/protoNEB',
+                        'SiestaSubroutine/SimpleTest/Src/simple_pipes_parallel',
+                        'SiestaSubroutine/SimpleTest/Src/simple_pipes_serial',
+                        'SiestaSubroutine/SimpleTest/Src/simple_sockets_parallel',
+                        'SiestaSubroutine/SimpleTest/Src/simple_sockets_serial',
+                        ])
                 expected_utils.extend([
-                    'SiestaSubroutine/ProtoNEB/Src/protoNEB',
-                    'SiestaSubroutine/SimpleTest/Src/simple_pipes_parallel',
-                    'SiestaSubroutine/SimpleTest/Src/simple_pipes_serial',
-                    'SiestaSubroutine/SimpleTest/Src/simple_sockets_parallel',
-                    'SiestaSubroutine/SimpleTest/Src/simple_sockets_serial',
                     'Sockets/f2fmaster', 'Sockets/f2fslave',
                 ])
                 if self.toolchain.options.get('usempi', None):
-                    expected_utils.extend([
-                        'SiestaSubroutine/SimpleTest/Src/simple_mpi_parallel',
-                        'SiestaSubroutine/SimpleTest/Src/simple_mpi_serial',
-                    ])
+                    if self.version != '4.1-MaX-1.0':
+                        expected_utils.extend([
+                            'SiestaSubroutine/SimpleTest/Src/simple_mpi_parallel',
+                            'SiestaSubroutine/SimpleTest/Src/simple_mpi_serial',
+                        ])
 
             if loose_ver < LooseVersion('4.1'):
+                expected_utils.append('WFS/info_wfsx')
                 if loose_ver >= LooseVersion('4.0'):
                     expected_utils.extend([
                         'COOP/dm_creator',
@@ -380,8 +389,12 @@ class EB_Siesta(ConfigureMake):
                     'Grimme/fdf2grimme',
                     'SpPivot/pvtsp',
                     'TS/TBtrans/tbtrans', 'TS/tselecs.sh',
-                    'TS/ts2ts/ts2ts', 'TS/tshs2tshs/tshs2tshs',
+                    'TS/ts2ts/ts2ts',
                 ])
+                if self.version != '4.1-MaX-1.0':
+                    expected_utils.extend([
+                        'TS/tshs2tshs/tshs2tshs',
+                    ])
 
             for util in expected_utils:
                 copy_file(os.path.join(start_dir, 'Util', util), bindir)


### PR DESCRIPTION
and skip check for broken utils in 4.1-MaX-1.0 release

(created using `eb --new-pr`)
