### PR TITLE
take into account user defined gallium_drivers and swr_arches in Mesa easyblock

### DIFF
--- a/easybuild/easyblocks/m/mesa.py
+++ b/easybuild/easyblocks/m/mesa.py
@@ -37,6 +37,7 @@ from easybuild.tools.filetools import copy_dir
 from easybuild.tools.systemtools import POWER, X86_64, get_cpu_architecture, get_cpu_features, get_shared_lib_ext
 from easybuild.tools.build_log import EasyBuildError
 
+
 class EB_Mesa(MesonNinja):
     """Custom easyblock for building and installing Mesa."""
 

--- a/easybuild/easyblocks/m/mesa.py
+++ b/easybuild/easyblocks/m/mesa.py
@@ -43,7 +43,7 @@ class EB_Mesa(MesonNinja):
     """Custom easyblock for building and installing Mesa."""
 
     def __init__(self, *args, **kwargs):
-        """Constructor for custom Mesa easyblock: figure out which vales to pass to swr-arches configuration option."""
+        """Constructor for custom Mesa easyblock: figure out which values to pass to swr-arches configuration option."""
 
         super(EB_Mesa, self).__init__(*args, **kwargs)
 
@@ -63,6 +63,8 @@ class EB_Mesa(MesonNinja):
                 gallium_drivers = arch_gallium_drivers[arch]
                 # Add configopt for additional Gallium drivers
                 self.gallium_configopts.append('-Dgallium-drivers=' + ','.join(gallium_drivers))
+
+        self.log.debug('Gallium driver(s) included in the installation: %s' % ', '.join(gallium_drivers))
 
         self.swr_arches = []
 
@@ -84,6 +86,8 @@ class EB_Mesa(MesonNinja):
                 self.swr_arches = sorted([swrarch for feat, swrarch in feat_to_swrarch.items() if feat in cpu_features])
                 # Add configopt for additional SWR arches
                 self.gallium_configopts.append('-Dswr-arches=' + ','.join(self.swr_arches))
+
+            self.log.debug('SWR Gallium driver will support: %s' % ', '.join(self.swr_arches))
 
     def get_configopt_value(self, configopt_name):
         """

--- a/easybuild/easyblocks/m/mesa.py
+++ b/easybuild/easyblocks/m/mesa.py
@@ -36,7 +36,6 @@ from distutils.version import LooseVersion
 from easybuild.easyblocks.generic.mesonninja import MesonNinja
 from easybuild.tools.filetools import copy_dir
 from easybuild.tools.systemtools import POWER, X86_64, get_cpu_architecture, get_cpu_features, get_shared_lib_ext
-from easybuild.tools.build_log import EasyBuildError
 
 
 class EB_Mesa(MesonNinja):

--- a/easybuild/easyblocks/m/mesa.py
+++ b/easybuild/easyblocks/m/mesa.py
@@ -92,17 +92,18 @@ class EB_Mesa(MesonNinja):
         """
         Return list of values for the given configuration option in configopts
         """
-        configopt_value = [opt.split('=')[1] for opt in self.cfg['configopts'].split() if configopt_name in opt]
+        configopt_args = [opt for opt in self.cfg['configopts'].split() if opt.startswith('-D%s=' % configopt_name)]
 
-        if configopt_value:
-            configopt_value = configopt_value[-1].replace("'", '').replace('"', '')
-            configopt_value = configopt_value.split(',')
-
-            if len(configopt_value) > 1:
-                configopt_pair = "%s = %s" % (configopt_name, ', '.join(configopt_value))
-                self.log.warning(
-                    "Found multiple instances of %s in configopts, using last one: %s", configopt_name, configopt_pair
-                )
+        if configopt_args:
+            if len(configopt_args) > 1:
+                self.log.warning("Found multiple instances of %s in configopts, using last one: %s",
+                                 configopt_name, configopt_args[-1])
+            # Get value of last option added
+            configopt_value = configopt_args[-1].split('=')[-1]
+            # Remove quotes and extract individual values
+            configopt_value = configopt_value.strip('"\'').split(',')
+        else:
+            configopt_value = None
 
         return configopt_value
 

--- a/easybuild/easyblocks/m/mesa.py
+++ b/easybuild/easyblocks/m/mesa.py
@@ -28,6 +28,7 @@ EasyBuild support for installing Mesa, implemented as an easyblock
 @author: Andrew Edmondson (University of Birmingham)
 @author: Kenneth Hoste (HPC-UGent)
 @author: Alex Domingo (Vrije Universiteit Brussel)
+@author: Alexander Grund (TU Dresden)
 """
 import os
 from distutils.version import LooseVersion
@@ -63,23 +64,24 @@ class EB_Mesa(MesonNinja):
                 # Add configopt for additional Gallium drivers
                 self.gallium_configopts.append('-Dgallium-drivers=' + ','.join(gallium_drivers))
 
