### PR TITLE
Use new MATLAB binary installer for versions >= 2020a

### DIFF
--- a/easybuild/easyblocks/m/matlab.py
+++ b/easybuild/easyblocks/m/matlab.py
@@ -170,8 +170,6 @@ class EB_MATLAB(PackedBinary):
             except IOError as err:
                 raise EasyBuildError("Failed to update config file %s: %s", self.configfile, err)
 
-            self.log.debug('configuration file updated with installation key:\n %s', config)
-
             (out, _) = run_cmd(cmd, log_all=True, simple=False)
 
             # check installer output for known signs of trouble

--- a/easybuild/easyblocks/m/matlab.py
+++ b/easybuild/easyblocks/m/matlab.py
@@ -158,48 +158,22 @@ class EB_MATLAB(PackedBinary):
         # Compile the installation key regex outside of the loop
         regkey = re.compile(r"^(# )?fileInstallationKey=.*", re.M)
 
-        # Make one install for each key
+        # Run an install for each key
         for i, key in enumerate(keys):
 
-            self.log.debug('Installing with key %s of %s', i + 1, len(keys))
+            self.log.info('Installing MATLAB with key %s of %s', i + 1, len(keys))
 
-            if LooseVersion(self.version) >= LooseVersion('2020a'):
-                self.log.debug('Version is %s - using binary installer method', self.version)
-                try:
-                    config = read_file(self.configfile)
-                    config = regkey.sub("fileInstallationKey=%s" % key, config)
-                    write_file(self.configfile, config)
+            try:
+                config = read_file(self.configfile)
+                config = regkey.sub("fileInstallationKey=%s" % key, config)
+                write_file(self.configfile, config)
 
-                except IOError as err:
-                    raise EasyBuildError("Failed to update config file %s: %s", self.configfile, err)
+            except IOError as err:
+                raise EasyBuildError("Failed to update config file %s: %s", self.configfile, err)
 
-                self.log.debug('configuration file updated with installation key:\n %s', config)
+            self.log.debug('configuration file updated with installation key:\n %s', config)
 
-                cmd = ' '.join([
-                    self.cfg['preinstallopts'],
-                    src,
-                    '-inputFile',
-                    self.configfile,
-                    self.cfg['installopts'],
-                ])
-
-                (out, _) = run_cmd(cmd, log_all=True, simple=False)
-
-            else:
-                self.log.debug('Version is %s - using script installer method', self.version)
-                cmd = ' '.join([
-                    self.cfg['preinstallopts'],
-                    src,
-                    '-v',
-                    tmpdir,
-                    '-inputFile',
-                    self.configfile,
-                    '-fileInstallationKey',
-                    key,
-                    self.cfg['installopts'],
-                ])
-
-                (out, _) = run_cmd(cmd, log_all=True, simple=False)
+            (out, _) = run_cmd(cmd, log_all=True, simple=False)
 
             # check installer output for known signs of trouble
             patterns = [

--- a/easybuild/easyblocks/m/matlab.py
+++ b/easybuild/easyblocks/m/matlab.py
@@ -46,7 +46,6 @@ from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import adjust_permissions, change_dir, read_file, write_file
 from easybuild.tools.py2vs3 import string_type
 from easybuild.tools.run import run_cmd
-from easybuild.tools.systemtools import get_shared_lib_ext
 
 
 class EB_MATLAB(PackedBinary):

--- a/easybuild/easyblocks/m/matlab.py
+++ b/easybuild/easyblocks/m/matlab.py
@@ -131,8 +131,23 @@ class EB_MATLAB(PackedBinary):
         if LooseVersion(self.version) >= LooseVersion('2016b'):
             change_dir(self.builddir)
 
-        # MATLAB installer ignores TMPDIR (always uses /tmp) and might need a large tmpdir
-        tmpdir = "-tmpdir %s" % tempfile.mkdtemp()
+        # Build the cmd string
+        cmdlist = [
+            self.cfg['preinstallopts'],
+            src,
+            '-inputFile',
+            self.configfile,
+        ]
+        if LooseVersion(self.version) < LooseVersion('2020a'):
+            # MATLAB installers < 2020a ignore $TMPDIR (always use /tmp) and might need a large tmpdir
+            tmpdir = tempfile.mkdtemp()
+            cmdlist.extend([
+                '-v',
+                '-tmpdir',
+                tmpdir,
+            ])
+        cmdlist.append(self.cfg['installopts'])
+        cmd = ' '.join(cmdlist)
 
         keys = self.cfg['key']
         if keys is None:


### PR DESCRIPTION
MATLAB will be deprecating the script-based installation method from 2020b onwards.