### PR TITLE
add custom easyblock for PyTorch

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -557,7 +557,12 @@ class PythonPackage(ExtensionEasyBlock):
 
             cmd = ' '.join([self.cfg['prebuildopts'], self.python_cmd, 'setup.py', self.cfg['buildcmd'],
                             self.cfg['buildopts']])
-            run_cmd(cmd, log_all=True, simple=True)
+            (out, _) = run_cmd(cmd, log_all=True, log_ok=True, simple=False)
+
+            # keep track of all output, so we can check for auto-downloaded dependencies;
+            # take into account that build/install steps may be run multiple times
+            # We consider the build and install output together as downloads likely happen here if this is run
+            self.install_cmd_output += out
 
     def test_step(self):
         """Test the built Python package."""

--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -123,6 +123,11 @@ class EB_PyTorch(PythonPackage):
 
         # Gather default options. Will be checked against (and can be overwritten by) custom_opts
         options = ['PYTORCH_BUILD_VERSION=' + self.version, 'PYTORCH_BUILD_NUMBER=1']
+
+        # enable verbose mode when --debug is used (to show compiler commands)
+        if build_option('debug'):
+            options.append('VERBOSE=1')
+
         # Restrict parallelism
         options.append('MAX_JOBS=%s' % self.cfg['parallel'])
 

