### PR TITLE
fix version check in TensorFlow easyblock

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -441,7 +441,7 @@ class EB_TensorFlow(PythonPackage):
         cmd.extend(['--subcommands', '--verbose_failures'])
 
         # Disable support of AWS platform via config switch introduced in 1.12.1
-        if LooseVersion(self.version) >= LooseVersion('v1.12.1'):
+        if LooseVersion(self.version) >= LooseVersion('1.12.1'):
             cmd.append('--config=noaws')
 
         # Bazel seems to not be able to handle a large amount of parallel jobs, e.g. 176 on some Power machines,


### PR DESCRIPTION
Installing `TensorFlow` with EasyBuild running on top of Python 3 is broken since @Flamefire's PR #2002 got merged:

```
ERROR: Traceback (most recent call last):
  File "/work/maintainers/easybuild-framework/easybuild/main.py", line 114, in build_and_install_software
    (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env)
  File "/work/maintainers/easybuild-framework/easybuild/framework/easyblock.py", line 3183, in build_and_install_one
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/work/maintainers/easybuild-framework/easybuild/framework/easyblock.py", line 3087, in run_all_steps
    self.run_step(step_name, step_methods)
  File "/work/maintainers/easybuild-framework/easybuild/framework/easyblock.py", line 2926, in run_step
    step_method(self)()
  File "/work/maintainers/easybuild-framework/easybuild/framework/easyblock.py", line 2186, in extensions_step
    txt = ext.run()
  File "/work/maintainers/easybuild-easyblocks/easybuild/easyblocks/generic/pythonpackage.py", line 631, in run
    self.build_step()
  File "/work/maintainers/easybuild-easyblocks/easybuild/easyblocks/t/tensorflow.py", line 444, in build_step
    if LooseVersion(self.version) >= LooseVersion('v1.12.1'):
  File "/usr/lib64/python3.6/distutils/version.py", line 70, in __ge__
    c = self._cmp(other)
  File "/usr/lib64/python3.6/distutils/version.py", line 337, in _cmp
    if self.version < other.version:
TypeError: '<' not supported between instances of 'int' and 'str'
```

The version check is also faulty when using Python 2, since:

```python
>>> LooseVersion('1.15.2') >= LooseVersion('v1.12.1')
False