### PR TITLE
also set TRINITY_HOME environment variable in Trinity easyblock

### DIFF
--- a/easybuild/easyblocks/t/trinity.py
+++ b/easybuild/easyblocks/t/trinity.py
@@ -367,9 +367,10 @@ class EB_Trinity(EasyBlock):
 
         guesses = super(EB_Trinity, self).make_module_req_guess()
 
+        install_rootdir = os.path.basename(self.cfg['start_dir'].strip('/'))
         guesses.update({
-            'PATH': [os.path.basename(self.cfg['start_dir'].strip('/'))],
-            'TRINITY_HOME': [os.path.basename(self.cfg['start_dir'].strip('/'))],
+            'PATH': [install_rootdir],
+            'TRINITY_HOME': [install_rootdir],
         })
 
         return guesses

--- a/easybuild/easyblocks/t/trinity.py
+++ b/easybuild/easyblocks/t/trinity.py
@@ -369,6 +369,7 @@ class EB_Trinity(EasyBlock):
 
         guesses.update({
             'PATH': [os.path.basename(self.cfg['start_dir'].strip('/'))],
+            'TRINITY_HOME': [os.path.basename(self.cfg['start_dir'].strip('/'))],
         })
 
         return guesses


### PR DESCRIPTION
Many scripts in `Trinity` rely on having the environmental variable `TRINITY_HOME` pointing to the root of the installation directory.