### PR TITLE
Use config.guess for GCC builds

### DIFF
--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -392,7 +392,7 @@ class EB_GCC(ConfigureMake):
             config_guess = self.config_guess or '../config.guess'
             out, ec = run_cmd("../config.guess")
             if ec != 0:
-                raise EasyBuildError('Failed to optain platform_lib value from %s', config_guess)
+                raise EasyBuildError('Failed to obtain platform_lib value from %s', config_guess)
             self.platform_lib = out.strip()
 
         # IV) actual configure, but not on default path

--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -381,18 +381,20 @@ class EB_GCC(ConfigureMake):
         else:
             objdir = self.create_dir("obj")
 
-        build_and_host_options = self.determine_build_and_host_options()
-        configopts += ' ' + ' '.join(build_and_host_options)
+        build_type, host_type = self.determine_build_and_host_type()
+        if build_type:
+            configopts += ' --build=' + build_type
+        if host_type:
+            configopts += ' --host=' + host_type
 
         # instead of relying on uname, we use the actual --build option
-        if build_and_host_options and build_and_host_options[0].startswith('--build='):
-            self.platform_lib = build_and_host_options[0].split('=', 1)[1]
+        if build_type:
+            self.platform_lib = build_type
         else:
             # Fallback
-            config_guess = self.config_guess or '../config.guess'
             out, ec = run_cmd("../config.guess")
             if ec != 0:
-                raise EasyBuildError('Failed to obtain platform_lib value from %s', config_guess)
+                raise EasyBuildError('Failed to obtain platform_lib value from config.guess')
             self.platform_lib = out.strip()
 
         # IV) actual configure, but not on default path

--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -400,9 +400,6 @@ class EB_GCC(ConfigureMake):
         # IV) actual configure, but not on default path
         cmd = "../configure  %s %s" % (self.configopts, configopts)
 
-        # instead of relying on uname, we run the same command GCC uses to
-        # determine the platform
-
         self.run_configure_cmd(cmd)
 
         self.disable_lto_mpfr_old_gcc(objdir)

--- a/easybuild/easyblocks/generic/configuremake.py
+++ b/easybuild/easyblocks/generic/configuremake.py
@@ -182,6 +182,45 @@ class ConfigureMake(EasyBlock):
         # Use an updated config.guess from a global location (if possible)
         self.config_guess = self.obtain_config_guess()
 
+    def determine_build_and_host_options(self):
+        """
+        Return a list with command line args for build and host if set
+        Uses the EasyConfig values or queries config.guess if those are not set
+        """
+        build_type = self.cfg.get('build_type')
+        host_type = self.cfg.get('host_type')
+
+        if build_type is None or host_type is None:
+            # config.guess script may not be obtained yet despite the call in fetch_step,
+            # for example when installing a Bundle component with ConfigureMake
+            if not self.config_guess:
+                self.config_guess = self.obtain_config_guess()
+
+            if not self.config_guess:
+                print_warning("No config.guess available, not setting '--build' option for configure step\n"
+                              "EasyBuild attempts to download a recent config.guess but seems to have failed!")
+            else:
+                self.check_config_guess()
+                system_type, _ = run_cmd(self.config_guess, log_all=True)
+                system_type = system_type.strip()
+                self.log.info("%s returned a system type '%s'", self.config_guess, system_type)
+
+                if build_type is None:
+                    build_type = system_type
+                    self.log.info("Providing '%s' as value to --build option of configure script", build_type)
+
+                if host_type is None:
+                    host_type = system_type
+                    self.log.info("Providing '%s' as value to --host option of configure script", host_type)
+
+        options = []
+        if build_type:
+            options.append('--build=' + build_type)
+        if host_type:
+            options.append('--host=' + host_type)
+
+        return options
+
     def configure_step(self, cmd_prefix=''):
         """
         Configure step
@@ -216,55 +255,22 @@ class ConfigureMake(EasyBlock):
         # use the version downloaded by EasyBuild instead, and provide the result to the configure command;
         # it is possible that the configure script is generated using preconfigopts...
         # if so, we're at the mercy of the gods
-        build_type_option = ''
-        host_type_option = ''
 
         # note: reading contents of 'configure' script in bytes mode,
         # to avoid problems when non-UTF-8 characters are included
         # see https://github.com/easybuilders/easybuild-easyblocks/pull/1817
         if os.path.exists(configure_command) and AUTOCONF_GENERATED_MSG in read_file(configure_command, mode='rb'):
+            build_and_host_options = self.determine_build_and_host_options()
+        else:
+            build_and_host_options = []
 
-            build_type = self.cfg.get('build_type')
-            host_type = self.cfg.get('host_type')
-
-            if build_type is None or host_type is None:
-
-                # config.guess script may not be obtained yet despite the call in fetch_step,
-                # for example when installing a Bundle component with ConfigureMake
-                if self.config_guess is None:
-                    self.config_guess = self.obtain_config_guess()
-
-                if self.config_guess is None:
-                    print_warning("No config.guess available, not setting '--build' option for configure step\n"
-                                  "EasyBuild attempts to download a recent config.guess but seems to have failed!")
-                else:
-                    self.check_config_guess()
-                    system_type, _ = run_cmd(self.config_guess, log_all=True)
-                    system_type = system_type.strip()
-                    self.log.info("%s returned a system type '%s'", self.config_guess, system_type)
-
-                    if build_type is None:
-                        build_type = system_type
-                        self.log.info("Providing '%s' as value to --build option of configure script", build_type)
-
-                    if host_type is None:
-                        host_type = system_type
-                        self.log.info("Providing '%s' as value to --host option of configure script", host_type)
-
-            if build_type is not None and build_type:
-                build_type_option = '--build=' + build_type
-
-            if host_type is not None and host_type:
-                host_type_option = '--host=' + host_type
-
-        cmd = ' '.join([
-            self.cfg['preconfigopts'],
-            configure_command,
-            prefix_opt + self.installdir,
-            build_type_option,
-            host_type_option,
-            self.cfg['configopts'],
-        ])
+        cmd = ' '.join(
+            [
+                self.cfg['preconfigopts'],
+                configure_command,
+                prefix_opt + self.installdir,
+            ] + build_and_host_options + [self.cfg['configopts']]
+        )
 
         (out, _) = run_cmd(cmd, log_all=True, simple=False)
 


### PR DESCRIPTION
Building of some older GCCs (tried 4.4) fails on e.g. Power due to config.guess being to old.

This is a solved problem in ConfigureMake by using an up-to-date one but GCC EB didn't use it yet as it doesn't call the super-configure method.

Additonally it ignores the build_type and host_type EC variables.

This is fixed with this PR by factoring out a method from ConfigureMake which can then be called by GCC