### PR TITLE
make MATLAB runtime available from MATLAB

### DIFF
--- a/easybuild/easyblocks/m/matlab.py
+++ b/easybuild/easyblocks/m/matlab.py
@@ -176,6 +176,12 @@ class EB_MATLAB(PackedBinary):
     def make_module_extra(self):
         """Extend PATH and set proper _JAVA_OPTIONS (e.g., -Xmx)."""
         txt = super(EB_MATLAB, self).make_module_extra()
+
+        # make MATLAB runtime available
+        if LooseVersion(self.version) >= LooseVersion('2017a'):
+            for ldlibdir in ['runtime', 'bin', os.path.join('sys', 'os')]:
+                libdir = os.path.join(self.installdir, ldlibdir, 'glnxa64')
+                txt += self.module_generator.prepend_paths('LD_LIBRARY_PATH', libdir)
         if self.cfg['java_options']:
             txt += self.module_generator.set_environment('_JAVA_OPTIONS', self.cfg['java_options'])
         return txt

--- a/easybuild/easyblocks/m/matlab.py
+++ b/easybuild/easyblocks/m/matlab.py
@@ -180,7 +180,7 @@ class EB_MATLAB(PackedBinary):
         # make MATLAB runtime available
         if LooseVersion(self.version) >= LooseVersion('2017a'):
             for ldlibdir in ['runtime', 'bin', os.path.join('sys', 'os')]:
-                libdir = os.path.join(self.installdir, ldlibdir, 'glnxa64')
+                libdir = os.path.join(ldlibdir, 'glnxa64')
                 txt += self.module_generator.prepend_paths('LD_LIBRARY_PATH', libdir)
         if self.cfg['java_options']:
             txt += self.module_generator.set_environment('_JAVA_OPTIONS', self.cfg['java_options'])


### PR DESCRIPTION
with this update, the MCR is no longer needed if MATLAB is installed.