### PR TITLE
 make sure CFLAGS and MYCFLAGS are used in Lua easyblock

### DIFF
--- a/easybuild/easyblocks/l/lua.py
+++ b/easybuild/easyblocks/l/lua.py
@@ -69,7 +69,8 @@ class EB_Lua(ConfigureMake):
         if LooseVersion(self.version) > LooseVersion('5.2'):
             mycflags.append('-DLUA_COMPAT_5_2')
         if LooseVersion(self.version) > LooseVersion('5.3'):
-            mycflags.extend([os.getenv('CFLAGS', ''), os.getenv('MYCFLAGS', ''), '-fPIC'])
+            mycflags.append(os.getenv('CFLAGS', ''))
+        mycflags.append(os.getenv('MYCFLAGS', ''))
         if mycflags:
             self.cfg.update('buildopts', 'MYCFLAGS="%s"' % ' '.join(mycflags))
 

--- a/easybuild/easyblocks/l/lua.py
+++ b/easybuild/easyblocks/l/lua.py
@@ -68,6 +68,8 @@ class EB_Lua(ConfigureMake):
             mycflags.append('-DLUA_COMPAT_5_1')
         if LooseVersion(self.version) > LooseVersion('5.2'):
             mycflags.append('-DLUA_COMPAT_5_2')
+        if LooseVersion(self.version) > LooseVersion('5.3'):
+            mycflags.extend([os.getenv('CFLAGS', ''), os.getenv('MYCFLAGS', ''), '-fPIC'])
         if mycflags:
             self.cfg.update('buildopts', 'MYCFLAGS="%s"' % ' '.join(mycflags))
 

--- a/easybuild/easyblocks/l/lua.py
+++ b/easybuild/easyblocks/l/lua.py
@@ -68,9 +68,10 @@ class EB_Lua(ConfigureMake):
             mycflags.append('-DLUA_COMPAT_5_1')
         if LooseVersion(self.version) > LooseVersion('5.2'):
             mycflags.append('-DLUA_COMPAT_5_2')
-        if LooseVersion(self.version) > LooseVersion('5.3'):
-            mycflags.append(os.getenv('CFLAGS', ''))
+
+        mycflags.append(os.getenv('CFLAGS', ''))
         mycflags.append(os.getenv('MYCFLAGS', ''))
+
         if mycflags:
             self.cfg.update('buildopts', 'MYCFLAGS="%s"' % ' '.join(mycflags))
 


### PR DESCRIPTION
needed for ARGoS, to avoid compilation errors like this:
```
/apps/brussel/CO7/ivybridge-ib/software/binutils/2.34-GCCcore-9.3.0/bin/ld.gold: error: /apps/brussel/CO7/ivybridge-ib/software/Lua/5.3.5-GCCcore-9.3.0/lib/liblua.a(lapi.o): requires dynamic R_X86_64_32 reloc against 'luaO_nilobject_' which may overflow at runtime; recompile with -fPIC
/apps/brussel/CO7/ivybridge-ib/software/binutils/2.34-GCCcore-9.3.0/bin/ld.gold: error: /apps/brussel/CO7/ivybridge-ib/software/Lua/5.3.5-GCCcore-9.3.0/lib/liblua.a(ldebug.o): requires dynamic R_X86_64_32 reloc which may overflow at runtime; recompile with -fPIC
/apps/brussel/CO7/ivybridge-ib/software/binutils/2.34-GCCcore-9.3.0/bin/ld.gold: error: /apps/brussel/CO7/ivybridge-ib/software/Lua/5.3.5-GCCcore-9.3.0/lib/liblua.a(ldo.o): requires dynamic R_X86_64_32 reloc which may overflow at runtime; recompile with -fPIC
/apps/brussel/CO7/ivybridge-ib/software/binutils/2.34-GCCcore-9.3.0/bin/ld.gold: error: /apps/brussel/CO7/ivybridge-ib/software/Lua/5.3.5-GCCcore-9.3.0/lib/liblua.a(ldump.o): requires unsupported dynamic reloc 11; recompile with -fPIC
/apps/brussel/CO7/ivybridge-ib/software/binutils/2.34-GCCcore-9.3.0/bin/ld.gold: error: /apps/brussel/CO7/ivybridge-ib/software/Lua/5.3.5-GCCcore-9.3.0/lib/liblua.a(lgc.o): requires unsupported dynamic reloc 11; recompile with -fPIC
/apps/brussel/CO7/ivybridge-ib/software/binutils/2.34-GCCcore-9.3.0/bin/ld.gold: error: /apps/brussel/CO7/ivybridge-ib/software/Lua/5.3.5-GCCcore-9.3.0/lib/liblua.a(lmem.o): requires dynamic R_X86_64_32 reloc which may overflow at runtime; recompile with -fPIC
```
also added EB defined `CFLAGS` and optionally user defined `MYCFLAGS`.
tested with Lua-5.3.4 and Lua-5.3.5.