### PR TITLE
filter out Python in SLEPc configure

### DIFF
--- a/easybuild/easyblocks/s/slepc.py
+++ b/easybuild/easyblocks/s/slepc.py
@@ -78,7 +78,7 @@ class EB_SLEPc(ConfigureMake):
         self.log.debug('SLEPC_DIR: %s' % os.getenv('SLEPC_DIR'))
 
         # optional dependencies
-        depfilter = self.cfg.builddependencies() + ["PETSc"]
+        depfilter = self.cfg.builddependencies() + ['PETSc', 'Python']
         deps = [dep['name'] for dep in self.cfg.dependencies() if not dep['name'] in depfilter]
         for dep in deps:
             deproot = get_software_root(dep)
@@ -92,7 +92,7 @@ class EB_SLEPc(ConfigureMake):
             (out, _) = run_cmd(cmd, log_all=True, simple=False)
         else:
             # regular './configure --prefix=X' for non-source install
-            
+
             # make sure old install dir is removed first
             self.make_installdir(dontcreate=True)
 

--- a/easybuild/easyblocks/s/slepc.py
+++ b/easybuild/easyblocks/s/slepc.py
@@ -78,8 +78,8 @@ class EB_SLEPc(ConfigureMake):
         self.log.debug('SLEPC_DIR: %s' % os.getenv('SLEPC_DIR'))
 
         # optional dependencies
-        depfilter = self.cfg.builddependencies() + ['PETSc', 'Python']
-        deps = [dep['name'] for dep in self.cfg.dependencies() if not dep['name'] in depfilter]
+        dep_filter = self.cfg.builddependencies() + ['PETSc', 'Python']
+        deps = [dep['name'] for dep in self.cfg.dependencies() if dep['name'] not in dep_filter]
         for dep in deps:
             deproot = get_software_root(dep)
             if deproot:


### PR DESCRIPTION
Filter out Python from the dependency check in the configure step of `SLEPc`.
This is needed for https://github.com/easybuilders/easybuild-easyconfigs/pull/10908 to fix issue https://github.com/easybuilders/easybuild-easyconfigs/issues/10865