### PR TITLE
add support for building NWChem on top of external GlobalArrays + also define $LAPACK_LIB (required for NWChem 7.x)

### DIFF
--- a/easybuild/easyblocks/n/nwchem.py
+++ b/easybuild/easyblocks/n/nwchem.py
@@ -236,8 +236,8 @@ class EB_NWChem(ConfigureMake):
         self.setvar_env_makeopt('FOPTIMIZE', os.getenv('FFLAGS'))
 
         # BLAS and ScaLAPACK
-        MPI_LIB_DIRS = ' '.join('-L' + d for d in os.getenv('MPI_LIB_DIR').split())
-        self.setvar_env_makeopt('BLASOPT', ' '.join([os.getenv('LDFLAGS'), MPI_LIB_DIRS,
+        mpi_lib_dirs = ' '.join('-L' + d for d in os.getenv('MPI_LIB_DIR').split())
+        self.setvar_env_makeopt('BLASOPT', ' '.join([os.getenv('LDFLAGS'), mpi_lib_dirs,
                                                      os.getenv('LIBSCALAPACK_MT'), libmpi]))
 
         # Setting LAPACK_LIB is required from 7.0.0 onwards.

--- a/easybuild/easyblocks/n/nwchem.py
+++ b/easybuild/easyblocks/n/nwchem.py
@@ -26,7 +26,6 @@
 EasyBuild support for building and installing NWChem, implemented as an easyblock
 
 @author: Kenneth Hoste (Ghent University)
-@author: Mikael Öhman (Chalmers University of Technology)
 """
 import os
 import re
@@ -237,8 +236,8 @@ class EB_NWChem(ConfigureMake):
         self.setvar_env_makeopt('FOPTIMIZE', os.getenv('FFLAGS'))
 
         # BLAS and ScaLAPACK
-        self.setvar_env_makeopt('BLASOPT', '%s -L%s %s %s' % (os.getenv('LDFLAGS'), os.getenv('MPI_LIB_DIR'),
-                                                              os.getenv('LIBSCALAPACK_MT'), libmpi))
+        MPI_LIB_DIRS = ' '.join('-L' + d for d in os.getenv('MPI_LIB_DIR').split())
+        self.setvar_env_makeopt('BLASOPT', ' '.join([os.getenv('LDFLAGS'), MPI_LIB_DIRS, os.getenv('LIBSCALAPACK_MT'), libmpi]))
 
         # Setting LAPACK_LIB is required from 7.0.0 onwards.
         self.setvar_env_makeopt('LAPACK_LIB', os.getenv('LIBLAPACK'))

--- a/easybuild/easyblocks/n/nwchem.py
+++ b/easybuild/easyblocks/n/nwchem.py
@@ -237,7 +237,8 @@ class EB_NWChem(ConfigureMake):
 
         # BLAS and ScaLAPACK
         MPI_LIB_DIRS = ' '.join('-L' + d for d in os.getenv('MPI_LIB_DIR').split())
-        self.setvar_env_makeopt('BLASOPT', ' '.join([os.getenv('LDFLAGS'), MPI_LIB_DIRS, os.getenv('LIBSCALAPACK_MT'), libmpi]))
+        self.setvar_env_makeopt('BLASOPT', ' '.join([os.getenv('LDFLAGS'), MPI_LIB_DIRS,
+                                                     os.getenv('LIBSCALAPACK_MT'), libmpi]))
 
         # Setting LAPACK_LIB is required from 7.0.0 onwards.
         self.setvar_env_makeopt('LAPACK_LIB', os.getenv('LIBLAPACK'))

--- a/easybuild/easyblocks/n/nwchem.py
+++ b/easybuild/easyblocks/n/nwchem.py
@@ -26,6 +26,7 @@
 EasyBuild support for building and installing NWChem, implemented as an easyblock
 
 @author: Kenneth Hoste (Ghent University)
+@author: Mikael Öhman (Chalmers University of Technology)
 """
 import os
 import re
@@ -142,12 +143,17 @@ class EB_NWChem(ConfigureMake):
             self.setvar_env_makeopt('NWCHEM_LONG_PATHS', 'Y')
 
         env.setvar('NWCHEM_TARGET', self.cfg['target'])
-        env.setvar('MSG_COMMS', self.cfg['msg_comms'])
-        env.setvar('ARMCI_NETWORK', self.cfg['armci_network'])
-        if self.cfg['armci_network'] in ["OPENIB"]:
-            env.setvar('IB_INCLUDE', "/usr/include")
-            env.setvar('IB_LIB', "/usr/lib64")
-            env.setvar('IB_LIB_NAME', "-libumad -libverbs -lpthread")
+
+        garoot = get_software_root('GlobalArrays')
+        if garoot:
+            self.setvar_env_makeopt('EXTERNAL_GA_PATH', garoot)
+        else:
+            env.setvar('MSG_COMMS', self.cfg['msg_comms'])
+            env.setvar('ARMCI_NETWORK', self.cfg['armci_network'])
+            if self.cfg['armci_network'] in ["OPENIB"]:
+                env.setvar('IB_INCLUDE', "/usr/include")
+                env.setvar('IB_LIB', "/usr/lib64")
+                env.setvar('IB_LIB_NAME', "-libumad -libverbs -lpthread")
 
         if 'python' in self.cfg['modules']:
             python_root = get_software_root('Python')
@@ -222,8 +228,9 @@ class EB_NWChem(ConfigureMake):
                 raise EasyBuildError("Don't know how to set LIBMPI for %s", mpi_family)
             env.setvar('LIBMPI', libmpi)
 
-        if self.cfg['armci_network'] in ["OPENIB"]:
-            libmpi += " -libumad -libverbs -lpthread"
+        if not garoot:
+            if self.cfg['armci_network'] in ["OPENIB"]:
+                libmpi += " -libumad -libverbs -lpthread"
 
         # compiler optimization flags: set environment variables _and_ add them to list of make options
         self.setvar_env_makeopt('COPTIMIZE', os.getenv('CFLAGS'))
@@ -232,6 +239,9 @@ class EB_NWChem(ConfigureMake):
         # BLAS and ScaLAPACK
         self.setvar_env_makeopt('BLASOPT', '%s -L%s %s %s' % (os.getenv('LDFLAGS'), os.getenv('MPI_LIB_DIR'),
                                                               os.getenv('LIBSCALAPACK_MT'), libmpi))
+
+        # Setting LAPACK_LIB is required from 7.0.0 onwards.
+        self.setvar_env_makeopt('LAPACK_LIB', os.getenv('LIBLAPACK'))
 
         self.setvar_env_makeopt('SCALAPACK', '%s %s' % (os.getenv('LDFLAGS'), os.getenv('LIBSCALAPACK_MT')))
         if self.toolchain.options['i8']:


### PR DESCRIPTION
WIP

It is now required to set `LAPACK_LIB` as well. Shouldn't hurt to set it for older NWchem either, so I skipped the messy if-version stuff.

External GlobalArrays is a big benefit, so that it doesn't download and builds it's own (sometimes buggy) version.
I'm not sure what to do with
```python
            elif mpi_family in [toolchain.INTELMPI]:
                if self.cfg['armci_network'] in ["MPI-MT"]:
                    libmpi = "-lmpigf -lmpigi -lmpi_ilp64 -lmpi_mt"
                else:
                    libmpi = "-lmpigf -lmpigi -lmpi_ilp64 -lmpi"
```
