### PR TITLE
fix order of intel64/lib paths in generated module for impi (and drop intel64/lib/release_mt)

### DIFF
--- a/easybuild/easyblocks/i/impi.py
+++ b/easybuild/easyblocks/i/impi.py
@@ -261,7 +261,7 @@ EULA=accept
             if LooseVersion(self.version) >= LooseVersion('2019'):
                 # The "release" library is default in v2019. Give it precedence over intel64/lib.
                 # (remember paths are *prepended*, so the last path in the list has highest priority)
-                lib_dirs = ['intel64/%s' % x for x in ['lib/release_mt', 'lib/release', 'lib']]
+                lib_dirs = ['intel64/%s' % x for x in ['lib', 'lib/release']]
                 include_dirs = ['intel64/include']
                 path_dirs = ['intel64/bin']
                 if self.cfg['ofi_internal']:

--- a/easybuild/easyblocks/i/impi.py
+++ b/easybuild/easyblocks/i/impi.py
@@ -259,7 +259,8 @@ EULA=accept
         else:
             guesses = {}
             if LooseVersion(self.version) >= LooseVersion('2019'):
-                # Keep release_mt and release in front, to give them priority over the possible symlinks in intel64/lib.
+                # Keep release_mt and release in front, to give priority to the possible symlinks in intel64/lib.
+                # (remember paths are *prepended*, so the last path in the list has highest priority)
                 # IntelMPI 2019 changed the default library to be the non-mt version.
                 lib_dirs = ['intel64/%s' % x for x in ['lib/release_mt', 'lib/release', 'lib']]
                 include_dirs = ['intel64/include']

--- a/easybuild/easyblocks/i/impi.py
+++ b/easybuild/easyblocks/i/impi.py
@@ -259,9 +259,8 @@ EULA=accept
         else:
             guesses = {}
             if LooseVersion(self.version) >= LooseVersion('2019'):
-                # Keep release_mt and release in front, to give priority to the possible symlinks in intel64/lib.
+                # The "release" library is default in v2019. Give it precedence over intel64/lib.
                 # (remember paths are *prepended*, so the last path in the list has highest priority)
-                # IntelMPI 2019 changed the default library to be the non-mt version.
                 lib_dirs = ['intel64/%s' % x for x in ['lib/release_mt', 'lib/release', 'lib']]
                 include_dirs = ['intel64/include']
                 path_dirs = ['intel64/bin']


### PR DESCRIPTION
This reverts https://github.com/easybuilders/easybuild-easyblocks/commit/0874dafb46550cbedc854d2f92d26422ac206121