### PR TITLE
rewrite GROMACS easyblock to build all four variations in the same build

### DIFF
--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -254,12 +254,13 @@ class EB_GROMACS(CMakeMake):
                     mpiexec = which(mpiexec)
                     if mpiexec:
                         self.cfg.update('configopts', "-DMPIEXEC=%s" % mpiexec)
-                        self.cfg.update('configopts', "-DMPIEXEC_NUMPROC_FLAG=%s" % self.cfg.get('mpiexec_numproc_flag'))
+                        self.cfg.update('configopts', "-DMPIEXEC_NUMPROC_FLAG=%s" %
+                                        self.cfg.get('mpiexec_numproc_flag'))
                         self.cfg.update('configopts', "-DNUMPROC=%s" % mpi_numprocs)
                     elif self.cfg['runtest']:
                         raise EasyBuildError("'%s' not found in $PATH", self.cfg.get('mpiexec'))
                 else:
-                        raise EasyBuildError("No value found for 'mpiexec'")
+                    raise EasyBuildError("No value found for 'mpiexec'")
                 self.log.info("Using %s as MPI executable when testing, with numprocs flag '%s' and %s tasks",
                               self.cfg.get('mpiexec'), self.cfg.get('mpiexec_numproc_flag'),
                               mpi_numprocs)
@@ -430,7 +431,8 @@ class EB_GROMACS(CMakeMake):
 
             super(EB_GROMACS, self).install_step()
 
-            # the GROMACS libraries get installed in different locations (deeper subdirectory), depending on the platform;
+            # the GROMACS libraries get installed in different locations (deeper subdirectory),
+            # depending on the platform;
             # this is determined by the GNUInstallDirs CMake module;
             # rather than trying to replicate the logic, we just figure out where the library was placed
 

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -158,13 +158,15 @@ class EB_GROMACS(CMakeMake):
                 # otherwise warn about it and skip the double precision build
                 if self.cfg['double_precision']:
                     raise EasyBuildError("Double precision is not available for GPU build. " +
-                                         "Please explicitly set \"double_precision = False\" or remove it in the easyconfig file.")
+                                         "Please explicitly set \"double_precision = False\" " +
+                                         "or remove it in the easyconfig file.")
                 if re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I):
                     if self.cfg['double_precision'] is None:
                         # Only print warning once when trying double precision
                         # build the frst time
                         self.cfg['double_precision'] = False
-                        print_warning("Double precision is not available for GPU build. Skipping the double precision build.")
+                        print_warning("Double precision is not available for " +
+                                      "GPU build. Skipping the double precision build.")
 
                     print_msg("skipping configure step", silent=self.silent)
                     return
@@ -257,7 +259,8 @@ class EB_GROMACS(CMakeMake):
                     # check whether Python is loaded as a dependency
                     python_root = get_software_root('Python')
                     if python_root:
-                        self.cfg.update('configopts', "-DPYTHON_EXECUTABLE=%s" % os.path.join(python_root, 'bin', 'python'))
+                        self.cfg.update('configopts',
+                                        "-DPYTHON_EXECUTABLE=%s" % os.path.join(python_root, 'bin', 'python'))
                         self.cfg.update('configopts', "-DGMX_PYTHON_PACKAGE=ON")
 
             # Now patch GROMACS for PLUMED before cmake
@@ -383,7 +386,8 @@ class EB_GROMACS(CMakeMake):
 
         cuda = get_software_root('CUDA')
         if cuda:
-            if not self.cfg['double_precision'] and re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I):
+            if not self.cfg['double_precision'] and
+               re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I):
                 print_msg("skipping build step", silent=self.silent)
                 return
 
@@ -415,7 +419,8 @@ class EB_GROMACS(CMakeMake):
         # is for double precision
         cuda = get_software_root('CUDA')
         if cuda:
-            if not self.cfg['double_precision'] and re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I):
+            if not self.cfg['double_precision'] and
+               re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I):
                 print_msg("skipping install step", silent=self.silent)
                 return
 
@@ -632,7 +637,6 @@ class EB_GROMACS(CMakeMake):
             for mpitype in mpitypes:
                 self.variants_to_build += 1
                 versions_built.append('%s precision %s' % (prec, mpitype))
-                var_preconfopts = []
                 var_confopts = []
                 var_buildopts = []
                 var_installopts = []

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -132,7 +132,7 @@ class EB_GROMACS(CMakeMake):
     def is_double_precision_cuda_build(self):
         """Check if the current build step involves double precision and CUDA"""
         cuda = get_software_root('CUDA')
-        return cuda and self.DP_pattern in self.cfg['configopts']
+        return cuda and self.double_prec_pattern in self.cfg['configopts']
 
     def prepare_step(self, *args, **kwargs):
         """Custom prepare step for GROMACS."""
@@ -166,7 +166,7 @@ class EB_GROMACS(CMakeMake):
                     raise EasyBuildError("Double precision is not available for GPU build. " +
                                          "Please explicitly set \"double_precision = False\" " +
                                          "or remove it in the easyconfig file.")
-                if self.DP_pattern in self.cfg['configopts']:
+                if self.double_prec_pattern in self.cfg['configopts']:
                     if self.cfg.get('double_precision') is None:
                         # Only print warning once when trying double precision
                         # build the first time
@@ -540,7 +540,7 @@ class EB_GROMACS(CMakeMake):
         if not get_software_root('CUDA'):
             for configopts in configopts_list:
                 # add the _d suffix to the suffix, in case of double precission
-                if self.DP_pattern in configopts:
+                if self.double_prec_pattern in configopts:
                     dsuff = '_d'
 
         if dsuff:
@@ -605,7 +605,7 @@ class EB_GROMACS(CMakeMake):
             }
 
         # Double precision pattern so search for in configopts