-        # Check user-defined SWR arches
-        self.swr_arches = self.get_configopt_value('swr-arches')
+        if 'swr' in gallium_drivers:
+            # Check user-defined SWR arches
+            self.swr_arches = self.get_configopt_value('swr-arches')
 
-        if not self.swr_arches and 'swr' in gallium_drivers:
-            # Set cpu features of SWR for current micro-architecture
-            feat_to_swrarch = {
-                'avx': 'avx',
-                'avx1.0': 'avx',  # on macOS, AVX is indicated with 'avx1.0' rather than 'avx'
-                'avx2': 'avx2',
-                'avx512f': 'skx',  # AVX-512 Foundation - introduced in Skylake
-                'avx512er': 'knl',  # AVX-512 Exponential and Reciprocal Instructions implemented in Knights Landing
-            }
-            # Determine list of values to pass to swr-arches configuration option
-            cpu_features = get_cpu_features()
-            self.swr_arches = sorted([swrarch for feat, swrarch in feat_to_swrarch.items() if feat in cpu_features])
-            # Add configopt for additional SWR arches
-            self.gallium_configopts.append('-Dswr-arches=' + ','.join(self.swr_arches))
+            if not self.swr_arches:
+                # Set cpu features of SWR for current micro-architecture
+                feat_to_swrarch = {
+                    'avx': 'avx',
+                    'avx1.0': 'avx',  # on macOS, AVX is indicated with 'avx1.0' rather than 'avx'
+                    'avx2': 'avx2',
+                    'avx512f': 'skx',  # AVX-512 Foundation - introduced in Skylake
+                    'avx512er': 'knl',  # AVX-512 Exponential and Reciprocal Instructions implemented in Knights Landing
+                }
+                # Determine list of values to pass to swr-arches configuration option
+                cpu_features = get_cpu_features()
+                self.swr_arches = sorted([swrarch for feat, swrarch in feat_to_swrarch.items() if feat in cpu_features])
+                # Add configopt for additional SWR arches
+                self.gallium_configopts.append('-Dswr-arches=' + ','.join(self.swr_arches))
 
     def get_configopt_value(self, configopt_name):
         """

--- a/easybuild/easyblocks/m/mesa.py
+++ b/easybuild/easyblocks/m/mesa.py
@@ -64,6 +64,8 @@ class EB_Mesa(MesonNinja):
                 # Add configopt for additional Gallium drivers
                 self.gallium_configopts.append('-Dgallium-drivers=' + ','.join(gallium_drivers))
 
+        self.swr_arches = []
+
         if 'swr' in gallium_drivers:
             # Check user-defined SWR arches
             self.swr_arches = self.get_configopt_value('swr-arches')
@@ -89,13 +91,15 @@ class EB_Mesa(MesonNinja):
         """
         configopt_value = [opt.split('=')[1] for opt in self.cfg['configopts'].split() if configopt_name in opt]
 
-        if len(configopt_value) == 1:
-            configopt_value = configopt_value[0].replace("'", '').replace('"', '')
+        if configopt_value:
+            configopt_value = configopt_value[-1].replace("'", '').replace('"', '')
             configopt_value = configopt_value.split(',')
-        elif len(configopt_value) > 1:
-            raise EasyBuildError(
-                "Found multiple instances of '%s' in configopts: %s", configopt_name, self.cfg['configopts']
-            )
+
+            if len(configopt_value) > 1:
+                configopt_pair = "%s = %s" % (configopt_name, ', '.join(configopt_value))
+                self.log.warning(
+                    "Found multiple instances of %s in configopts, using last one: %s", configopt_name, configopt_pair
+                )
 
         return configopt_value
 


### PR DESCRIPTION
Current mesa easyblock fails the sanity checks if user customizes `gallium-drivers` or `swr-arches` in `configopts`.

This PR fixes that issue by 
1. first retrieve the values for those options from `configopts`
2. `gallium-drivers` is only set by easyblock if missing from `configopts` (as before)
3. `swr-arches` is only set by easyblock if missing from `configopts` **and** `swr` is present in `gallium-drivers`
4. SWR libs are added to sanity checks depending on `swr-arches` and regardless of who defined `swr-arches`

Tested cases:
* default easyconfig of Mesa-20.0.2-GCCcore-9.3.0.eb
   * easyblock behaves as before this PR
* adding `configopts += "-Dgallium-drivers=''"` 
   * the build will fail as at least one driver is missing, but easyblock will respect this configuration if it's set by user
* adding `configopts += "-Dgallium-drivers='swrast'"`
   * no `swr-arches` added and sanity checks do not include any SWR libs
* adding `configopts += "-Dgallium-drivers='swrast,swr'"`
   * `swr-arches` added depending on CPU arch and respective SWR libs checked in sanity checks
* adding `configopts += "-Dgallium-drivers='swrast,swr' -Dswr-arches=avx2"`
   * `swr-arches` is not modified and `libswrAVX2.so` is added to sanity checks