### PR TITLE
Allow differing names for TF wheel

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -515,6 +515,8 @@ class EB_TensorFlow(PythonPackage):
             whl_version = self.version
 
         whl_paths = glob.glob(os.path.join(self.builddir, 'tensorflow-%s-*.whl' % whl_version))
+        if not whl_paths:
+            whl_paths = glob.glob(os.path.join(self.builddir, 'tensorflow-*.whl'))
         if len(whl_paths) == 1:
             # --ignore-installed is required to ensure *this* wheel is installed
             cmd = "pip install --ignore-installed --prefix=%s %s" % (self.installdir, whl_paths[0])


### PR DESCRIPTION
This provides better resistance against changes from the TF side but mainly allows to build custom version like "TensorFlow master" (which I did to have some local EC which allows me to install the current master)

Problem was: The wheel was still named `tensorflow-2.1.0.whl` or something while the version set in the EC could be 2nightly or so