### PR TITLE
fix sanity check for OpenFOAM-Extend >= 4.1

### DIFF
--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -347,7 +347,13 @@ class EB_OpenFOAM(EasyBlock):
         shlib_ext = get_shared_lib_ext()
 
         # OpenFOAM >= 3.0.0 can use 64 bit integers
-        if 'extend' not in self.name.lower() and self.looseversion >= LooseVersion('3.0'):
+        # same goes for OpenFOAM-Extend >= 4.1
+        if 'extend' in self.name.lower():
+            set_int_size = self.looseversion >= LooseVersion('4.1')
+        else:
+            set_int_size = self.looseversion >= LooseVersion('3.0')
+
+        if set_int_size:
             if self.toolchain.options['i8']:
                 int_size = 'Int64'
             else:


### PR DESCRIPTION
binaries and libraries for `OpenFOAM-Extend` 4.1 are now also installed into `applications/bin/linux64GccDPOpt` rather than `applications/bin/linux64GccDPInt32Opt`, and `lib/linux64GccDPInt32Opt` rather than `lib/linux64GccDPOpt` (like was already the case for `OpenFOAM` >= 3.0)