-        self.DP_pattern = prec_opts['double']
+        self.double_prec_pattern = prec_opts['double']
 
         if LooseVersion(self.version) < LooseVersion('5'):
             # For older versions we only build/install the mdrun part for

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -570,16 +570,16 @@ class EB_GROMACS(CMakeMake):
         """
         # Save installopts so we can reset it later. The gmxapi pip install
         # can't handle the -j argument.
-        self.save_installopts = self.cfg.get('installopts')
+        self.save_installopts = self.cfg['installopts']
 
         # keep track of config/build/installopts specified in easyconfig
         # file, so we can include them in each iteration later
-        common_config_opts = self.cfg.get('configopts')
-        common_build_opts = self.cfg.get('buildopts')
-        common_install_opts = self.cfg.get('installopts')
+        common_config_opts = self.cfg['configopts']
+        common_build_opts = self.cfg['buildopts']
+        common_install_opts = self.cfg['installopts']
 
-        self.save_install_cmd = self.cfg.get('install_cmd')
-        self.save_build_cmd = self.cfg.get('build_cmd')
+        self.save_install_cmd = self.cfg['install_cmd']
+        self.save_build_cmd = self.cfg['build_cmd']
 
         self.cfg['configopts'] = []
         self.cfg['buildopts'] = []

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -407,7 +407,7 @@ class EB_GROMACS(CMakeMake):
             if isinstance(self.cfg['runtest'], bool):
                 self.cfg['runtest'] = 'check'
 
-            # run 'make check' or whever the easyconfig specifies 
+            # run 'make check' or whever the easyconfig specifies
             # in parallel since it involves more compilation
             self.cfg.update('runtest', "-j %s" % self.cfg['parallel'])
             super(EB_GROMACS, self).test_step()

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -548,11 +548,9 @@ class EB_GROMACS(CMakeMake):
             suffixes.extend([dsuff])
 
         lib_files.extend([
-            'lib%s%s.%s' % (libname, suff, self.libext) for libname in libnames + mpi_libnames for suff in suffixes
+            'lib%s%s.%s' % (x, suff, self.libext) for x in libnames + mpi_libnames for suff in suffixes
         ])
-        bin_files.extend([
-            b + suff for b in bins + mpi_bins for suff in suffixes
-        ])
+        bin_files.extend([b + suff for b in bins + mpi_bins for suff in suffixes])
 
         # pkgconfig dir not available for earlier versions, exact version to use here is unclear
         if LooseVersion(self.version) >= LooseVersion('4.6'):

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -247,7 +247,7 @@ class EB_GROMACS(CMakeMake):
 
                 elif self.cfg.get('mpi_numprocs') > self.cfg['parallel']:
                     self.log.warning("Number of test MPI tasks (%s) is greater than value for 'parallel': %s",
-                                     self.cfg.get('mpi_numprocs'), self.cfg'parallel'])
+                                     self.cfg.get('mpi_numprocs'), self.cfg['parallel'])
 
                 mpiexec = which(self.cfg.get('mpiexec'))
                 if mpiexec:

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -44,7 +44,7 @@ import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.framework.easyconfig import CUSTOM
-from easybuild.tools.build_log import EasyBuildError, print_msg, print_warning
+from easybuild.tools.build_log import EasyBuildError, print_warning
 from easybuild.tools.config import build_option
 from easybuild.tools.filetools import download_file, extract_file, which
 from easybuild.tools.modules import get_software_libdir, get_software_root, get_software_version

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -162,7 +162,7 @@ class EB_GROMACS(CMakeMake):
                     raise EasyBuildError("Double precision is not available for GPU build. " +
                                          "Please explicitly set \"double_precision = False\" " +
                                          "or remove it in the easyconfig file.")
-                if re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I):
+                if re.search('-DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I):
                     if self.cfg.get('double_precision') is None:
                         # Only print warning once when trying double precision
                         # build the first time
@@ -232,7 +232,7 @@ class EB_GROMACS(CMakeMake):
                 run_cmd(plumed_cmd, log_all=True, simple=True)
 
         else:
-            if re.search('DGMX_MPI=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I):
+            if re.search('-DGMX_MPI=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I):
                 if self.cfg.get('mpi_numprocs') == 0:
                     self.log.info("No number of test MPI tasks specified -- using default: %s" % self.cfg.get('parallel'))
                     self.cfg['mpi_numprocs'] = self.cfg.get('parallel')
@@ -383,7 +383,7 @@ class EB_GROMACS(CMakeMake):
         cuda = get_software_root('CUDA')
         if cuda:
             if (not self.cfg.get('double_precision') and
-                    re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I)):
+                    re.search('-DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I)):
                 print_msg("skipping build step", silent=self.silent)
                 return
 
@@ -416,7 +416,7 @@ class EB_GROMACS(CMakeMake):
         cuda = get_software_root('CUDA')
         if cuda:
             if (not self.cfg.get('double_precision') and
-                    re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I)):
+                    re.search('-DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I)):
                 print_msg("skipping install step", silent=self.silent)
                 return
 
@@ -532,9 +532,9 @@ class EB_GROMACS(CMakeMake):
         if self.cfg.get('double_precision') is None or self.cfg.get('double_precision'):
             for configopts in configopts_list:
                 # add the _d suffix to the suffix, in case of double precission
-                if re.search('enable-double', configopts, re.I):
+                if re.search('-enable-double', configopts, re.I):
                     suff = '_d'
-                if re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', configopts, re.I):
+                if re.search('-DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', configopts, re.I):
                     suff = '_d'
 
         lib_files.extend(['lib%s%s.%s' % (libname, suff, self.libext) for libname in libnames + mpi_libnames])

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -387,7 +387,7 @@ class EB_GROMACS(CMakeMake):
         cuda = get_software_root('CUDA')
         if cuda:
             if not self.cfg['double_precision'] and
-               re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I):
+                re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I):
                 print_msg("skipping build step", silent=self.silent)
                 return
 
@@ -420,7 +420,7 @@ class EB_GROMACS(CMakeMake):
         cuda = get_software_root('CUDA')
         if cuda:
             if not self.cfg['double_precision'] and
-               re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I):
+                re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I):
                 print_msg("skipping install step", silent=self.silent)
                 return
 

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -387,9 +387,9 @@ class EB_GROMACS(CMakeMake):
         cuda = get_software_root('CUDA')
         if cuda:
             if (not self.cfg['double_precision'] and
-                re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I)):
-                    print_msg("skipping build step", silent=self.silent)
-                    return
+                    re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I)):
+                print_msg("skipping build step", silent=self.silent)
+                return
 
         super(EB_GROMACS, self).build_step()
 
@@ -420,9 +420,9 @@ class EB_GROMACS(CMakeMake):
         cuda = get_software_root('CUDA')
         if cuda:
             if (not self.cfg['double_precision'] and
-                re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I)):
-                    print_msg("skipping install step", silent=self.silent)
-                    return
+                    re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I)):
+                print_msg("skipping install step", silent=self.silent)
+                return
 
         # run 'make install' in parallel since it involves more compilation
         self.cfg.update('installopts', "-j %s" % self.cfg['parallel'])

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -456,7 +456,7 @@ class EB_GROMACS(CMakeMake):
                 raise EasyBuildError("Failed to determine lib subdirectory in %s", self.installdir)
 
             # Reset installopts etc for the benefit of the gmxapi extension
-            self.cfg['installopts'] = self.save_installopts
+            self.cfg['installopts'] = self.orig_installopts
 
     def extensions_step(self, fetch=False):
         """ Custom extensions step, only handle extensions after the last iteration round"""
@@ -569,7 +569,7 @@ class EB_GROMACS(CMakeMake):
         """
         # Save installopts so we can reset it later. The gmxapi pip install
         # can't handle the -j argument.
-        self.save_installopts = self.cfg['installopts']
+        self.orig_installopts = self.cfg['installopts']
 
         # keep track of config/build/installopts specified in easyconfig
         # file, so we can include them in each iteration later
@@ -577,8 +577,8 @@ class EB_GROMACS(CMakeMake):
         common_build_opts = self.cfg['buildopts']
         common_install_opts = self.cfg['installopts']
 
-        self.save_install_cmd = self.cfg['install_cmd']
-        self.save_build_cmd = self.cfg['build_cmd']
+        self.orig_install_cmd = self.cfg['install_cmd']
+        self.orig_build_cmd = self.cfg['build_cmd']
 
         self.cfg['configopts'] = []
         self.cfg['buildopts'] = []
@@ -672,7 +672,7 @@ class EB_GROMACS(CMakeMake):
         self.log.info("Building these variants of GROMACS: %s", ', '.join(versions_built))
         return super(EB_GROMACS, self).run_all_steps(*args, **kwargs)
 
-        self.cfg['install_cmd'] = self.save_install_cmd
-        self.cfg['build_cmd'] = self.save_build_cmd
+        self.cfg['install_cmd'] = self.orig_install_cmd
+        self.cfg['build_cmd'] = self.orig_build_cmd
 
         self.log.info("A full regression test suite is available from the GROMACS web site")

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -669,7 +669,7 @@ class EB_GROMACS(CMakeMake):
         self.variants_to_build = len(self.cfg['configopts'])
 
         self.log.debug("List of configure options to iterate over: %s", self.cfg['configopts'])
-        self.log.info("Building these versions of GROMACS: %s", ', '.join(versions_built))
+        self.log.info("Building these variants of GROMACS: %s", ', '.join(versions_built))
         return super(EB_GROMACS, self).run_all_steps(*args, **kwargs)
 
         self.cfg['install_cmd'] = self.save_install_cmd

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -539,7 +539,7 @@ class EB_GROMACS(CMakeMake):
         if not get_software_root('CUDA'):
             for configopts in configopts_list:
                 # add the _d suffix to the suffix, in case of double precission
-                if re.search(self.DP_pattern, configopts):
+                if self.DP_pattern in configopts:
                     dsuff = '_d'
 
         if dsuff:

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -664,9 +664,9 @@ class EB_GROMACS(CMakeMake):
                 var_buildopts.append(build_opts[mpitype])
                 var_installopts.append(install_opts[mpitype])
 
