### PR TITLE
use 'wclean -platform' instead of 'wcleanPlatform' for OpenFOAM v2006 & newer

### DIFF
--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -292,7 +292,10 @@ class EB_OpenFOAM(EasyBlock):
 
         precmd = "source %s" % os.path.join(self.builddir, self.openfoamdir, "etc", "bashrc")
         if 'extend' not in self.name.lower() and self.looseversion >= LooseVersion('4.0'):
-            cleancmd = "cd $WM_PROJECT_DIR && wcleanPlatform -all && cd -"
+            if self.looseversion >= LooseVersion('2006'):
+                cleancmd = "cd $WM_PROJECT_DIR && wclean -platform -all && cd -"
+            else:
+                cleancmd = "cd $WM_PROJECT_DIR && wcleanPlatform -all && cd -"
         else:
             cleancmd = "wcleanAll"
 


### PR DESCRIPTION
see also https://develop.openfoam.com/Development/openfoam/-/wikis/guides/upgrade/v2006-User-Upgrade-Guide#additional-wmake-subcommands