### PR TITLE
FreeSurfer: fix the extra dirs added to PATH

### DIFF
--- a/easybuild/easyblocks/f/freesurfer.py
+++ b/easybuild/easyblocks/f/freesurfer.py
@@ -55,7 +55,7 @@ class EB_FreeSurfer(Tarball):
         """Include correct subdirectories to $PATH for FreeSurfer."""
         guesses = super(EB_FreeSurfer, self).make_module_req_guess()
 
-        guesses.update({'PATH': ['bin', 'fsfast/bin', 'mni/bin', 'tktools']})
+        guesses['PATH'].extend([os.path.join('fsfast', 'bin'), os.path.join('mni', 'bin'), 'tktools'])
 
         return guesses
 

--- a/easybuild/easyblocks/f/freesurfer.py
+++ b/easybuild/easyblocks/f/freesurfer.py
@@ -44,7 +44,7 @@ class EB_FreeSurfer(Tarball):
         extra_vars = {
             'license_text': ['', "Text for required license file.", MANDATORY],
         }
-        return EasyBlock.extra_options(extra_vars)
+        return Tarball.extra_options(extra_vars)
 
     def install_step(self):
         """Custom installation procedure for FreeSurfer, which includes installed the license file '.license'."""

--- a/easybuild/easyblocks/f/freesurfer.py
+++ b/easybuild/easyblocks/f/freesurfer.py
@@ -51,11 +51,11 @@ class EB_FreeSurfer(Tarball):
         super(EB_FreeSurfer, self).install_step()
         write_file(os.path.join(self.installdir, '.license'), self.cfg['license_text'])
 
-    def make_module_guesses(self):
+    def make_module_req_guess(self):
         """Include correct subdirectories to $PATH for FreeSurfer."""
-        guesses = super(EB_FreeSurfer, self).make_module_guesses()
+        guesses = super(EB_FreeSurfer, self).make_module_req_guess()
 
-        guesses['PATH'] = ['bin', 'fsfast/bin', 'mni/bin', 'tktools']
+        guesses.update({'PATH': ['bin', 'fsfast/bin', 'mni/bin', 'tktools']})
 
         return guesses
 


### PR DESCRIPTION
Only `bin` was ending up in the `PATH` for us. I think this is because `make_module_guesses` is not the right function and never gets called and then `bin` ends up there by default.

The change to line 47 is to fix:
```
ERROR EasyBuild crashed with an error (at easybuild/base/exceptions.py:124 in __init__): Use of unknown easyconfig parameter 'preinstall_cmd' when getting parameter value (at easybuild/framework/easyconfig/easyconfig.py:1638 in __getitem__)
```