### PR TITLE
[CMake] Handle configopts without configure args

### DIFF
--- a/easybuild/easyblocks/c/cmake.py
+++ b/easybuild/easyblocks/c/cmake.py
@@ -51,7 +51,8 @@ class EB_CMake(ConfigureMake):
         """
         Run qmake on the GUI, if necessary
         """
-        configopts = self.cfg['configopts'].split(' -- ', 1)
+        configopts = self.cfg['configopts']
+        configopts = configopts.split('-- ' if configopts.startswith('-- ') else ' -- ', 1)
         configure_opts = configopts[0]
         cmake_opts = configopts[1] if len(configopts) == 2 else ''
 


### PR DESCRIPTION
If there are configopts that start with "-- " then this is not recognized as arguments for the 2nd stage (CMake) leading to configure errors.

This handles the case specifically and is tested with https://github.com/easybuilders/easybuild-easyconfigs/pull/9923