### PR TITLE
fix assumption in Bazel easyblock that include-fixed subdirectory is always there in GCC installation

### DIFF
--- a/easybuild/easyblocks/b/bazel.py
+++ b/easybuild/easyblocks/b/bazel.py
@@ -56,9 +56,10 @@ class EB_Bazel(EasyBlock):
             else:
                 raise EasyBuildError("Failed to pinpoint location of GCC include files: %s", res)
 
-            gcc_lib_inc_fixed = os.path.join(os.path.dirname(gcc_lib_inc), 'include-fixed')
-            if not os.path.exists(gcc_lib_inc_fixed):
-                raise EasyBuildError("Derived directory %s does not exist", gcc_lib_inc_fixed)
+            gcc_lib_inc_bis = os.path.join(os.path.dirname(gcc_lib_inc), 'include-fixed')
+            if not os.path.exists(gcc_lib_inc_bis):
+                self.log.info("Derived directory %s does not exist, falling back to %s", gcc_lib_inc_bis, gcc_lib_inc)
+                gcc_lib_inc_bis = gcc_lib_inc
 
             gcc_cplusplus_inc = os.path.join(gcc_root, 'include', 'c++', gcc_ver)
             if not os.path.exists(gcc_cplusplus_inc):
@@ -71,7 +72,7 @@ class EB_Bazel(EasyBlock):
                 regex_subs = [
                     (r'-B/usr/bin', '-B%s' % os.path.join(binutils_root, 'bin')),
                     (r'(cxx_builtin_include_directory:.*)/usr/lib/gcc', r'\1%s' % gcc_lib_inc),
-                    (r'(cxx_builtin_include_directory:.*)/usr/local/include', r'\1%s' % gcc_lib_inc_fixed),
+                    (r'(cxx_builtin_include_directory:.*)/usr/local/include', r'\1%s' % gcc_lib_inc_bis),
                     (r'(cxx_builtin_include_directory:.*)/usr/include', r'\1%s' % gcc_cplusplus_inc),
                 ]
                 for tool in ['ar', 'cpp', 'dwp', 'gcc', 'ld']:


### PR DESCRIPTION
(partial fix for #2092)