### PR TITLE
add cascadelake to KOKKOS_CPU_MAPPING in LAMMPS easyblock

### DIFF
--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -64,6 +64,7 @@ KOKKOS_CPU_MAPPING = {
     'haswell': 'HSW',
     'broadwell': 'BDW',
     'skylake_avx512': 'SKX',
+    'cascadelake': 'SKX',
     'knights-landing': 'KNL',
 }
 


### PR DESCRIPTION
fix for `Couldn't determine CPU architecture, you need to set 'kokkos_arch' manually.` when building LAMMPS on an Intel Cascade Lake system (e.g. Intel Xeon Gold 6240), avoid having to add `kokkos_arch = 'SKX'` in the easyconfig file...