### PR TITLE
only build OpenCV with IPP support on x86_64 systems

### DIFF
--- a/easybuild/easyblocks/o/opencv.py
+++ b/easybuild/easyblocks/o/opencv.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2018-2019 Ghent University
+# Copyright 2018-2020 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
@@ -48,10 +48,12 @@ class EB_OpenCV(CMakeMake):
     @staticmethod
     def extra_options():
         """Custom easyconfig parameters specific to OpenCV."""
-        extra_vars = {
-            'cpu_dispatch': ['NONE', "Value to pass to -DCPU_DISPATCH configuration option", CUSTOM],
-        }
-        return CMakeMake.extra_options(extra_vars)
+        extra_vars = CMakeMake.extra_options()
+        extra_vars.update({
+             'cpu_dispatch': ['NONE', "Value to pass to -DCPU_DISPATCH configuration option", CUSTOM],
+        })
+        extra_vars['separate_build_dir'][0] = True
+        return extra_vars
 
     def __init__(self, *args, **kwargs):
         """Initialisation of custom class variables for OpenCV."""
@@ -59,8 +61,6 @@ class EB_OpenCV(CMakeMake):
 
         # can't be set before prepare_step is run
         self.pylibdir = None
-
-        self.cfg['separate_build_dir'] = True
 
     def prepare_step(self, *args, **kwargs):
         """Prepare environment for installing OpenCV."""
@@ -92,9 +92,6 @@ class EB_OpenCV(CMakeMake):
 
     def configure_step(self):
         """Custom configuration procedure for OpenCV."""
-
-        if 'CMAKE_BUILD_TYPE' not in self.cfg['configopts']:
-            self.cfg.update('configopts', '-DCMAKE_BUILD_TYPE=Release')
 
         # enable Python support if unspecified and Python is a dependency
         if 'BUILD_PYTHON_SUPPORT' not in self.cfg['configopts']:
@@ -192,7 +189,7 @@ class EB_OpenCV(CMakeMake):
         libfile = 'libopencv_core.%s' % get_shared_lib_ext()
         custom_paths = {
             'files': [os.path.join('bin', 'opencv_%s' % x) for x in opencv_bins] + [os.path.join('lib64', libfile)],
-            'dirs': ['include', self.pylibdir],
+            'dirs': ['include'],
         }
         if 'WITH_IPP=ON' in self.cfg['configopts']:
             custom_paths['files'].append(os.path.join('lib', 'libippicv.a'))

--- a/easybuild/easyblocks/o/opencv.py
+++ b/easybuild/easyblocks/o/opencv.py
@@ -50,7 +50,7 @@ class EB_OpenCV(CMakeMake):
         """Custom easyconfig parameters specific to OpenCV."""
         extra_vars = CMakeMake.extra_options()
         extra_vars.update({
-             'cpu_dispatch': ['NONE', "Value to pass to -DCPU_DISPATCH configuration option", CUSTOM],
+            'cpu_dispatch': ['NONE', "Value to pass to -DCPU_DISPATCH configuration option", CUSTOM],
         })
         extra_vars['separate_build_dir'][0] = True
         return extra_vars

--- a/easybuild/easyblocks/o/opencv.py
+++ b/easybuild/easyblocks/o/opencv.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2018-2020 Ghent University
+# Copyright 2018-2019 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
@@ -38,7 +38,7 @@ from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option
 from easybuild.tools.filetools import compute_checksum, copy
 from easybuild.tools.modules import get_software_libdir, get_software_root
-from easybuild.tools.systemtools import get_cpu_features, get_shared_lib_ext
+from easybuild.tools.systemtools import X86_64, get_cpu_architecture, get_cpu_features, get_shared_lib_ext
 from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
 
 
@@ -48,12 +48,10 @@ class EB_OpenCV(CMakeMake):
     @staticmethod
     def extra_options():
         """Custom easyconfig parameters specific to OpenCV."""
-        extra_vars = CMakeMake.extra_options()
-        extra_vars.update({
+        extra_vars = {
             'cpu_dispatch': ['NONE', "Value to pass to -DCPU_DISPATCH configuration option", CUSTOM],
-        })
-        extra_vars['separate_build_dir'][0] = True
-        return extra_vars
+        }
+        return CMakeMake.extra_options(extra_vars)
 
     def __init__(self, *args, **kwargs):
         """Initialisation of custom class variables for OpenCV."""
