### PR TITLE
use checkout@v2 in GitHub Actions to fix broken re-triggered tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -32,7 +32,7 @@ jobs:
             python: 3.7
       fail-fast: false
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: set up Python
       uses: actions/setup-python@v1


### PR DESCRIPTION
see https://github.com/actions/checkout/issues/23 and https://github.com/easybuilders/easybuild-easyconfigs/pull/9925