### PR TITLE
fix use of 'sorted' in LAMMPS easyblock

### DIFF
--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -282,7 +282,7 @@ class EB_LAMMPS(CMakeMake):
 def get_cuda_gpu_arch(cuda_cc):
     """Return CUDA gpu ARCH in LAMMPS required format. Example: 'sm_32' """
     # Get largest cuda supported
-    return 'sm_%s' % str(cuda_cc.sorted(reverse=True)[0]).replace(".", "")
+    return 'sm_%s' % str(sorted(cuda_cc, reverse=True)[0]).replace(".", "")
 
 
 def get_kokkos_arch(cuda_cc, kokkos_arch):
@@ -317,7 +317,7 @@ def get_kokkos_arch(cuda_cc, kokkos_arch):
     if cuda:
         # CUDA below
         gpu_arch = None
-        for cc in cuda_cc.sorted(reverse=True):
+        for cc in sorted(cuda_cc, reverse=True):
             gpu_arch = KOKKOS_GPU_ARCH_TABLE.get(str(cc))
             if gpu_arch:
                 break


### PR DESCRIPTION
fixes this issue when trying to build LAMMPS with CUDA support:

```
ERROR: Traceback (most recent call last):
  File "/lib/python2.7/site-packages/easybuild_framework-4.1.2.dev0-py2.7.egg/easybuild/main.py", line 113, in build_and_install_software
    (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env)
  File "/lib/python2.7/site-packages/easybuild_framework-4.1.2.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 3138, in build_and_install_one
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/lib/python2.7/site-packages/easybuild_framework-4.1.2.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 3046, in run_all_steps
    self.run_step(step_name, step_methods)
  File "/lib/python2.7/site-packages/easybuild_framework-4.1.2.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2916, in run_step
    step_method(self)()
  File "/tmp/eb-8m0xt0i7/included-easyblocks/easybuild/easyblocks/lammps.py", line 208, in configure_step
    self.cfg.update('configopts', '-DKOKKOS_ARCH="%s"' % get_kokkos_arch(cuda_cc, self.cfg['kokkos_arch']))
  File "/tmp/eb-8m0xt0i7/included-easyblocks/easybuild/easyblocks/lammps.py", line 320, in get_kokkos_arch
    for cc in cuda_cc.sorted(reverse=True):
AttributeError: 'list' object has no attribute 'sorted'
```

It can never have worked with the `.sorted()`, this was overlooked in #1964