### PR TITLE
fix bug in PythonBundle: always add */site-packages subdirs to $PYTHONPATH when installing extensions

### DIFF
--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -134,9 +134,17 @@ class PythonBundle(Bundle):
         if self.multi_python:
             txt += self.module_generator.prepend_paths(EBPYTHONPREFIXES, '')
         else:
-            for pylibdir in self.all_pylibdirs:
-                if os.path.exists(os.path.join(self.installdir, pylibdir)):
+
+            # the temporary module file that is generated before installing extensions
+            # must add all subdirectories to $PYTHONPATH without checking existence,
+            # otherwise paths will be missing since nothing is there initially
+            if self.current_step == 'extensions':
+                for pylibdir in self.all_pylibdirs:
                     txt += self.module_generator.prepend_paths('PYTHONPATH', pylibdir)
+            else:
+                for pylibdir in self.all_pylibdirs:
+                    if os.path.exists(os.path.join(self.installdir, pylibdir)):
+                        txt += self.module_generator.prepend_paths('PYTHONPATH', pylibdir)
 
         return txt
 

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -139,12 +139,12 @@ class PythonBundle(Bundle):
             # must add all subdirectories to $PYTHONPATH without checking existence,
             # otherwise paths will be missing since nothing is there initially
             if self.current_step == 'extensions':
-                for pylibdir in self.all_pylibdirs:
-                    txt += self.module_generator.prepend_paths('PYTHONPATH', pylibdir)
+                new_pylibdirs = self.all_pylibdirs
             else:
-                for pylibdir in self.all_pylibdirs:
-                    if os.path.exists(os.path.join(self.installdir, pylibdir)):
-                        txt += self.module_generator.prepend_paths('PYTHONPATH', pylibdir)
+                new_pylibdirs = [l for l in self.all_pylibdirs if os.path.exists(os.path.join(self.installdir, l))]
+
+            for pylibdir in new_pylibdirs:
+                txt += self.module_generator.prepend_paths('PYTHONPATH', pylibdir)
 
         return txt
 


### PR DESCRIPTION
This fixes a bug that was introduced in #2075.

Installing `SciPy-bundle` is broken currently for example, the installation of the `scipy` extensions fails because `numpy` can not be found, even though it is installed correctly.