### PR TITLE
Make VMD easyblock Python 3 compatible

### DIFF
--- a/easybuild/easyblocks/v/vmd.py
+++ b/easybuild/easyblocks/v/vmd.py
@@ -94,14 +94,23 @@ class EB_VMD(ConfigureMake):
         netcdflib = os.path.join(deps['netCDF'], 'lib')
 
         # Python locations
-        pyshortver = '.'.join(get_software_version('Python').split('.')[:2])
-        env.setvar('PYTHON_INCLUDE_DIR', os.path.join(deps['Python'], 'include/python%s' % pyshortver))
+        pymajver = get_software_version('Python').split('.')[0]
+        out, ec = run_cmd("python -c 'import sysconfig; print(sysconfig.get_path(\"include\"))'", simple=False)
+        if ec:
+            raise EasyBuildError("Failed to determine Python include path: %s", out)
+        else:
+            env.setvar('PYTHON_INCLUDE_DIR', out.strip())
         pylibdir = det_pylibdir()
         python_libdir = os.path.join(deps['Python'], os.path.dirname(pylibdir))
         env.setvar('PYTHON_LIBRARY_DIR', python_libdir)
+        out, ec = run_cmd("python%s-config --libs" % pymajver, simple=False)
+        if ec:
+            raise EasyBuildError("Failed to determine Python library name: %s", out)
+        else:
+            env.setvar('PYTHON_LIBRARIES', out.strip())
 
         # numpy include location, easiest way to determine it is via numpy.get_include()
-        out, ec = run_cmd("python -c 'import numpy; print numpy.get_include()'", simple=False)
+        out, ec = run_cmd("python -c 'import numpy; print(numpy.get_include())'", simple=False)
         if ec:
             raise EasyBuildError("Failed to determine numpy include directory: %s", out)
         else:


### PR DESCRIPTION
Besides the fix for getting the Numpy include path (which didn't work in Python 3), I'm also adding two additional environment variables. The first sets the path to the Python include dir (Python 3 versions have something like include/python3.7m/python.h), for which I use the sysconfig package in Python. The second holds the linker flags (-lpython3.7m) for linking the Python libraries. For the latter I call python<majorversion>-config, e.g.:
```
$ python3-config --libs
-lpython3.7m -lcrypt -ldl -lm -lpthread -lutil -lm 
```
Since this only adds two environment variables (which my patch for new VMD versions will pick up), older VMD version should still work fine (they seem to have some hardcoded stuff in the configure script for, for instance, the name of the Python library).