### PR TITLE
fix Mothur easyblock to work with 1.44.0 and higher

### DIFF
--- a/easybuild/easyblocks/m/mothur.py
+++ b/easybuild/easyblocks/m/mothur.py
@@ -30,10 +30,11 @@ EasyBuild support for Mothur, implemented as an easyblock
 import glob
 import os
 import shutil
+from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.modules import get_software_root
+from easybuild.tools.modules import get_software_root, get_software_version
 
 
 class EB_Mothur(ConfigureMake):
@@ -83,9 +84,14 @@ class EB_Mothur(ConfigureMake):
         srcdir = os.path.join(self.builddir, self.cfg['start_dir'])
         destdir = os.path.join(self.installdir, 'bin')
         srcfile = None
+        # After version 1.43.0 uchime binary is not included in the Mothur tarball
+        if LooseVersion(self.version) > LooseVersion('1.43.0'):
+            files_to_copy = ['mothur']
+        else:
+            files_to_copy = ['mothur', 'uchime']
         try:
             os.makedirs(destdir)
-            for filename in ['mothur', 'uchime']:
+            for filename in files_to_copy:
                 srcfile = os.path.join(srcdir, filename)
                 shutil.copy2(srcfile, destdir)
         except OSError as err:

--- a/easybuild/easyblocks/m/mothur.py
+++ b/easybuild/easyblocks/m/mothur.py
@@ -34,7 +34,7 @@ from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.modules import get_software_root, get_software_version
+from easybuild.tools.modules import get_software_root
 
 
 class EB_Mothur(ConfigureMake):


### PR DESCRIPTION
in newer mothur versions uchime should be included as a dependency