### PR TITLE
Enable TK, FLTK and OPENGL in VMD config (deps already present)

### DIFF
--- a/easybuild/easyblocks/v/vmd.py
+++ b/easybuild/easyblocks/v/vmd.py
@@ -148,7 +148,8 @@ class EB_VMD(ConfigureMake):
         # PTHREADS: enable support for POSIX threads
         # COLVARS: enable support for collective variables (related to NAMD/LAMMPS)
         # NOSILENT: verbose build command
-        self.cfg.update('configopts', "LINUXAMD64 LP64 IMD PTHREADS COLVARS NOSILENT", allow_duplicate=False)
+        self.cfg.update(
+            'configopts', "LINUXAMD64 LP64 IMD PTHREADS COLVARS NOSILENT FLTK TK OPENGL", allow_duplicate=False)
 
         # add additional configopts based on available dependencies
         for key in deps:

--- a/easybuild/easyblocks/v/vmd.py
+++ b/easybuild/easyblocks/v/vmd.py
@@ -148,6 +148,9 @@ class EB_VMD(ConfigureMake):
         # PTHREADS: enable support for POSIX threads
         # COLVARS: enable support for collective variables (related to NAMD/LAMMPS)
         # NOSILENT: verbose build command
+        # FLTK: enable the standard FLTK GUI
+        # TK: enable TK to support extension GUI elements
+        # OPENGL: enable OpenGL
         self.cfg.update(
             'configopts', "LINUXAMD64 LP64 IMD PTHREADS COLVARS NOSILENT FLTK TK OPENGL", allow_duplicate=False)
 


### PR DESCRIPTION
Dear EasyBuilders,

This is a fix for VMD that enables the already included dependencies FLTK, TK and OPENGL (through MESA). Without this fix the TK support is disabled and the extension menu in the GUI is empty.

Tested at C3SE.

Best, Hugo