### PR TITLE
impi: execute minimal test in sanity check commands

### DIFF
--- a/easybuild/easyblocks/i/impi.py
+++ b/easybuild/easyblocks/i/impi.py
@@ -212,20 +212,14 @@ EULA=accept
         }
 
         # Add minimal test program to sanity checks
-        try:
-            fake_mod_data = self.load_fake_module()
-        except EasyBuildError as err:
-            self.log.debug("Loading fake module failed: %s" % err)
-
         impi_testsrc = os.path.join(self.installdir, 'test/test.c')
         impi_testexe = os.path.join(self.builddir, 'mpi_test')
-        self.log.info("Building minimal MPI test program: %s", impi_testsrc)
-        build_test = "mpiicc %s -o %s" % (impi_testsrc, impi_testexe)
-        run_cmd(build_test, log_all=True, simple=True)
+        self.log.info("Adding minimal MPI test program to sanity checks: %s", impi_testsrc)
 
-        self.clean_up_fake_module(fake_mod_data)  # unload build environment
-
-        custom_commands = ['mpirun -n %s %s' % (self.cfg['parallel'], impi_testexe)]
+        custom_commands = [
+            "mpiicc %s -o %s" % (impi_testsrc, impi_testexe),  # build test program
+            'mpirun -n %s %s' % (self.cfg['parallel'], impi_testexe),  # run test program
+        ]
 
         super(EB_impi, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
 

--- a/easybuild/easyblocks/i/impi.py
+++ b/easybuild/easyblocks/i/impi.py
@@ -213,27 +213,30 @@ EULA=accept
             'dirs': [],
         }
 
-        # Add minimal test program to sanity checks
-        impi_testsrc = os.path.join(self.installdir, 'test/test.c')
-        impi_testexe = os.path.join(self.builddir, 'mpi_test')
-        self.log.info("Adding minimal MPI test program to sanity checks: %s", impi_testsrc)
+        custom_commands = []
 
-        # Build test program with appropriate compiler from current toolchain
-        comp_fam = self.toolchain.comp_family()
-        if comp_fam == toolchain.INTELCOMP:
-            build_comp = 'mpiicc'
-        else:
-            build_comp = 'mpicc'
-        build_cmd = "%s %s -o %s" % (build_comp, impi_testsrc, impi_testexe)
+        if LooseVersion(self.version) >= LooseVersion('2017'):
+            # Add minimal test program to sanity checks
+            impi_testsrc = os.path.join(self.installdir, 'test/test.c')
+            impi_testexe = os.path.join(self.builddir, 'mpi_test')
+            self.log.info("Adding minimal MPI test program to sanity checks: %s", impi_testsrc)
 
-        # Execute test program with appropriate MPI executable for target toolchain
-        params = {'nr_ranks': self.cfg['parallel'], 'cmd': impi_testexe}
-        mpi_cmd_tmpl, params = get_mpi_cmd_template(toolchain.INTELMPI, params, mpi_version=self.version)
+            # Build test program with appropriate compiler from current toolchain
+            comp_fam = self.toolchain.comp_family()
+            if comp_fam == toolchain.INTELCOMP:
+                build_comp = 'mpiicc'
+            else:
+                build_comp = 'mpicc'
+            build_cmd = "%s %s -o %s" % (build_comp, impi_testsrc, impi_testexe)
 
-        custom_commands = [
-            build_cmd,  # build test program
-            mpi_cmd_tmpl % params,  # run test program
-        ]
+            # Execute test program with appropriate MPI executable for target toolchain
+            params = {'nr_ranks': self.cfg['parallel'], 'cmd': impi_testexe}
+            mpi_cmd_tmpl, params = get_mpi_cmd_template(toolchain.INTELMPI, params, mpi_version=self.version)
+
+            custom_commands.extend([
+                build_cmd,  # build test program
+                mpi_cmd_tmpl % params,  # run test program
+            ])
 
         super(EB_impi, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
 

--- a/easybuild/easyblocks/i/impi.py
+++ b/easybuild/easyblocks/i/impi.py
@@ -31,6 +31,7 @@ EasyBuild support for installing the Intel MPI library, implemented as an easybl
 @author: Pieter De Baets (Ghent University)
 @author: Jens Timmerman (Ghent University)
 @author: Damian Alvarez (Forschungszentrum Juelich GmbH)
+@author: Alex Domingo (Vrije Universiteit Brussel)
 """
 import os
 from distutils.version import LooseVersion

--- a/easybuild/easyblocks/i/impi.py
+++ b/easybuild/easyblocks/i/impi.py
@@ -218,10 +218,20 @@ EULA=accept
         impi_testexe = os.path.join(self.builddir, 'mpi_test')
         self.log.info("Adding minimal MPI test program to sanity checks: %s", impi_testsrc)
 
+        # Build test program with appropriate compiler from current toolchain
+        comp_fam = self.toolchain.comp_family()
+        if comp_fam == toolchain.INTELCOMP:
+            build_comp = 'mpiicc'
+        else:
+            build_comp = 'mpicc'
+        build_cmd = "%s %s -o %s" % (build_comp, impi_testsrc, impi_testexe)
+
+        # Execute test program with appropriate MPI executable for target toolchain
         params = {'nr_ranks': self.cfg['parallel'], 'cmd': impi_testexe}
         mpi_cmd_tmpl, params = get_mpi_cmd_template(toolchain.INTELMPI, params, mpi_version=self.version)
+
         custom_commands = [
-            "mpiicc %s -o %s" % (impi_testsrc, impi_testexe),  # build test program
+            build_cmd,  # build test program
             mpi_cmd_tmpl % params,  # run test program
         ]
 

--- a/easybuild/easyblocks/i/impi.py
+++ b/easybuild/easyblocks/i/impi.py
@@ -222,6 +222,8 @@ EULA=accept
         build_test = "mpiicc %s -o %s" % (impi_testsrc, impi_testexe)
         run_cmd(build_test, log_all=True, simple=True)
 
+        self.clean_up_fake_module(fake_mod_data)  # unload build environment
+
         custom_commands = ['mpirun -n %s %s' % (self.cfg['parallel'], impi_testexe)]
 
         super(EB_impi, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)


### PR DESCRIPTION
This PR improves the sanity checks of `impi` easyblock by building the minimal MPI test program `test.c` and adding its execution to the sanity check commands.

I tested it with latest impi-2019.7.217-iccifort-2020.1.217.eb
* broken build with default easyconfig properly **fails** on sanity checks: https://gist.github.com/lexming/5ab5be4624fa0786547973a65897f40f
* sane build setting `'I_MPI_HYDRA_TOPOLIB': 'ipl'` in easyconfig (which we need in our site) properly **passes** all sanity checks: https://gist.github.com/lexming/29ac434c5e7ad799cca986541f214a00

The tests are currently enabled for all versions as this test program is available in all non-archived releases of `impi`.