### PR TITLE
don't let extract_file change directory in various easyblocks

### DIFF
--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -46,7 +46,7 @@ from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError, print_warning
 from easybuild.tools.config import build_option
-from easybuild.tools.filetools import download_file, extract_file, which
+from easybuild.tools.filetools import which
 from easybuild.tools.modules import get_software_libdir, get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
 from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC

--- a/easybuild/easyblocks/i/impi.py
+++ b/easybuild/easyblocks/i/impi.py
@@ -133,7 +133,8 @@ EULA=accept
                 libfabric_src_tgz_fn = 'src.tgz'
                 if os.path.exists(os.path.join(libfabric_path, libfabric_src_tgz_fn)):
                     change_dir(libfabric_path)
-                    extract_file(libfabric_src_tgz_fn, os.getcwd())
+                    srcdir = extract_file(libfabric_src_tgz_fn, os.getcwd(), change_into_dir=False)
+                    change_dir(srcdir)
                     libfabric_installpath = os.path.join(self.installdir, 'intel64', 'libfabric')
 
                     make = 'make'

--- a/easybuild/easyblocks/n/namd.py
+++ b/easybuild/easyblocks/n/namd.py
@@ -49,7 +49,7 @@ class EB_NAMD(MakeCp):
         })
         return extra
 
-    def __init__(self,*args,**kwargs):
+    def __init__(self, *args, **kwargs):
         """Custom easyblock constructor for NAMD, initialize class variables."""
         super(EB_NAMD, self).__init__(*args, **kwargs)
         self.namd_arch = None
@@ -63,7 +63,8 @@ class EB_NAMD(MakeCp):
         if len(self.charm_tarballs) != 1:
             raise EasyBuildError("Expected to find exactly one tarball for Charm++, found: %s", self.charm_tarballs)
 
-        extract_file(self.charm_tarballs[0], os.getcwd())
+        srcdir = extract_file(self.charm_tarballs[0], os.getcwd(), change_into_dir=False)
+        change_dir(srcdir)
 
     def configure_step(self):
         """Custom configure step for NAMD, we build charm++ first (if required)."""
@@ -97,7 +98,6 @@ class EB_NAMD(MakeCp):
         self.log.info("Updated 'charm_arch': %s" % self.cfg['charm_arch'])
         self.namd_arch = '%s-%s' % (self.cfg['namd_basearch'], namd_comp)
         self.log.info("Completed NAMD target architecture: %s" % self.namd_arch)
-
 
         tup = (self.cfg['charm_arch'], self.cfg['charm_opts'], self.cfg['parallel'], os.environ['CXXFLAGS'])
         cmd = "./build charm++ %s %s --with-numa -j%s %s -DMPICH_IGNORE_CXX_SEEK" % tup

--- a/easybuild/easyblocks/p/python_meep.py
+++ b/easybuild/easyblocks/p/python_meep.py
@@ -38,7 +38,7 @@ import tempfile
 
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import extract_file, remove_dir
+from easybuild.tools.filetools import change_dir, extract_file, remove_dir
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
 
@@ -99,15 +99,17 @@ class EB_python_minus_meep(PythonPackage):
 
         # unpack tarball to temporary directory
         tmpdir = tempfile.mkdtemp()
-        srcdir = extract_file(tarball, tmpdir)
-        if not srcdir:
+        srcdir = extract_file(tarball, tmpdir, change_into_dir=False)
+        if srcdir:
+            change_dir(srcdir)
+        else:
             raise EasyBuildError("Unpacking tarball %s failed?", tarball)
 
         # locate site-packages dir to copy by diving into unpacked tarball
         src = srcdir
         while len(os.listdir(src)) == 1:
             src = os.path.join(src, os.listdir(src)[0])
-        if not os.path.basename(src) =='site-packages':
+        if not os.path.basename(src) == 'site-packages':
             raise EasyBuildError("Expected to find a site-packages path, but found something else: %s", src)
 
         # copy contents of site-packages dir
@@ -122,9 +124,9 @@ class EB_python_minus_meep(PythonPackage):
     def sanity_check_step(self):
 
         custom_paths = {
-                        'files':["site-packages/meep_mpi.py"],
-                        'dirs':[]
-                       }
+            'files': [os.path.join('site-packages', 'meep_mpi.py')],
+            'dirs': [],
+        }
 
         self.options['modulename'] = 'meep_mpi'
 

