### PR TITLE
Fix TensorFlow in some environments

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -440,6 +440,10 @@ class EB_TensorFlow(PythonPackage):
         # https://docs.bazel.build/versions/master/user-manual.html#flag--verbose_failures
         cmd.extend(['--subcommands', '--verbose_failures'])
 
+        # Disable support of AWS platform via config switch introduced in 1.12.1
+        if LooseVersion(self.version) >= LooseVersion('v1.12.1'):
+            cmd.append('--config=noaws')
+
         # Bazel seems to not be able to handle a large amount of parallel jobs, e.g. 176 on some Power machines,
         # and will hang forever building the TensorFlow package.
         # So limit to something high but still reasonable while allowing ECs to overwrite it

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -231,6 +231,7 @@ class EB_TensorFlow(PythonPackage):
             'TF_NEED_AWS': '0',  # Amazon AWS Platform
             'TF_NEED_KAFKA': '0',  # Amazon Kafka Platform
             'TF_SET_ANDROID_WORKSPACE': '0',
+            'TF_DOWNLOAD_CLANG': '0',  # Still experimental in TF 2.1.0
         }
         if cuda_root:
             cuda_version = get_software_version('CUDA')

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -468,6 +468,9 @@ class EB_TensorFlow(PythonPackage):
         if 'EBPYTHONPREFIXES' in os.environ:
             cmd.append('--action_env=EBPYTHONPREFIXES')
 
+        # Ignore user environment for Python
+        cmd.append('--action_env=PYTHONNOUSERSITE=1')
+
         # use same configuration for both host and target programs, which can speed up the build
         # only done when optarch is enabled, since this implicitely assumes that host and target platform are the same
         # see https://docs.bazel.build/versions/master/guide.html#configurations


### PR DESCRIPTION
In https://github.com/easybuilders/easybuild-easyconfigs/pull/9991 I noticed TensorFlow still uses the local user repository which we usually prevent with `PYTHONNOUSERSITE=1` but (of course) TensorFlow needs it slightly different.

Also 2 minor fixes:
- TF 1.12.1 introduced an experimental download clang option which is disabled by default. Explicitely disable it to avoid the prompt
- AWS support was enabled although it should be disabled. Previously it was `TF_NEED_AWS=0` but no it is an explicit switch.