### PR TITLE
LAMMPS: add support to handle Atomistica

### DIFF
--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -123,7 +123,7 @@ class EB_LAMMPS(CMakeMake):
 
         # Add files from Atomistica
         atomistica = get_software_root('Atomistica')
-        if atomistica:
+        if atomistica and 'ATOMISTICA' in self.cfg['user_packages']:
             # Package files
             atomistica_files = ['pair_atomistica.%s' % e for e in ['cpp', 'h']]
             self.log.info("Adding Atomistica package files into LAMMPS: %s" % ', '.join(atomistica_files))
@@ -273,7 +273,7 @@ class EB_LAMMPS(CMakeMake):
 
         # Atomistica custom sanity checks
         atomistica = get_software_root('Atomistica')
-        if atomistica:
+        if atomistica and 'ATOMISTICA' in self.cfg['user_packages']:
             custom_commands += [
                 "cd %s && " % os.path.join(self.start_dir, 'examples/atomistica') +
                 """python -c 'from lammps import lammps; l=lammps(); l.file("atomistica.in")'"""

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -130,7 +130,7 @@ class EB_LAMMPS(CMakeMake):
             for pkgfile in atomistica_files:
                 copy_file(os.path.join(atomistica, 'share/lammps', pkgfile), os.path.join('src', pkgfile))
             # Test for sanity checks
-            copy_dir(os.path.join(atomistica, 'share/examples/liquid_silicon'), 'examples/atomistica')
+            copy_dir(os.path.join(atomistica, 'share/examples/LAMMPS/liquid_silicon'), 'examples/atomistica')
 
     def configure_step(self, **kwargs):
         """Custom configuration procedure for LAMMPS."""

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -224,31 +224,6 @@ class EB_LAMMPS(CMakeMake):
             if '-DFFT_PACK=' not in self.cfg['configopts']:
                 self.cfg.update('configopts', '-DFFT_PACK=array')
 
-        # Additional linker flags
-        lammps_linklibs = []
-
-        # Atomistica
-        if get_software_root('Atomistica'):
-            # link with libatomistica
-            lammps_linklibs += ['-latomistica']
-            # Atomistica needs the MPI Fortran bindings, which are not added
-            # by default in LAMMPS as it uses a C++ linker
-            if self.toolchain.options.get('usempi', None):
-                if self.toolchain.mpi_family() == toolchain.OPENMPI:
-                    # retrieve libraries used to compile OpenMPI
-                    out, ec = run_cmd("mpifort --showme:libs", simple=False)
-                    if ec:
-                        raise EasyBuildError("Failed to determine OpenMPI libraries: %s", out)
-                    lammps_linklibs += ["-l%s" % lib for lib in out.split()]
-                elif self.toolchain.mpi_family() == toolchain.INTELMPI:
-                    # add Fortran libraries used by Intel MPI
-                    lammps_linklibs += ['-lmpifort', '-lmpi']
-
-        # Set additional linker flags
-        if len(lammps_linklibs) > 0:
-            cmake_lammps_linklibs = '-DLAMMPS_LINK_LIBS="%s"' % ' '.join(lammps_linklibs)
-            self.cfg.update('configopts', cmake_lammps_linklibs)
-
         # https://lammps.sandia.gov/doc/Build_extras.html
         # KOKKOS
         if self.cfg['kokkos']:


### PR DESCRIPTION
Adding the inter-atomic potentials from [Atomistica](https://github.com/Atomistica/atomistica) into LAMMPS requires not only linking to its library `libatomistica` but also building LAMMPS with additional source code files.
This PR updates the easyblock of `lammps` to detect the dependency on Atomistica and if it's present perform all needed steps to build LAMMPS including its potentials.

Tests can be done with `LAMMPS-7Aug2019-foss-2019b-Python-3.7.4-kokkos-atomistica.eb` from https://github.com/easybuilders/easybuild-easyconfigs/pull/10433, which is basically a regular easyconfig of LAMMPS with the added dependency on Atomistica. All needed files and libraries are provided by `Atomistica-0.10.1-foss-2019b-Python-3.7.4.eb` (also available in https://github.com/easybuilders/easybuild-easyconfigs/pull/10433). 