--- a/easybuild/easyblocks/r/rosetta.py
+++ b/easybuild/easyblocks/r/rosetta.py
@@ -39,10 +39,9 @@ import sys
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.icc import get_icc_version
 from easybuild.framework.easyblock import EasyBlock
-from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import extract_file, mkdir, write_file
-from easybuild.tools.modules import get_software_root, get_software_version
+from easybuild.tools.filetools import change_dir, extract_file, mkdir, write_file
+from easybuild.tools.modules import get_software_version
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
 
@@ -75,7 +74,8 @@ class EB_Rosetta(EasyBlock):
             if not os.path.exists(self.srcdir):
                 src_tarball = os.path.join(prefix, 'rosetta%s_source.tgz' % self.version)
                 if os.path.isfile(src_tarball):
-                    self.srcdir = extract_file(src_tarball, prefix)
+                    self.srcdir = extract_file(src_tarball, prefix, change_into_dir=False)
+                    change_dir(self.srcdir)
                 else:
                     raise EasyBuildError("Neither source directory '%s', nor source tarball '%s' found.",
                                          self.srcdir, src_tarball)

--- a/easybuild/easyblocks/v/vmd.py
+++ b/easybuild/easyblocks/v/vmd.py
@@ -30,7 +30,6 @@ EasyBuild support for VMD, implemented as an easyblock
 @author: Kenneth Hoste (HPC-UGent)
 """
 import os
-import shutil
 
 from distutils.version import LooseVersion
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
@@ -60,7 +59,8 @@ class EB_VMD(ConfigureMake):
 
         if LooseVersion(self.version) >= LooseVersion("1.9.3"):
             change_dir(self.surf_dir)
-            extract_file('surf.tar.Z', os.getcwd())
+            srcdir = extract_file('surf.tar.Z', os.getcwd(), change_into_dir=False)
+            change_dir(srcdir)
 
     def configure_step(self):
         """

--- a/easybuild/easyblocks/w/wien2k.py
+++ b/easybuild/easyblocks/w/wien2k.py
@@ -46,7 +46,8 @@ import easybuild.tools.toolchain as toolchain
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import apply_regex_substitutions, extract_file, mkdir, read_file, remove_dir, write_file
+from easybuild.tools.filetools import apply_regex_substitutions, change_dir, extract_file, mkdir, read_file
+from easybuild.tools.filetools import remove_dir, write_file
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd, run_cmd_qa
 
@@ -445,7 +446,8 @@ class EB_WIEN2k(EasyBlock):
 
                 # unpack serial benchmark
                 serial_test_name = "test_case"
-                extract_file(testdata_paths['%s.tar.gz' % serial_test_name], tmpdir)
+                srcdir = extract_file(testdata_paths['%s.tar.gz' % serial_test_name], tmpdir, change_into_dir=False)
+                change_dir(srcdir)
 
                 # run serial benchmark
                 os.chdir(os.path.join(tmpdir, serial_test_name))
@@ -453,7 +455,8 @@ class EB_WIEN2k(EasyBlock):
 
                 # unpack parallel benchmark (in serial benchmark dir)
                 parallel_test_name = "mpi-benchmark"
-                extract_file(testdata_paths['%s.tar.gz' % parallel_test_name], tmpdir)
+                srcdir = extract_file(testdata_paths['%s.tar.gz' % parallel_test_name], tmpdir, change_into_dir=False)
+                change_dir(srcdir)
 
                 # run parallel benchmark
                 os.chdir(os.path.join(tmpdir, serial_test_name))

--- a/easybuild/easyblocks/w/wps.py
+++ b/easybuild/easyblocks/w/wps.py
@@ -279,7 +279,8 @@ class EB_WPS(EasyBlock):
 
                 # unpack data
                 for path in testdata_paths:
-                    extract_file(path, tmpdir)
+                    srcdir = extract_file(path, tmpdir, change_into_dir=False)
+                    change_dir(srcdir)
 
                 namelist_file = os.path.join(tmpdir, 'namelist.wps')
 


### PR DESCRIPTION
requires https://github.com/easybuilders/easybuild-framework/pull/3292 where implicit changing of directory in `extract_file` was deprecated