-                self.cfg.update('configopts', [' '.join(var_confopts + [common_config_opts])])
-                self.cfg.update('buildopts', [' '.join(var_buildopts + [common_build_opts])])
-                self.cfg.update('installopts', [' '.join(var_installopts + [common_install_opts])])
+                self.cfg.update('configopts', ' '.join(var_confopts + [common_config_opts]))
+                self.cfg.update('buildopts', ' '.join(var_buildopts + [common_build_opts]))
+                self.cfg.update('installopts', ' '.join(var_installopts + [common_install_opts]))
         self.variants_to_build = len(self.cfg['configopts'])
 
         self.log.debug("List of configure options to iterate over: %s", self.cfg['configopts'])

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -590,8 +590,6 @@ class EB_GROMACS(CMakeMake):
                 'nompi': '--disable-mpi',
                 'mpi': '--enable-mpi'
             }
-            # Double precision pattern so search for in configopts
-            self.DP_pattern = '--enable-double'
         else:
             prec_opts = {
                 'single': '-DGMX_DOUBLE=OFF',
@@ -601,8 +599,9 @@ class EB_GROMACS(CMakeMake):
                 'nompi': '-DGMX_MPI=OFF -DGMX_THREAD_MPI=ON',
                 'mpi': '-DGMX_MPI=ON -DGMX_THREAD_MPI=OFF'
             }
