### PR TITLE
let CMakeMake remove 'easybuild_obj' build directory if it already exists

### DIFF
--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -39,7 +39,7 @@ from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import print_warning
 from easybuild.tools.config import build_option
-from easybuild.tools.filetools import change_dir, mkdir, which
+from easybuild.tools.filetools import change_dir, mkdir, which, remove_dir
 from easybuild.tools.environment import setvar
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
@@ -120,6 +120,12 @@ class CMakeMake(ConfigureMake):
 
         if builddir is None and self.cfg.get('separate_build_dir', True):
             builddir = os.path.join(self.builddir, 'easybuild_obj')
+            # For separate_build_dir we want a clean folder. So remove if it exists
+            # This can happen when multiple iterations are done (e.g. shared, static, ...)
+            if os.path.exists(builddir):
+                self.log.warning('Build directory %s already exists (from previous iterations?). Removing...',
+                                 builddir)
+                remove_dir(builddir)
 
         if builddir:
             mkdir(builddir, parents=True)


### PR DESCRIPTION
without also ensuring that the directories that are used for that build are also unique
there are build problems with bundles that contain more than one CMake package and didn’t
explicitly set separate_build_dir to false

This also applies partially to multiple iterations of the same software build (e.g. configopts)

Reported in https://github.com/easybuilders/easybuild-easyblocks/pull/1933#issuecomment-614642219

As the build directory is unique to EasyBuild it is safe to remove