### PR TITLE
use mpirun for sanity check commands in LAMMPS easyblock

### DIFF
--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -258,6 +258,10 @@ class EB_LAMMPS(CMakeMake):
             for check_file in check_files
         ]
 
+        # Execute sanity check commands within an initialized MPI in MPI enabled toolchains
+        if self.toolchain.options.get('usempi', None):
+            custom_commands = [self.toolchain.mpi_cmd_for(cmd, 1) for cmd in custom_commands]
+
         shlib_ext = get_shared_lib_ext()
         custom_paths = {
             'files': [


### PR DESCRIPTION
Needed by https://github.com/easybuilders/easybuild-easyconfigs/pull/10712

This is mandatory for `intel/2020a` due to issue https://github.com/easybuilders/easybuild-easyconfigs/issues/10213 .
In other toolchains does not cause any downsides.