### PR TITLE
fixes/enhancements for PETSc easyblock

### DIFF
--- a/easybuild/easyblocks/p/petsc.py
+++ b/easybuild/easyblocks/p/petsc.py
@@ -276,6 +276,7 @@ class EB_PETSc(ConfigureMake):
 
         # PETSc > 3.5, make does not accept -j
         if LooseVersion(self.version) >= LooseVersion("3.5"):
+            env.setvar('MAKE_NP', str(self.cfg['parallel']))
             self.cfg['parallel'] = None
 
     # default make should be fine


### PR DESCRIPTION
* allow disabling `--with-mpi4py` option (enabling it seems totally broken, yields errors like `No rule to make target `mpi4py-build'`)
* add `SciPy-bundle` to dep filter (not really necessary since unknown options to `configure` command are silently ignored, but fine...)
* add path to PETSc Python scripts to `$PYTHONPATH` (see https://www.mcs.anl.gov/petsc/documentation/faq.html#sparse-matrix-ascii-format)
* add sanity check command for `PetscBinaryIO` Python module

requires for https://github.com/easybuilders/easybuild-easyconfigs/pull/10532