### PR TITLE
make sure libxml2 is built with XZ provided as dependency

### DIFF
--- a/easybuild/easyblocks/l/libxml2.py
+++ b/easybuild/easyblocks/l/libxml2.py
@@ -79,6 +79,10 @@ class EB_libxml2(ConfigureMake, PythonPackage):
         if zlib:
             self.cfg.update('configopts', '--with-zlib=%s' % zlib)
 
+        xz_root = get_software_root('XZ')
+        if xz_root:
+            self.cfg.update('configopts', '--with-lzma=%s' % xz_root)
+
         # enable building of Python bindings if Python is a dependency (or build them ourselves for old versions)
         # disable building of Python bindings if Python is not a dependency
         if self.with_python_bindings and LooseVersion(self.version) >= LooseVersion('2.9.2'):


### PR DESCRIPTION
Just to make sure we don't accidentally pick up the lzma provided by the OS...