### PR TITLE
Fix "AttributeError: module 'git' has no attribute 'Git'"

### DIFF
--- a/easybuild/easyblocks/__init__.py
+++ b/easybuild/easyblocks/__init__.py
@@ -55,15 +55,21 @@ def get_git_revision():
     relies on GitPython (see http://gitorious.org/git-python)
     """
     try:
-        import git
+        from git import Git, GitCommandError
     except ImportError:
         return UNKNOWN
     try:
         path = os.path.dirname(__file__)
-        gitrepo = git.Git(path)
-        return gitrepo.rev_list("HEAD").splitlines()[0]
-    except git.GitCommandError:
-        return UNKNOWN
+        gitrepo = Git(path)
+        res = gitrepo.rev_list('HEAD').splitlines()[0]
+        # 'encode' may be required to make sure a regular string is returned rather than a unicode string
+        # (only needed in Python 2; in Python 3, regular strings are already unicode)
+        if not isinstance(res, str):
+            res = res.encode('ascii')
+    except GitCommandError:
+        res = UNKNOWN
+
+    return res
 
 
 git_rev = get_git_revision()


### PR DESCRIPTION
This can happen when using Python3 with EasyBuild in a directory with a
subdirectory named "git" or with any directory "git" in PYTHONPATH but
not having GitPython installed

The fixed code was copied from the framework file (tools/version.py)

edit: see also https://github.com/easybuilders/easybuild-framework/pull/3198