--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -1,0 +1,232 @@
+##
+# Copyright 2020-2020 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for building and installing PyTorch, implemented as an easyblock
+
+@author: Alexander Grund (TU Dresden)
+"""
+
+import os
+import re
+import tempfile
+from distutils.version import LooseVersion
+from easybuild.easyblocks.generic.pythonpackage import PythonPackage
+from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.config import build_option
+import easybuild.tools.environment as env
+from easybuild.tools.modules import get_software_root
+from easybuild.tools.systemtools import POWER, get_cpu_architecture
+
+
+class EB_PyTorch(PythonPackage):
+    """Support for building/installing TensorFlow."""
+
+    @staticmethod
+    def extra_options():
+        extra_vars = PythonPackage.extra_options()
+        extra_vars.update({
+            'excluded_tests': [{}, 'Mapping of architecture strings to list of tests to be excluded', CUSTOM],
+            'custom_opts': [[], 'List of options for the build/install command. Can be used to change the defaults ' +
+                                'set by the PyTorch EasyBlock, for example ["USE_MKLDNN=0"].', CUSTOM]
+        })
+        extra_vars['download_dep_fail'][0] = True
+        extra_vars['sanity_pip_check'][0] = True
+
+        return extra_vars
+
+    def __init__(self, *args, **kwargs):
+        """Constructor for PyTorch easyblock."""
+        super(EB_PyTorch, self).__init__(*args, **kwargs)
+        self.options['modulename'] = 'torch'
+        # Test as-if pytorch was installed
+        self.testinstall = True
+        self.tmpdir = tempfile.mkdtemp(suffix='-pytorch-build')
+
+    def fetch_step(self, skip_checksums=False):
+        """Fetch sources for installing PyTorch, including those for tests."""
+        super(EB_PyTorch, self).fetch_step(skip_checksums)
+        # Resolve tests early to avoid failures later. Use obtain_file if path is not absolute
+        tests = [test if os.path.isabs(test) else self.obtain_file(test) for test in self.cfg['tests']]
+        self.cfg['tests'] = tests
+
+    @staticmethod
+    def get_dependency_options_for_version(pytorch_version):
+        """
+        PyTorch can enable some functionality based on available software or use system software instead of a submodule
+        This returns EasyBuild names of that and the flag that should be used when the dependency is found
+
+        The result is a list of tuples (enable_flag, eb_name)
+        """
+        pytorch_version = LooseVersion(pytorch_version)
+
+        def is_version_ok(version_range):
+            """Return True if the PyTorch version to be installed matches the version_range"""
+            min_version, max_version = version_range.split(':')
+            result = True
+            if min_version and pytorch_version < LooseVersion(min_version):
+                result = False
+            if max_version and pytorch_version >= LooseVersion(max_version):
+                result = False
+            return result
+
+        available_libs = (
+            # Format: (PyTorch flag to enable, EB name, '<min version>:<exclusive max version>')
+            # Use `None` for the EB name if no known EC exists
+            ('USE_FFMPEG=1', 'FFmpeg', '1.0.0:'),
+            ('USE_GFLAGS=1', 'gflags', '1.0.0:'),
+            ('USE_GLOG=1', 'glog', '1.0.0:'),
+
+            # For system libs check CMakeLists.txt, below `if(USE_SYSTEM_LIBS)`, order kept here
+            # NCCL handled specially as other env variables are requires for it
+            ('USE_SYSTEM_CPUINFO=1', None, '1.6.0:'),
+            ('USE_SYSTEM_SLEEF=1', None, '1.6.0:'),
+            ('USE_SYSTEM_GLOO=1', None, '1.6.0:'),
+            ('BUILD_CUSTOM_PROTOBUF=0', 'protobuf', '1.2.0:'),
+            ('USE_SYSTEM_EIGEN_INSTALL=1', 'Eigen', '1.0.0:'),
+            ('USE_SYSTEM_FP16=1', None, '1.6.0:'),
+            ('USE_SYSTEM_PTHREADPOOL=1', None, '1.6.0:'),
+            ('USE_SYSTEM_PSIMD=1', None, '1.6.0:'),
+            ('USE_SYSTEM_FXDIV=1', None, '1.6.0:'),
+            ('USE_SYSTEM_BENCHMARK=1', None, '1.6.0:'),  # Google Benchmark
+            ('USE_SYSTEM_ONNX=1', None, '1.6.0:'),
+            ('USE_SYSTEM_XNNPACK=1', None, '1.6.0:'),
+        )
+        return [(enable_opt, dep_name) for enable_opt, dep_name, version_range in available_libs
+                if is_version_ok(version_range)]
+
+    def configure_step(self):
+        """Custom configure procedure for PyTorch."""
+        super(EB_PyTorch, self).configure_step()
+
+        # Gather default options. Will be checked against (and can be overwritten by) custom_opts
+        options = ['PYTORCH_BUILD_VERSION=' + self.version, 'PYTORCH_BUILD_NUMBER=1']
+        # Restrict parallelism
+        options.append('MAX_JOBS=%s' % self.cfg['parallel'])
+
+        # BLAS Interface
+        if get_software_root('imkl'):
+            options.append('BLAS=MKL')
+        else:
+            # This is what PyTorch defaults to if no MKL is found. Make this explicit here
+            options.append('BLAS=Eigen')
+
+        available_dependency_options = EB_PyTorch.get_dependency_options_for_version(self.version)
+        dependency_names = set(dep['name'] for dep in self.cfg.dependencies())
+        not_used_dep_names = []
+        for enable_opt, dep_name in available_dependency_options:
+            if dep_name is None:
+                continue
+            if dep_name in dependency_names:
+                options.append(enable_opt)
+            else:
+                not_used_dep_names.append(dep_name)
+        self.log.info('Did not enable options for the following dependencies as they are not used in the EC: %s',
+                      not_used_dep_names)
+
+        # Use Infiniband by default
+        # you can disable this by including 'USE_IBVERBS=0' in 'custom_opts' in the easyconfig file
+        options.append('USE_IBVERBS=1')
+
+        cudnn_root = get_software_root('cuDNN')
+        if cudnn_root:
+            options.append('CUDNN_LIB_DIR=' + os.path.join(cudnn_root, 'lib64'))
+            options.append('CUDNN_INCLUDE_DIR=' + os.path.join(cudnn_root, 'include'))
+
+        nccl_root = get_software_root('NCCL')
+        if nccl_root:
+            options.append('USE_SYSTEM_NCCL=1')
+            options.append('NCCL_INCLUDE_DIR=' + os.path.join(nccl_root, 'include'))
+
+        # list of CUDA compute capabilities to use can be specifed in two ways (where (2) overrules (1)):
+        # (1) in the easyconfig file, via the custom cuda_compute_capabilities;
+        # (2) in the EasyBuild configuration, via --cuda-compute-capabilities configuration option;
+        cuda_cc = build_option('cuda_compute_capabilities') or self.cfg['cuda_compute_capabilities']
+        if not cuda_cc:
+            raise EasyBuildError("List of CUDA compute capabilities must be specified, either via " +
+                                 "cuda_compute_capabilities easyconfig parameter or via --cuda-compute-capabilities")
+        self.log.info("Compiling with specified list of CUDA compute capabilities: %s", ', '.join(cuda_cc))
+        options.append('TORCH_CUDA_ARCH_LIST="%s"' % ';'.join(cuda_cc))
+
+        if get_cpu_architecture() == POWER:
+            # *NNPACK is not supported on Power, disable to avoid warnings
+            nnpacks = ('NNPACK', 'QNNPACK', 'USE_PYTORCH_QNNPACK', 'USE_XNNPACK')
+            options.extend('USE_%s=0' % nnpack for nnpack in nnpacks)
+
+        # Metal only supported on IOS which likely doesn't work with EB, so disabled
+        options.append('USE_METAL=0')
+
+        unique_options = self.cfg['custom_opts']
+        for option in options:
+            name = option.split('=')[0] + '='  # Include the equals sign to avoid partial matches
+            if not any(opt.startswith(name) for opt in unique_options):
+                unique_options.append(option)
+
+        self.cfg.update('prebuildopts', ' '.join(unique_options) + ' ')
+        self.cfg.update('preinstallopts', ' '.join(unique_options) + ' ')
+
+    def test_step(self):
+        """Run unit tests"""
+        # Make PyTorch tests not use the user home
+        env.setvar('XDG_CACHE_HOME', os.path.join(self.tmpdir, '.cache'))
+        # Parse excluded_tests and flatten into space separated string
+        excluded_tests = []
+        for arch, tests in self.cfg['excluded_tests'].items():
+            if not arch or arch == get_cpu_architecture():
+                excluded_tests.extend(tests)
+        # -x should not be used if there are no excluded tests
+        if excluded_tests:
+            excluded_tests = ['-x'] + excluded_tests
+        self.cfg.template_values.update({
+            'python': self.python_cmd,
+            'excluded_tests': ' '.join(excluded_tests)
+        })
+        super(EB_PyTorch, self).test_step()
+
+    def test_cases_step(self):
+        # Make PyTorch tests not use the user home
+        env.setvar('XDG_CACHE_HOME', os.path.join(self.tmpdir, '.cache'))
+        super(EB_PyTorch, self).test_cases_step()
+
+    def sanity_check_step(self, *args, **kwargs):
+        """Custom sanity check for PyTorch"""
+
+        super(EB_PyTorch, self).sanity_check_step(*args, **kwargs)
+
+        if self.cfg.get('download_dep_fail', True):
+            # CMake might mistakenly download dependencies during configure
+            pattern = r'^-- Downloading (\w+) to /'
+            downloaded_deps = re.findall(pattern, self.install_cmd_output, re.M)
+
+            if downloaded_deps:
+                fail_msg = "found one or more downloaded dependencies: %s" % ', '.join(downloaded_deps)
+                self.sanity_check_fail_msgs.append(fail_msg)
+
+    def make_module_req_guess(self):
+        """Set extra environment variables for PyTorch."""
+
+        guesses = super(EB_PyTorch, self).make_module_req_guess()
+        guesses['CMAKE_PREFIX_PATH'] = [os.path.join(self.pylibdir, 'torch')]
+        return guesses


### PR DESCRIPTION
This makes writing ECs for PyTorch much easier through the following features:

- Support for `cuda_compute_capabilities` just like TF
- Auto setting of `modulename`
- Test on (dummy) installation (there have been reports that tests fail in build tree but pass on installed module)
- Auto setting of `PYTORCH_BUILD_VERSION/NUMBER`
- Auto detection of dependencies and setting of setup config variables for both build and install step (no more duplication required)
- Auto exclude *NNPACK on power
- Avoid using the users home during test
- Detection of build time downloaded submodules
- Arch specific test exclusion (`-x` with no test is invalid, hence need to do this in an EasyBlock!)
- Set `CMAKE_PREFIX_PATH` for `find_package(Torch)` to work for user apps build against the PyTorch C++ API

Example: https://github.com/easybuilders/easybuild-easyconfigs/pull/11000