### PR TITLE
QtWebEngine is not fully supported on POWER - so do not sanity check it

### DIFF
--- a/easybuild/easyblocks/q/qt.py
+++ b/easybuild/easyblocks/q/qt.py
@@ -36,7 +36,7 @@ from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import apply_regex_substitutions
 from easybuild.tools.run import run_cmd_qa
-from easybuild.tools.systemtools import get_glibc_version, get_shared_lib_ext
+from easybuild.tools.systemtools import POWER, get_cpu_architecture, get_glibc_version, get_shared_lib_ext
 
 
 class EB_Qt(ConfigureMake):
@@ -169,11 +169,14 @@ class EB_Qt(ConfigureMake):
 
         if self.cfg['check_qtwebengine']:
             glibc_version = get_glibc_version()
-            if LooseVersion(glibc_version) > LooseVersion("2.16"):
+            myarch = get_cpu_architecture()
+            if LooseVersion(glibc_version) <= LooseVersion("2.16"):
+                self.log.debug("Skipping check for qtwebengine, since it requires a more recent glibc.")
+            elif myarch == POWER:
+                self.log.debug("Skipping check for qtwebengine, since it is not supported on POWER.")
+            else:
                 qtwebengine_libs = ['libQt%s%s.%s' % (libversion, l, shlib_ext) for l in ['WebEngine', 'WebEngineCore']]
                 custom_paths['files'].extend([os.path.join('lib', lib) for lib in qtwebengine_libs])
-            else:
-                self.log.debug("Skipping check for qtwebengine, since it requires a more recent glibc.")
 
         if LooseVersion(self.version) >= LooseVersion('4'):
             custom_paths['files'].append('bin/xmlpatterns')


### PR DESCRIPTION
One of the components of QtWebEngine is not (currently) support on POWER, so we should skip the sanity check on it.