### PR TITLE
Tensorflow.py fails with bigger NCCL version names

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -317,15 +317,15 @@ class EB_TensorFlow(PythonPackage):
             else:
                 raise EasyBuildError("TensorFlow has a strict dependency on cuDNN if CUDA is enabled")
             if nccl_root:
-                nccl_version = get_software_version('NCCL')
-                nccl_maj_min_ver = '.'.join(nccl_version.split('.')[:2])
+                # Ignore the PKG_REVISION identifier (i.e., report 2.4.6 for 2.4.6-1 or 2.4.6-2)
+                nccl_version = nccl_version.split('-')[0]
                 config_env_vars.update({
                     'NCCL_INSTALL_PATH': nccl_root,
                 })
             else:
-                nccl_maj_min_ver = '1.3'  # Use simple downloadable version
+                nccl_version = '1.3'  # Use simple downloadable version
             config_env_vars.update({
-                'TF_NCCL_VERSION': nccl_maj_min_ver,
+                'TF_NCCL_VERSION': nccl_version,
             })
             if tensorrt_root:
                 tensorrt_version = get_software_version('TensorRT')

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -318,13 +318,14 @@ class EB_TensorFlow(PythonPackage):
                 raise EasyBuildError("TensorFlow has a strict dependency on cuDNN if CUDA is enabled")
             if nccl_root:
                 nccl_version = get_software_version('NCCL')
+                nccl_maj_min_ver = '.'.join(nccl_version.split('.')[:2])
                 config_env_vars.update({
                     'NCCL_INSTALL_PATH': nccl_root,
                 })
             else:
-                nccl_version = '1.3'  # Use simple downloadable version
+                nccl_maj_min_ver = '1.3'  # Use simple downloadable version
             config_env_vars.update({
-                'TF_NCCL_VERSION': nccl_version,
+                'TF_NCCL_VERSION': nccl_maj_min_ver,
             })
             if tensorrt_root:
                 tensorrt_version = get_software_version('TensorRT')

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -317,6 +317,7 @@ class EB_TensorFlow(PythonPackage):
             else:
                 raise EasyBuildError("TensorFlow has a strict dependency on cuDNN if CUDA is enabled")
             if nccl_root:
+                nccl_version = get_software_version('NCCL')
                 # Ignore the PKG_REVISION identifier (i.e., report 2.4.6 for 2.4.6-1 or 2.4.6-2)
                 nccl_version = nccl_version.split('-')[0]
                 config_env_vars.update({

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -318,7 +318,7 @@ class EB_TensorFlow(PythonPackage):
                 raise EasyBuildError("TensorFlow has a strict dependency on cuDNN if CUDA is enabled")
             if nccl_root:
                 nccl_version = get_software_version('NCCL')
-                # Ignore the PKG_REVISION identifier (i.e., report 2.4.6 for 2.4.6-1 or 2.4.6-2)
+                # Ignore the PKG_REVISION identifier if it exists (i.e., report 2.4.6 for 2.4.6-1 or 2.4.6-2)
                 nccl_version = nccl_version.split('-')[0]
                 config_env_vars.update({
                     'NCCL_INSTALL_PATH': nccl_root,


### PR DESCRIPTION
FZJ-JSC has a NCCL versioned 2.4.6-1. This makes the bazel question about NCCL version to fail - as the version on the `nccl.h` is like this:

```#define NCCL_MAJOR 2
#define NCCL_MINOR 4
#define NCCL_PATCH 6
#define NCCL_SUFFIX ""
#define NCCL_VERSION_CODE 2406```

This patch makes sure that NCCL versions with patch names (and sub-names) work.