### PR TITLE
tarball: add support for preinstallopts and install in subdirectory

### DIFF
--- a/easybuild/easyblocks/generic/tarball.py
+++ b/easybuild/easyblocks/generic/tarball.py
@@ -53,7 +53,7 @@ class Tarball(EasyBlock):
         """Extra easyconfig parameters specific to Tarball."""
         extra_vars = EasyBlock.extra_options(extra=extra_vars)
         extra_vars.update({
-            'final_dir': [None, "Override default installation path with provided path", CUSTOM],
+            'install_in_subdir': [False, "Extract tarball in a subdirectory with the name of the package", CUSTOM],
         })
         return extra_vars
 
@@ -86,8 +86,8 @@ class Tarball(EasyBlock):
         # Copy source directory
         source_path = src or self.cfg['start_dir']
 
-        if 'final_dir' in self.cfg and self.cfg['final_dir']:
-            install_path = os.path.join(self.installdir, self.cfg['final_dir'])
+        if self.cfg['install_in_subdir']:
+            install_path = os.path.join(self.installdir, self.name.lower())
         else:
             install_path = self.installdir
 

--- a/easybuild/easyblocks/generic/tarball.py
+++ b/easybuild/easyblocks/generic/tarball.py
@@ -54,6 +54,7 @@ class Tarball(EasyBlock):
         extra_vars = EasyBlock.extra_options(extra=extra_vars)
         extra_vars.update({
             'install_in_subdir': [False, "Extract tarball in a subdirectory with the name of the package", CUSTOM],
+            'preinstall_cmd': [None, "Command to execute before installation", CUSTOM],
         })
         return extra_vars
 
@@ -76,10 +77,14 @@ class Tarball(EasyBlock):
     def install_step(self, src=None):
         """Install by copying from specified source directory (or 'start_dir' if not specified)."""
 
-        # Run preinstallopts before copy of source directory
+        # Run preinstallopts and/or preinstall_cmd before copy of source directory
+        preinstall_cmd = None
         if self.cfg['preinstallopts']:
             preinstall_opts = self.cfg['preinstallopts'].split('&&')
             preinstall_cmd = '&&'.join([opt for opt in preinstall_opts if opt and not opt.isspace()])
+        if self.cfg['preinstall_cmd']:
+            preinstall_cmd = '&& '.join([cmd for cmd in [preinstall_cmd, self.cfg['preinstall_cmd']] if cmd])
+        if preinstall_cmd:
             self.log.info("Preparing installation of %s using command '%s'..." % (self.name, preinstall_cmd))
             run_cmd(preinstall_cmd, log_all=True, simple=True)
 

--- a/easybuild/easyblocks/generic/tarball.py
+++ b/easybuild/easyblocks/generic/tarball.py
@@ -34,6 +34,8 @@ implemented as an easyblock
 @author: Alex Domingo (Vrije Universiteit Brussel)
 """
 
+import os
+
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.filetools import copy_dir, remove_dir
@@ -83,7 +85,12 @@ class Tarball(EasyBlock):
 
         # Copy source directory
         source_path = src or self.cfg['start_dir']
-        install_path = self.cfg['final_dir'] or self.installdir
+
+        if 'final_dir' in self.cfg and self.cfg['final_dir']:
+            install_path = os.path.join(self.installdir, self.cfg['final_dir'])
+        else:
+            install_path = self.installdir
+
         self.log.info("Copying tarball contents of %s to %s..." % (self.name, install_path))
         remove_dir(install_path)
         copy_dir(source_path, install_path, symlinks=self.cfg['keepsymlinks'])

--- a/easybuild/easyblocks/generic/tarball.py
+++ b/easybuild/easyblocks/generic/tarball.py
@@ -32,6 +32,7 @@ implemented as an easyblock
 @author: Pieter De Baets (Ghent University)
 @author: Jens Timmerman (Ghent University)
 @author: Alex Domingo (Vrije Universiteit Brussel)
+@author: Pavel Grochal (INUITS)
 """
 
 import os


### PR DESCRIPTION
Update for tarball easyblock to make it (1) more flexible and (2) usable as a component in a bundle:
* Currently, `tarball` deletes and re-creates `installdir` on each installation, removing any installation from previous components. This PR adds an extra variable `final_dir` that is similar to `start_dir` and can be used to target sub-directories of `installdir`, preserving installations from previous components. The default behavior of `tarball` will be unaffected.
* Adds support for using `preinstallopts` with `tarball`. Any commands given through `preinstallopts` will be executed before the copy of files to install directory.