@@ -62,33 +60,41 @@ class EB_OpenCV(CMakeMake):
         # can't be set before prepare_step is run
         self.pylibdir = None
 
+        self.cfg['separate_build_dir'] = True
+
     def prepare_step(self, *args, **kwargs):
         """Prepare environment for installing OpenCV."""
         super(EB_OpenCV, self).prepare_step(*args, **kwargs)
 
         self.pylibdir = det_pylibdir()
 
-        ippicv_tgz = glob.glob(os.path.join(self.builddir, 'ippicv*.tgz'))
-        if ippicv_tgz:
-            if len(ippicv_tgz) == 1:
-                # copy ippicv tarball in the right place
-                # expected location is 3rdparty/ippicv/downloads/linux-<md5sum>/
-                ippicv_tgz = ippicv_tgz[0]
-                ippicv_tgz_md5 = compute_checksum(ippicv_tgz, checksum_type='md5')
-                target_subdir = os.path.join('3rdparty', 'ippicv', 'downloads', 'linux-%s' % ippicv_tgz_md5)
-                copy([ippicv_tgz], os.path.join(self.cfg['start_dir'], target_subdir))
+        if get_cpu_architecture() == X86_64:
+            # IPP are Intel's Integrated Performance Primitives - so only make sense on X86_64
+            ippicv_tgz = glob.glob(os.path.join(self.builddir, 'ippicv*.tgz'))
+            if ippicv_tgz:
+                if len(ippicv_tgz) == 1:
+                    # copy ippicv tarball in the right place
+                    # expected location is 3rdparty/ippicv/downloads/linux-<md5sum>/
+                    ippicv_tgz = ippicv_tgz[0]
+                    ippicv_tgz_md5 = compute_checksum(ippicv_tgz, checksum_type='md5')
+                    target_subdir = os.path.join('3rdparty', 'ippicv', 'downloads', 'linux-%s' % ippicv_tgz_md5)
+                    copy([ippicv_tgz], os.path.join(self.cfg['start_dir'], target_subdir))
 
-                self.cfg.update('configopts', '-DWITH_IPP=ON')
+                    self.cfg.update('configopts', '-DWITH_IPP=ON')
 
-                # for recent OpenCV 3.x versions (and newer), we must also specify the download location
-                # to prevent that the ippicv tarball is re-downloaded
-                if LooseVersion(self.version) >= LooseVersion('3.4.4'):
-                    self.cfg.update('configopts', '-DOPENCV_DOWNLOAD_PATH=%s' % self.builddir)
-            else:
-                raise EasyBuildError("Found multiple ippicv*.tgz source tarballs in %s: %s", self.builddir, ippicv_tgz)
+                    # for recent OpenCV 3.x versions (and newer), we must also specify the download location
+                    # to prevent that the ippicv tarball is re-downloaded
+                    if LooseVersion(self.version) >= LooseVersion('3.4.4'):
+                        self.cfg.update('configopts', '-DOPENCV_DOWNLOAD_PATH=%s' % self.builddir)
+                else:
+                    raise EasyBuildError("Found multiple ippicv*.tgz source tarballs in %s: %s",
+                                         self.builddir, ippicv_tgz)
 
     def configure_step(self):
         """Custom configuration procedure for OpenCV."""
+
+        if 'CMAKE_BUILD_TYPE' not in self.cfg['configopts']:
+            self.cfg.update('configopts', '-DCMAKE_BUILD_TYPE=Release')
 
         # enable Python support if unspecified and Python is a dependency
         if 'BUILD_PYTHON_SUPPORT' not in self.cfg['configopts']:
@@ -186,7 +192,7 @@ class EB_OpenCV(CMakeMake):
         libfile = 'libopencv_core.%s' % get_shared_lib_ext()
         custom_paths = {
             'files': [os.path.join('bin', 'opencv_%s' % x) for x in opencv_bins] + [os.path.join('lib64', libfile)],
-            'dirs': ['include'],
+            'dirs': ['include', self.pylibdir],
         }
         if 'WITH_IPP=ON' in self.cfg['configopts']:
             custom_paths['files'].append(os.path.join('lib', 'libippicv.a'))


### PR DESCRIPTION
This is a small change to exclude trying to build OpenCV using the Intel Integrated Performance Primitives on non-X86 systems.