-            # Double precision pattern so search for in configopts
-            self.DP_pattern = '-DGMX_DOUBLE=ON'
+
+        # Double precision pattern so search for in configopts
+        self.DP_pattern = prec_opts['double']
 
         if LooseVersion(self.version) < LooseVersion('5'):
             # For older versions we only build/install the mdrun part for

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -60,7 +60,8 @@ class EB_GROMACS(CMakeMake):
     def extra_options():
         extra_vars = CMakeMake.extra_options()
         extra_vars.update({
-            'double_precision': [None, "Build with double precision enabled (-DGMX_DOUBLE=ON), default is to build double precision unless CUDA is enabled", CUSTOM],
+            'double_precision': [None, "Build with double precision enabled (-DGMX_DOUBLE=ON), " + 
+                                 "default is to build double precision unless CUDA is enabled", CUSTOM],
             'mpisuffix': ['_mpi', "Suffix to append to MPI-enabled executables (only for GROMACS < 4.6)", CUSTOM],
             'mpiexec': ['mpirun', "MPI executable to use when running tests", CUSTOM],
             'mpiexec_numproc_flag': ['-np', "Flag to introduce the number of MPI tasks when running tests", CUSTOM],
@@ -232,7 +233,8 @@ class EB_GROMACS(CMakeMake):
         else:
             if re.search('-DGMX_MPI=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I):
                 if self.cfg.get('mpi_numprocs') == 0:
-                    self.log.info("No number of test MPI tasks specified -- using default: %s" % self.cfg.get('parallel'))
+                    self.log.info("No number of test MPI tasks specified -- using default: %s",
+                                  self.cfg.get('parallel'))
                     self.cfg['mpi_numprocs'] = self.cfg.get('parallel')
 
                 elif self.cfg.get('mpi_numprocs') > self.cfg.get('parallel'):
@@ -247,7 +249,8 @@ class EB_GROMACS(CMakeMake):
                 elif self.cfg.get('runtest'):
                     raise EasyBuildError("'%s' not found in $PATH", self.cfg.get('mpiexec'))
                 self.log.info("Using %s as MPI executable when testing, with numprocs flag '%s' and %s tasks",
-                              self.cfg.get('mpiexec'), self.cfg.get('mpiexec_numproc_flag'), self.cfg.get('mpi_numprocs'))
+                              self.cfg.get('mpiexec'), self.cfg.get('mpiexec_numproc_flag'),
+                              self.cfg.get('mpi_numprocs'))
 
             if LooseVersion(self.version) >= LooseVersion('2019'):
                 # Building the gmxapi interface requires shared libraries

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -404,7 +404,7 @@ class EB_GROMACS(CMakeMake):
             # make very sure OMP_NUM_THREADS is set to 1, to avoid hanging GROMACS regression test
             env.setvar('OMP_NUM_THREADS', '1')
 
-            if isinstance(self.cfg['runtest'], bool):
+            if self.cfg['runtest'] is None or isinstance(self.cfg['runtest'], bool):
                 self.cfg['runtest'] = 'check'
 
             # run 'make check' or whever the easyconfig specifies

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -44,7 +44,7 @@ import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.framework.easyconfig import CUSTOM
-from easybuild.tools.build_log import EasyBuildError, print_warning
+from easybuild.tools.build_log import EasyBuildError, print_msg, print_warning
 from easybuild.tools.config import build_option
 from easybuild.tools.filetools import download_file, extract_file, which
 from easybuild.tools.modules import get_software_libdir, get_software_root, get_software_version
@@ -59,7 +59,7 @@ class EB_GROMACS(CMakeMake):
     @staticmethod
     def extra_options():
         extra_vars = {
-            'double_precision': [False, "Build with double precision enabled (-DGMX_DOUBLE=ON)", CUSTOM],
+            'double_precision': [None, "Build with double precision enabled (-DGMX_DOUBLE=ON)", CUSTOM],
             'mpisuffix': ['_mpi', "Suffix to append to MPI-enabled executables (only for GROMACS < 4.6)", CUSTOM],
             'mpiexec': ['mpirun', "MPI executable to use when running tests", CUSTOM],
             'mpiexec_numproc_flag': ['-np', "Flag to introduce the number of MPI tasks when running tests", CUSTOM],
@@ -72,6 +72,9 @@ class EB_GROMACS(CMakeMake):
         super(EB_GROMACS, self).__init__(*args, **kwargs)
         self.lib_subdir = ''
         self.pre_env = ''
+        self.dynamic = self.toolchain.options.get('dynamic', False)
+        if LooseVersion(self.version) >= LooseVersion('4.6'):
+            self.cfg['separate_build_dir'] = True
 
     def get_gromacs_arch(self):
         """Determine value of GMX_SIMD CMake flag based on optarch string.
@@ -147,6 +150,31 @@ class EB_GROMACS(CMakeMake):
     def configure_step(self):
         """Custom configuration procedure for GROMACS: set configure options for configure or cmake."""
 
+        if LooseVersion(self.version) >= LooseVersion('4.6'):
+            cuda = get_software_root('CUDA')
+            if cuda:
+                # CUDA and double precision is currently not supported
+                # If easyconfig explicitly have double_precision=True error out,
+                # otherwise warn about it and skip the double precision build
+                if self.cfg['double_precision']:
+                    raise EasyBuildError("Double precision is not available for GPU build. " +
+                                         "Please explicitly set \"double_precision = False\" or remove it in the easyconfig file.")
+                if re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I):
+                    if self.cfg['double_precision'] is None:
+                        # Only print warning once when trying double precision
+                        # build the frst time
+                        self.cfg['double_precision'] = False
+                        print_warning("Double precision is not available for GPU build. Skipping the double precision build.")
+
+                    print_msg("skipping configure step", silent=self.silent)
+                    return
+
+                self.cfg.update('configopts', "-DGMX_GPU=ON -DCUDA_TOOLKIT_ROOT_DIR=%s" % cuda)
+            else:
+                # explicitly disable GPU support if CUDA is not available,
+                # to avoid that GROMACS find and uses a system-wide CUDA compiler
+                self.cfg.update('configopts', "-DGMX_GPU=OFF")
+
         # check whether PLUMED is loaded as a dependency
         plumed_root = get_software_root('PLUMED')
         if plumed_root:
@@ -164,6 +192,7 @@ class EB_GROMACS(CMakeMake):
 
         if LooseVersion(self.version) < LooseVersion('4.6'):
             self.log.info("Using configure script for configuring GROMACS build.")
+
             # Use static libraries if possible
             self.cfg.update('configopts', "--enable-static")
 
@@ -199,6 +228,38 @@ class EB_GROMACS(CMakeMake):
                 run_cmd(plumed_cmd, log_all=True, simple=True)
 
         else:
+            if re.search('DGMX_MPI=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I):
+                if self.cfg['mpi_numprocs'] == 0:
+                    self.log.info("No number of test MPI tasks specified -- using default: %s" % self.cfg['parallel'])
+                    self.cfg['mpi_numprocs'] = self.cfg['parallel']
+
+                elif self.cfg['mpi_numprocs'] > self.cfg['parallel']:
+                    self.log.warning("Number of test MPI tasks (%s) is greater than value for 'parallel': %s",
+                                     self.cfg['mpi_numprocs'], self.cfg['parallel'])
+
+                mpiexec = which(self.cfg['mpiexec'])
+                if mpiexec:
+                    self.cfg.update('configopts', "-DMPIEXEC=%s" % mpiexec)
+                    self.cfg.update('configopts', "-DMPIEXEC_NUMPROC_FLAG=%s" % self.cfg['mpiexec_numproc_flag'])
+                    self.cfg.update('configopts', "-DNUMPROC=%s" % self.cfg['mpi_numprocs'])
+                elif self.cfg['runtest']:
+                    raise EasyBuildError("'%s' not found in $PATH", self.cfg['mpiexec'])
+                self.log.info("Using %s as MPI executable when testing, with numprocs flag '%s' and %s tasks",
+                              self.cfg['mpiexec'], self.cfg['mpiexec_numproc_flag'], self.cfg['mpi_numprocs'])
+
+            if LooseVersion(self.version) >= LooseVersion('2019'):
+                # Building the gmxapi interface requires shared libraries
+                self.dynamic = True
+                self.cfg.update('configopts', "-DBUILD_SHARED_LIBS=ON")
+                self.cfg.update('configopts', "-DGMXAPI=ON")
+
+                if LooseVersion(self.version) >= LooseVersion('2020'):
+                    # check whether Python is loaded as a dependency
+                    python_root = get_software_root('Python')
+                    if python_root:
+                        self.cfg.update('configopts', "-DPYTHON_EXECUTABLE=%s" % os.path.join(python_root, 'bin', 'python'))
+                        self.cfg.update('configopts', "-DGMX_PYTHON_PACKAGE=ON")
+
             # Now patch GROMACS for PLUMED before cmake
             if plumed_root:
                 if LooseVersion(self.version) >= LooseVersion('5.1'):
@@ -206,7 +267,7 @@ class EB_GROMACS(CMakeMake):
                     # setting of self.toolchain.options.get('dynamic')
                     # and adapt cmake flags accordingly as per instructions
                     # from "plumed patch -i"
-                    if self.toolchain.options.get('dynamic', False):
+                    if self.dynamic:
                         mode = 'shared'
                     else:
                         mode = 'static'
@@ -221,15 +282,12 @@ class EB_GROMACS(CMakeMake):
                 self.cfg.update('configopts', "-DCMAKE_BUILD_TYPE=Release")
 
             # prefer static libraries, if available
-            if self.toolchain.options.get('dynamic', False):
+            if self.dynamic:
                 self.cfg.update('configopts', "-DGMX_PREFER_STATIC_LIBS=OFF")
             else:
                 self.cfg.update('configopts', "-DGMX_PREFER_STATIC_LIBS=ON")
                 if plumed_root:
                     self.cfg.update('configopts', "-DBUILD_SHARED_LIBS=OFF")
-
-            if self.cfg['double_precision']:
-                self.cfg.update('configopts', "-DGMX_DOUBLE=ON")
 
             # always specify to use external BLAS/LAPACK
             self.cfg.update('configopts', "-DGMX_EXTERNAL_BLAS=ON -DGMX_EXTERNAL_LAPACK=ON")
@@ -258,17 +316,6 @@ class EB_GROMACS(CMakeMake):
                 self.cfg.update('configopts', "-DGMX_OPENMP=ON")
             else:
                 self.cfg.update('configopts', "-DGMX_OPENMP=OFF")
-
-            # disable MPI support for initial, serial/SMP build; actual MPI build is done later
-            self.cfg.update('configopts', "-DGMX_MPI=OFF")
-
-            # explicitly disable GPU support if CUDA is not available,
-            # to avoid that GROMACS find and uses a system-wide CUDA compiler
-            cuda = get_software_root('CUDA')
-            if cuda:
-                self.cfg.update('configopts', "-DGMX_GPU=ON -DCUDA_TOOLKIT_ROOT_DIR=%s" % cuda)
-            else:
-                self.cfg.update('configopts', "-DGMX_GPU=OFF")
 
             if get_software_root('imkl'):
                 # using MKL for FFT, so it will also be used for BLAS/LAPACK
@@ -314,7 +361,6 @@ class EB_GROMACS(CMakeMake):
                     env.setvar('LDFLAGS', "%s -L%s %s" % (ldflags, os.path.join(root, libdir), link_flag))
 
             # complete configuration with configure_method of parent
-            self.cfg['separate_build_dir'] = True
             out = super(EB_GROMACS, self).configure_step()
 
             # for recent GROMACS versions, make very sure that a decent BLAS, LAPACK and FFT is found and used
@@ -328,6 +374,20 @@ class EB_GROMACS(CMakeMake):
                     regex = re.compile(pattern, re.M)
                     if not regex.search(out):
                         raise EasyBuildError("Pattern '%s' not found in GROMACS configuration output.", pattern)
+
+    def build_step(self):
+        """
+        Custom build step for GROMACS; Skip if CUDA is enabled and the current
+        iteration is for double precision
+        """
+
+        cuda = get_software_root('CUDA')
+        if cuda:
+            if not self.cfg['double_precision'] and re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I):
+                print_msg("skipping build step", silent=self.silent)
+                return
+
+        super(EB_GROMACS, self).build_step()
 
     def test_step(self):
         """Run the basic tests (but not necessarily the full regression tests) using make check"""
@@ -343,20 +403,32 @@ class EB_GROMACS(CMakeMake):
                 self.cfg.update('runtest', "-j %s" % self.cfg['parallel'])
             super(EB_GROMACS, self).test_step()
 
+            # Set runtest to None so that the gmxapi extension doesn't try to
+            # run "check" as a command
+            self.cfg['runtest'] = None
+
     def install_step(self):
         """
         Custom install step for GROMACS; figure out where libraries were installed to.
-        Also, install the MPI version of the executable in a separate step.
         """
+        # Skipping the install step if CUDA is enabled and the current iteration
+        # is for double precision
+        cuda = get_software_root('CUDA')
+        if cuda:
+            if not self.cfg['double_precision'] and re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I):
+                print_msg("skipping install step", silent=self.silent)
+                return
+
         # run 'make install' in parallel since it involves more compilation
         self.cfg.update('installopts', "-j %s" % self.cfg['parallel'])
+
         super(EB_GROMACS, self).install_step()
 
         # the GROMACS libraries get installed in different locations (deeper subdirectory), depending on the platform;
         # this is determined by the GNUInstallDirs CMake module;
         # rather than trying to replicate the logic, we just figure out where the library was placed
 
-        if self.toolchain.options.get('dynamic', False):
+        if self.dynamic:
             self.libext = get_shared_lib_ext()
         else:
             self.libext = 'a'
@@ -377,55 +449,15 @@ class EB_GROMACS(CMakeMake):
         if not self.lib_subdir:
             raise EasyBuildError("Failed to determine lib subdirectory in %s", self.installdir)
 
-        # Install a version with the MPI suffix
-        if self.toolchain.options.get('usempi', None):
-            if LooseVersion(self.version) < LooseVersion('4.6'):
+        # Reset installopts etc for the benefit of the gmxapi extension
+        self.cfg['installopts'] = self.save_installopts
 
-                cmd = "make distclean"
-                (out, _) = run_cmd(cmd, log_all=True, simple=False)
-
-                self.cfg.update('configopts', "--enable-mpi --program-suffix={0}".format(self.cfg['mpisuffix']))
-                ConfigureMake.configure_step(self)
-
-                super(EB_GROMACS, self).build_step()
-
-                super(EB_GROMACS, self).install_step()
-
-            else:
-                self.cfg['configopts'] = re.sub(r'-DGMX_MPI=OFF', r'', self.cfg['configopts'])
-
-                if self.cfg['mpi_numprocs'] == 0:
-                    self.log.info("No number of test MPI tasks specified -- using default: %s" % self.cfg['parallel'])
-                    self.cfg['mpi_numprocs'] = self.cfg['parallel']
-
-                elif self.cfg['mpi_numprocs'] > self.cfg['parallel']:
-                    self.log.warning("Number of test MPI tasks (%s) is greater than value for 'parallel': %s",
-                                     self.cfg['mpi_numprocs'], self.cfg['parallel'])
-
-                self.cfg.update('configopts', "-DGMX_MPI=ON -DGMX_THREAD_MPI=OFF")
-
-                mpiexec = which(self.cfg['mpiexec'])
-                if mpiexec:
-                    self.cfg.update('configopts', "-DMPIEXEC=%s" % mpiexec)
-                    self.cfg.update('configopts', "-DMPIEXEC_NUMPROC_FLAG=%s" % self.cfg['mpiexec_numproc_flag'])
-                    self.cfg.update('configopts', "-DNUMPROC=%s" % self.cfg['mpi_numprocs'])
-                elif self.cfg['runtest']:
-                    raise EasyBuildError("'%s' not found in $PATH", self.cfg['mpiexec'])
-
-
-                self.log.info("Using %s as MPI executable when testing, with numprocs flag '%s' and %s tasks",
-                              self.cfg['mpiexec'], self.cfg['mpiexec_numproc_flag'], self.cfg['mpi_numprocs'])
-
-                # clean up obj dir before reconfiguring
-                shutil.rmtree(os.path.join(self.builddir, 'easybuild_obj'))
-
-                # rebuild/test/install with MPI options
-                super(EB_GROMACS, self).configure_step()
-                super(EB_GROMACS, self).build_step()
-                super(EB_GROMACS, self).test_step()
-                super(EB_GROMACS, self).install_step()
-
-                self.log.info("A full regression test suite is available from the GROMACS web site")
+    def extensions_step(self, fetch=False):
+        """ Custom extensions step, only handle extensions after the last iteration round"""
+        if self.iter_idx < self.variants_to_build-1:
+            print_msg("skipping extension step %s" % self.iter_idx, silent=self.silent)
+            return
+        super(EB_GROMACS, self).extensions_step(fetch)
 
     def make_module_req_guess(self):
         """Custom library subdirectories for GROMACS."""
@@ -444,21 +476,37 @@ class EB_GROMACS(CMakeMake):
 
         # in GROMACS v5.1, only 'gmx' binary is there
         # (only) in GROMACS v5.0, other binaries are symlinks to 'gmx'
+        # bins/libs that never have an _mpi suffix
         bins = []
         libnames = []
+        # bins/libs that may have an _mpi suffix
+        mpi_bins = []
+        mpi_libnames = []
         if LooseVersion(self.version) < LooseVersion('5.1'):
-            bins.extend(['editconf', 'g_lie', 'genbox', 'genconf', 'mdrun'])
+            mpi_bins.extend(['mdrun'])
 
         if LooseVersion(self.version) >= LooseVersion('5.0'):
-            bins.append('gmx')
-            libnames.append('gromacs')
-            if LooseVersion(self.version) < LooseVersion('5.1') and self.toolchain.options.get('usempi', None):
-                bins.append('mdrun')
+            mpi_bins.append('gmx')
+            mpi_libnames.append('gromacs')
         else:
-            libnames.extend(['gmxana', 'gmx', 'md'])
-            # note: gmxpreprocess may also already be there for earlier versions
-            if LooseVersion(self.version) > LooseVersion('4.6'):
-                libnames.append('gmxpreprocess')
+            bins.extend(['editconf', 'g_lie', 'genbox', 'genconf'])
+            libnames.extend(['gmxana'])
+            if LooseVersion(self.version) >= LooseVersion('4.6'):
+                if self.dynamic:
+                    mpi_libnames.extend(['gmx', 'md'])
+                else:
+                    libnames.extend(['gmx', 'md'])
+            else:
+                mpi_libnames.extend(['gmx', 'md'])
+
+            if LooseVersion(self.version) >= LooseVersion('4.5'):
+                if LooseVersion(self.version) >= LooseVersion('4.6'):
+                    if self.dynamic:
+                        mpi_libnames.append('gmxpreprocess')
+                    else:
+                        libnames.append('gmxpreprocess')
+                else:
+                    mpi_libnames.append('gmxpreprocess')
 
         # also check for MPI-specific binaries/libraries
         if self.toolchain.options.get('usempi', None):
@@ -467,8 +515,8 @@ class EB_GROMACS(CMakeMake):
             else:
                 mpisuff = '_mpi'
 
-            bins.extend([binary + mpisuff for binary in bins])
-            libnames.extend([libname + mpisuff for libname in libnames])
+            mpi_bins.extend([binary + mpisuff for binary in mpi_bins])
+            mpi_libnames.extend([libname + mpisuff for libname in mpi_libnames])
 
         suff = ''
 
@@ -480,13 +528,16 @@ class EB_GROMACS(CMakeMake):
         lib_files = []
         bin_files = []
 
-        for configopts in configopts_list:
-            # add the _d suffix to the suffix, in case of the double precission
-            if re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', configopts, re.I):
-                suff = '_d'
+        if self.cfg['double_precision'] is None or self.cfg['double_precision']:
+            for configopts in configopts_list:
+                # add the _d suffix to the suffix, in case of double precission
+                if re.search('enable-double', configopts, re.I):
+                    suff = '_d'
+                if re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', configopts, re.I):
+                    suff = '_d'
 
-            lib_files.extend(['lib%s%s.%s' % (libname, suff, self.libext) for libname in libnames])
-            bin_files.extend([b + suff for b in bins])
+        lib_files.extend(['lib%s%s.%s' % (libname, suff, self.libext) for libname in libnames + mpi_libnames])
+        bin_files.extend([b + suff for b in bins + mpi_bins])
 
         # pkgconfig dir not available for earlier versions, exact version to use here is unclear
         if LooseVersion(self.version) >= LooseVersion('4.6'):
@@ -498,3 +549,116 @@ class EB_GROMACS(CMakeMake):
             'dirs': dirs,
         }
         super(EB_GROMACS, self).sanity_check_step(custom_paths=custom_paths)
+
+    def run_all_steps(self, *args, **kwargs):
+        """
+        Put configure options in place for different variants, (no)mpi, single/double precision.
+        """
+        # Save installopts so we can reset it later. The gmxapi pip install
+        # can't handle the -j argument.
+        self.save_installopts = self.cfg['installopts']
+
+        # keep track of config/build/installopts specified in easyconfig
+        # file, so we can include them in each iteration later
+        common_config_opts = self.cfg['configopts']
+        common_build_opts = self.cfg['buildopts']
+        common_install_opts = self.cfg['installopts']
+
+        self.save_install_cmd = self.cfg.get('install_cmd')
+        self.save_build_cmd = self.cfg.get('build_cmd')
+
+        self.cfg['configopts'] = []
+        self.cfg['buildopts'] = []
+        self.cfg['installopts'] = []
+
+        if LooseVersion(self.version) < LooseVersion('4.6'):
+            prec_opts = {
+                'single': '',
+                'double': '--enable-double',
+            }
+            mpi_type_opts = {
+                'nompi': '',
+                'mpi': '--enable-mpi'
+            }
+        else:
+            prec_opts = {
+                'single': '',
+                'double': '-DGMX_DOUBLE=ON',
+            }
+            mpi_type_opts = {
+                'nompi': '-DGMX_MPI=OFF -DGMX_THREAD_MPI=ON',
+                'mpi': '-DGMX_MPI=ON -DGMX_THREAD_MPI=OFF'
+            }
+
+        if LooseVersion(self.version) < LooseVersion('5'):
+            # For older versions we only build/install the mdrun part for
+            # the MPI variant. So we need to be able to specify the
+            # install target depending on variant.
+            self.cfg['install_cmd'] = 'make'
+
+            # Use the fact that for older versions we just need to
+            # build and install mdrun for the MPI part
+            build_opts = {
+                'nompi': '',
+                'mpi': 'mdrun'
+            }
+            install_opts = {
+                'nompi': 'install',
+                'mpi': 'install-mdrun'
+            }
+        else:
+            build_opts = {
+                'nompi': '',
+                'mpi': ''
+            }
+            install_opts = {
+                'nompi': 'install',
+                'mpi': 'install'
+            }
+
+        precs = ['single']
+        if self.cfg['double_precision'] is None or self.cfg['double_precision']:
+            precs.append('double')
+
+        mpitypes = ['nompi']
+        if self.toolchain.options.get('usempi', None):
+            mpitypes.append('mpi')
+
+        # We need to count the numb er of variations to build.
+        self.variants_to_build = 0
+        versions_built = []
+        # Handle the different variants
+        for prec in precs:
+            for mpitype in mpitypes:
+                self.variants_to_build += 1
+                versions_built.append('%s precision %s' % (prec, mpitype))
+                var_preconfopts = []
+                var_confopts = []
+                var_buildopts = []
+                var_installopts = []
+
+                var_confopts.append(mpi_type_opts[mpitype])
+                var_confopts.append(prec_opts[prec])
+                if LooseVersion(self.version) < LooseVersion('4.6'):
+                    suffix = ''
+                    if mpitype == 'mpi':
+                        suffix = "--program-suffix={0}".format(self.cfg['mpisuffix'])
+                        if prec == 'double':
+                            suffix += '_d'
+                    var_confopts.append(suffix)
+
+                var_buildopts.append(build_opts[mpitype])
+                var_installopts.append(install_opts[mpitype])
+
+                self.cfg.update('configopts', [' '.join(var_confopts) + ' ' + common_config_opts])
+                self.cfg.update('buildopts', [' '.join(var_buildopts) + ' ' + common_build_opts])
+                self.cfg.update('installopts', [' '.join(var_installopts) + ' ' + common_install_opts])
+
+        self.log.debug("List of configure options to iterate over: %s", self.cfg['configopts'])
+        print_msg("Building these versions of GROMACS: %s" % ', '.join(versions_built), silent=self.silent)
+        return super(EB_GROMACS, self).run_all_steps(*args, **kwargs)
+
+        self.cfg['install_cmd'] = self.save_install_cmd
+        self.cfg['build_cmd'] = self.save_build_cmd
+
+        self.log.info("A full regression test suite is available from the GROMACS web site")

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -386,8 +386,8 @@ class EB_GROMACS(CMakeMake):
 
         cuda = get_software_root('CUDA')
         if cuda:
-            if not self.cfg['double_precision'] and
-                re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I):
+            if (not self.cfg['double_precision'] and
+                re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I)):
                     print_msg("skipping build step", silent=self.silent)
                     return
 
@@ -419,8 +419,8 @@ class EB_GROMACS(CMakeMake):
         # is for double precision
         cuda = get_software_root('CUDA')
         if cuda:
-            if not self.cfg['double_precision'] and
-                re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I):
+            if (not self.cfg['double_precision'] and
+                re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I)):
                     print_msg("skipping install step", silent=self.silent)
                     return
 

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -631,7 +631,6 @@ class EB_GROMACS(CMakeMake):
         # Handle the different variants
         for precicion in precisions:
             for mpitype in mpitypes:
-                self.variants_to_build += 1
                 versions_built.append('%s precision %s' % (precicion, mpitype))
                 var_confopts = []
                 var_buildopts = []
@@ -653,6 +652,7 @@ class EB_GROMACS(CMakeMake):
                 self.cfg.update('configopts', [' '.join(var_confopts) + ' ' + common_config_opts])
                 self.cfg.update('buildopts', [' '.join(var_buildopts) + ' ' + common_build_opts])
                 self.cfg.update('installopts', [' '.join(var_installopts) + ' ' + common_install_opts])
+        self.variants_to_build = len(self.cfg['configopts'])
 
         self.log.debug("List of configure options to iterate over: %s", self.cfg.get('configopts'))
         print_msg("Building these versions of GROMACS: %s" % ', '.join(versions_built), silent=self.silent)

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -643,20 +643,20 @@ class EB_GROMACS(CMakeMake):
         # We need to count the number of variations to build.
         versions_built = []
         # Handle the different variants
-        for precicion in precisions:
+        for precision in precisions:
             for mpitype in mpitypes:
-                versions_built.append('%s precision %s' % (precicion, mpitype))
+                versions_built.append('%s precision %s' % (precision, mpitype))
                 var_confopts = []
                 var_buildopts = []
                 var_installopts = []
 
                 var_confopts.append(mpi_type_opts[mpitype])
-                var_confopts.append(prec_opts[precicion])
+                var_confopts.append(prec_opts[precision])
                 if LooseVersion(self.version) < LooseVersion('4.6'):
                     suffix = ''
                     if mpitype == 'mpi':
                         suffix = "--program-suffix={0}".format(self.cfg.get('mpisuffix'))
-                        if precicion == 'double':
+                        if precision == 'double':
                             suffix += '_d'
                     var_confopts.append(suffix)
 

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -640,8 +640,7 @@ class EB_GROMACS(CMakeMake):
         if self.toolchain.options.get('usempi', None):
             mpitypes.append('mpi')
 
-        # We need to count the numb er of variations to build.
-        self.variants_to_build = 0
+        # We need to count the number of variations to build.
         versions_built = []
         # Handle the different variants
         for precicion in precisions:

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -617,9 +617,9 @@ class EB_GROMACS(CMakeMake):
                 'mpi': 'install'
             }
 
-        precs = ['single']
+        precisions = ['single']
         if self.cfg.get('double_precision') is None or self.cfg.get('double_precision'):
-            precs.append('double')
+            precisions.append('double')
 
         mpitypes = ['nompi']
         if self.toolchain.options.get('usempi', None):
@@ -629,21 +629,21 @@ class EB_GROMACS(CMakeMake):
         self.variants_to_build = 0
         versions_built = []
         # Handle the different variants
-        for prec in precs:
+        for precicion in precisions:
             for mpitype in mpitypes:
                 self.variants_to_build += 1
-                versions_built.append('%s precision %s' % (prec, mpitype))
+                versions_built.append('%s precision %s' % (precicion, mpitype))
                 var_confopts = []
                 var_buildopts = []
                 var_installopts = []
 
                 var_confopts.append(mpi_type_opts[mpitype])
-                var_confopts.append(prec_opts[prec])
+                var_confopts.append(prec_opts[precicion])
                 if LooseVersion(self.version) < LooseVersion('4.6'):
                     suffix = ''
                     if mpitype == 'mpi':
                         suffix = "--program-suffix={0}".format(self.cfg.get('mpisuffix'))
-                        if prec == 'double':
+                        if precicion == 'double':
                             suffix += '_d'
                     var_confopts.append(suffix)
 

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -132,10 +132,7 @@ class EB_GROMACS(CMakeMake):
     def is_double_precision_cuda_build(self):
         """Check if the current build step involves double precision and CUDA"""
         cuda = get_software_root('CUDA')
-        if cuda:
-            if self.DP_pattern in self.cfg['configopts']:
-                return True
-        return False
+        return cuda and self.DP_pattern in self.cfg['configopts']
 
     def prepare_step(self, *args, **kwargs):
         """Custom prepare step for GROMACS."""

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -541,7 +541,7 @@ class EB_GROMACS(CMakeMake):
             for configopts in configopts_list:
                 # add the _d suffix to the suffix, in case of double precission
                 if re.search(self.DP_pattern, configopts):
-                        dsuff = '_d'
+                    dsuff = '_d'
 
         if dsuff:
             suffixes.extend([dsuff])

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -389,7 +389,7 @@ class EB_GROMACS(CMakeMake):
         iteration is for double precision
         """
 
-        if is_double_precision_cuda_build():
+        if self.is_double_precision_cuda_build():
             self.log.info("skipping build step")
             return
 
@@ -398,7 +398,7 @@ class EB_GROMACS(CMakeMake):
     def test_step(self):
         """Run the basic tests (but not necessarily the full regression tests) using make check"""
 
-        if is_double_precision_cuda_build():
+        if self.is_double_precision_cuda_build():
             self.log.info("skipping test step")
             return
 
@@ -423,7 +423,7 @@ class EB_GROMACS(CMakeMake):
         Custom install step for GROMACS; figure out where libraries were installed to.
         """
         # Skipping if CUDA is enabled and the current iteration is double precision
-        if is_double_precision_cuda_build():
+        if self.is_double_precision_cuda_build():
             self.log.info("skipping install step")
             return
 

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -249,13 +249,17 @@ class EB_GROMACS(CMakeMake):
                     self.log.warning("Number of test MPI tasks (%s) is greater than value for 'parallel': %s",
                                      mpi_numprocs, self.cfg['parallel'])
 
-                mpiexec = which(self.cfg.get('mpiexec'))
+                mpiexec = self.cfg.get('mpiexec')
                 if mpiexec:
-                    self.cfg.update('configopts', "-DMPIEXEC=%s" % mpiexec)
-                    self.cfg.update('configopts', "-DMPIEXEC_NUMPROC_FLAG=%s" % self.cfg.get('mpiexec_numproc_flag'))
-                    self.cfg.update('configopts', "-DNUMPROC=%s" % mpi_numprocs)
-                elif self.cfg['runtest']:
-                    raise EasyBuildError("'%s' not found in $PATH", self.cfg.get('mpiexec'))
+                    mpiexec = which(mpiexec)
+                    if mpiexec:
+                        self.cfg.update('configopts', "-DMPIEXEC=%s" % mpiexec)
+                        self.cfg.update('configopts', "-DMPIEXEC_NUMPROC_FLAG=%s" % self.cfg.get('mpiexec_numproc_flag'))
+                        self.cfg.update('configopts', "-DNUMPROC=%s" % mpi_numprocs)
+                    elif self.cfg['runtest']:
+                        raise EasyBuildError("'%s' not found in $PATH", self.cfg.get('mpiexec'))
+                else:
+                        raise EasyBuildError("No value found for 'mpiexec'")
                 self.log.info("Using %s as MPI executable when testing, with numprocs flag '%s' and %s tasks",
                               self.cfg.get('mpiexec'), self.cfg.get('mpiexec_numproc_flag'),
                               mpi_numprocs)

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -388,8 +388,8 @@ class EB_GROMACS(CMakeMake):
         if cuda:
             if not self.cfg['double_precision'] and
                 re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I):
-                print_msg("skipping build step", silent=self.silent)
-                return
+                    print_msg("skipping build step", silent=self.silent)
+                    return
 
         super(EB_GROMACS, self).build_step()
 
@@ -421,8 +421,8 @@ class EB_GROMACS(CMakeMake):
         if cuda:
             if not self.cfg['double_precision'] and
                 re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg.get('configopts'), re.I):
-                print_msg("skipping install step", silent=self.silent)
-                return
+                    print_msg("skipping install step", silent=self.silent)
+                    return
 
         # run 'make install' in parallel since it involves more compilation
         self.cfg.update('installopts', "-j %s" % self.cfg['parallel'])

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -663,9 +663,9 @@ class EB_GROMACS(CMakeMake):
                 var_buildopts.append(build_opts[mpitype])
                 var_installopts.append(install_opts[mpitype])
 
-                self.cfg.update('configopts', [' '.join(var_confopts) + ' ' + common_config_opts])
-                self.cfg.update('buildopts', [' '.join(var_buildopts) + ' ' + common_build_opts])
-                self.cfg.update('installopts', [' '.join(var_installopts) + ' ' + common_install_opts])
+                self.cfg.update('configopts', [' '.join(var_confopts + [common_config_opts])])
+                self.cfg.update('buildopts', [' '.join(var_buildopts + [common_build_opts])])
+                self.cfg.update('installopts', [' '.join(var_installopts + [common_install_opts])])
         self.variants_to_build = len(self.cfg['configopts'])
 
         self.log.debug("List of configure options to iterate over: %s", self.cfg['configopts'])

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -404,7 +404,7 @@ class EB_GROMACS(CMakeMake):
             # allow to escape testing by setting runtest to False
             if self.cfg['runtest'] is None or self.cfg['runtest']:
 
-                old_runtest = self.cfg['runtest']
+                orig_runtest = self.cfg['runtest']
                 # make very sure OMP_NUM_THREADS is set to 1, to avoid hanging GROMACS regression test
                 env.setvar('OMP_NUM_THREADS', '1')
 
@@ -416,7 +416,7 @@ class EB_GROMACS(CMakeMake):
                 self.cfg.update('runtest', "-j %s" % self.cfg['parallel'])
                 super(EB_GROMACS, self).test_step()
 
-                self.cfg['runtest'] = old_runtest
+                self.cfg['runtest'] = orig_runtest
 
     def install_step(self):
         """
@@ -467,8 +467,10 @@ class EB_GROMACS(CMakeMake):
         else:
             # Set runtest to None so that the gmxapi extension doesn't try to
             # run "check" as a command
+            orig_runtest = self.cfg['runtest']
             self.cfg['runtest'] = None
             super(EB_GROMACS, self).extensions_step(fetch)
+            self.cfg['runtest'] = orig_runtest
 
     def make_module_req_guess(self):
         """Custom library subdirectories for GROMACS."""

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -678,4 +678,4 @@ class EB_GROMACS(CMakeMake):
         self.cfg['install_cmd'] = self.orig_install_cmd
         self.cfg['build_cmd'] = self.orig_build_cmd
 
-        self.log.info("A full regression test suite is available from the GROMACS web site")
+        self.log.info("A full regression test suite is available from the GROMACS web site: %s", self.cfg['homepage'])

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -60,7 +60,7 @@ class EB_GROMACS(CMakeMake):
     def extra_options():
         extra_vars = CMakeMake.extra_options()
         extra_vars.update({
-            'double_precision': [None, "Build with double precision enabled (-DGMX_DOUBLE=ON)", CUSTOM],
+            'double_precision': [None, "Build with double precision enabled (-DGMX_DOUBLE=ON), default is to build double precision unless CUDA is enabled", CUSTOM],
             'mpisuffix': ['_mpi', "Suffix to append to MPI-enabled executables (only for GROMACS < 4.6)", CUSTOM],
             'mpiexec': ['mpirun', "MPI executable to use when running tests", CUSTOM],
             'mpiexec_numproc_flag': ['-np', "Flag to introduce the number of MPI tasks when running tests", CUSTOM],

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -540,7 +540,7 @@ class EB_GROMACS(CMakeMake):
         dsuff = None
         if not get_software_root('CUDA'):
             for configopts in configopts_list:
-                # add the _d suffix to the suffix, in case of double precission
+                # add the _d suffix to the suffix, in case of double precision
                 if self.double_prec_pattern in configopts:
                     dsuff = '_d'
 

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -606,12 +606,11 @@ class EB_GROMACS(CMakeMake):
         # Double precision pattern so search for in configopts
         self.double_prec_pattern = prec_opts['double']
 
+        # For older versions we only build/install the mdrun part for
+        # the MPI variant. So we need to be able to specify the
+        # install target depending on variant.
+        self.cfg['install_cmd'] = 'make'
         if LooseVersion(self.version) < LooseVersion('5'):
-            # For older versions we only build/install the mdrun part for
-            # the MPI variant. So we need to be able to specify the
-            # install target depending on variant.
-            self.cfg['install_cmd'] = 'make'
-
             # Use the fact that for older versions we just need to
             # build and install mdrun for the MPI part
             build_opts = {

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -270,7 +270,7 @@ class EB_GROMACS(CMakeMake):
                 self.cfg.update('configopts', "-DGMXAPI=ON")
 
                 if LooseVersion(self.version) >= LooseVersion('2020'):
-                    # check whether Python is loaded as a dependency
+                    # build Python bindings if Python is loaded as a dependency
                     python_root = get_software_root('Python')
                     if python_root:
                         bin_python = os.path.join(python_root, 'bin', 'python')

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -251,18 +251,18 @@ class EB_GROMACS(CMakeMake):
 
                 mpiexec = self.cfg.get('mpiexec')
                 if mpiexec:
-                    mpiexec = which(mpiexec)
-                    if mpiexec:
-                        self.cfg.update('configopts', "-DMPIEXEC=%s" % mpiexec)
+                    mpiexec_path = which(mpiexec)
+                    if mpiexec_path:
+                        self.cfg.update('configopts', "-DMPIEXEC=%s" % mpiexec_path)
                         self.cfg.update('configopts', "-DMPIEXEC_NUMPROC_FLAG=%s" %
                                         self.cfg.get('mpiexec_numproc_flag'))
                         self.cfg.update('configopts', "-DNUMPROC=%s" % mpi_numprocs)
                     elif self.cfg['runtest']:
-                        raise EasyBuildError("'%s' not found in $PATH", self.cfg.get('mpiexec'))
+                        raise EasyBuildError("'%s' not found in $PATH", mpiexec)
                 else:
                     raise EasyBuildError("No value found for 'mpiexec'")
                 self.log.info("Using %s as MPI executable when testing, with numprocs flag '%s' and %s tasks",
-                              self.cfg.get('mpiexec'), self.cfg.get('mpiexec_numproc_flag'),
+                              mpiexec_path, self.cfg.get('mpiexec_numproc_flag'),
                               mpi_numprocs)
 
             if LooseVersion(self.version) >= LooseVersion('2019'):

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -520,7 +520,7 @@ class EB_GROMACS(CMakeMake):
         # also check for MPI-specific binaries/libraries
         if self.toolchain.options.get('usempi', None):
             if LooseVersion(self.version) < LooseVersion('4.6'):
-                mpisuff = self.cfg.get('mpisuffix')
+                mpisuff = self.cfg.get('mpisuffix', '_mpi')
             else:
                 mpisuff = '_mpi'
 
@@ -655,7 +655,7 @@ class EB_GROMACS(CMakeMake):
                 if LooseVersion(self.version) < LooseVersion('4.6'):
                     suffix = ''
                     if mpitype == 'mpi':
-                        suffix = "--program-suffix={0}".format(self.cfg.get('mpisuffix'))
+                        suffix = "--program-suffix={0}".format(self.cfg.get('mpisuffix', '_mpi'))
                         if precision == 'double':
                             suffix += '_d'
                     var_confopts.append(suffix)

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -239,25 +239,26 @@ class EB_GROMACS(CMakeMake):
 
         else:
             if '-DGMX_MPI=ON' in self.cfg['configopts']:
-                if self.cfg.get('mpi_numprocs', 0) == 0:
+                mpi_numprocs = self.cfg.get('mpi_numprocs', 0)
+                if mpi_numprocs == 0:
                     self.log.info("No number of test MPI tasks specified -- using default: %s",
                                   self.cfg['parallel'])
-                    self.cfg['mpi_numprocs'] = self.cfg['parallel']
+                    mpi_numprocs = self.cfg['parallel']
 
-                elif self.cfg.get('mpi_numprocs') > self.cfg['parallel']:
+                elif mpi_numprocs > self.cfg['parallel']:
                     self.log.warning("Number of test MPI tasks (%s) is greater than value for 'parallel': %s",
-                                     self.cfg.get('mpi_numprocs'), self.cfg['parallel'])
+                                     mpi_numprocs, self.cfg['parallel'])
 
                 mpiexec = which(self.cfg.get('mpiexec'))
                 if mpiexec:
                     self.cfg.update('configopts', "-DMPIEXEC=%s" % mpiexec)
                     self.cfg.update('configopts', "-DMPIEXEC_NUMPROC_FLAG=%s" % self.cfg.get('mpiexec_numproc_flag'))
-                    self.cfg.update('configopts', "-DNUMPROC=%s" % self.cfg.get('mpi_numprocs'))
+                    self.cfg.update('configopts', "-DNUMPROC=%s" % mpi_numprocs)
                 elif self.cfg['runtest']:
                     raise EasyBuildError("'%s' not found in $PATH", self.cfg.get('mpiexec'))
                 self.log.info("Using %s as MPI executable when testing, with numprocs flag '%s' and %s tasks",
                               self.cfg.get('mpiexec'), self.cfg.get('mpiexec_numproc_flag'),
-                              self.cfg.get('mpi_numprocs'))
+                              mpi_numprocs)
 
             if LooseVersion(self.version) >= LooseVersion('2019'):
                 # Building the gmxapi interface requires shared libraries

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -273,8 +273,8 @@ class EB_GROMACS(CMakeMake):
                     # check whether Python is loaded as a dependency
                     python_root = get_software_root('Python')
                     if python_root:
-                        self.cfg.update('configopts',
-                                        "-DPYTHON_EXECUTABLE=%s" % os.path.join(python_root, 'bin', 'python'))
+                        bin_python = os.path.join(python_root, 'bin', 'python')
+                        self.cfg.update('configopts', "-DPYTHON_EXECUTABLE=%s" % bin_python)
                         self.cfg.update('configopts', "-DGMX_PYTHON_PACKAGE=ON")
 
             # Now patch GROMACS for PLUMED before cmake

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -60,7 +60,7 @@ class EB_GROMACS(CMakeMake):
     def extra_options():
         extra_vars = CMakeMake.extra_options()
         extra_vars.update({
-            'double_precision': [None, "Build with double precision enabled (-DGMX_DOUBLE=ON), " + 
+            'double_precision': [None, "Build with double precision enabled (-DGMX_DOUBLE=ON), " +
                                  "default is to build double precision unless CUDA is enabled", CUSTOM],
             'mpisuffix': ['_mpi', "Suffix to append to MPI-enabled executables (only for GROMACS < 4.6)", CUSTOM],
             'mpiexec': ['mpirun', "MPI executable to use when running tests", CUSTOM],

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -201,8 +201,10 @@ class EB_GROMACS(CMakeMake):
         if LooseVersion(self.version) < LooseVersion('4.6'):
             self.log.info("Using configure script for configuring GROMACS build.")
 
-            # Use static libraries if possible
-            self.cfg.update('configopts', "--enable-static")
+            if self.cfg['build_shared_libs']:
+                self.cfg.update('configopts', "--enable-shared --disable-static")
+            else:
+                self.cfg.update('configopts', "--enable-static")
 
             # Use external BLAS and LAPACK
             self.cfg.update('configopts', "--with-external-blas --with-external-lapack")

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -75,8 +75,6 @@ class EB_GROMACS(CMakeMake):
         self.lib_subdir = ''
         self.pre_env = ''
         self.dynamic = self.toolchain.options.get('dynamic', False)
-        if LooseVersion(self.version) >= LooseVersion('4.6'):
-            self.cfg['separate_build_dir'] = True
 
     def get_gromacs_arch(self):
         """Determine value of GMX_SIMD CMake flag based on optarch string.


### PR DESCRIPTION
single precision without MPI, single precision with MPI,
double precision without MPI, double precision with MPI.

Change the default for double_precision from False to None
And a bunch of other changes.

This supersedes https://github.com/easybuilders/easybuild-easyblocks/pull/1987