### PR TITLE
handle installation of pip & setuptools in Python 3.4+

### DIFF
--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -200,7 +200,7 @@ class EB_Python(ConfigureMake):
 
         # Pip is included since 3.4 via ensurepip https://docs.python.org/3.4/whatsnew/changelog.html
         if LooseVersion(self.version) >= LooseVersion('3.4.0'):
-            # Default, but do it explicitely
+            # Default, but do it explicitly
             self.cfg.update('configopts', "--with-ensurepip=upgrade")
 
         modules_setup = os.path.join(self.cfg['start_dir'], 'Modules', 'Setup')
@@ -251,7 +251,7 @@ class EB_Python(ConfigureMake):
             self.cfg.update('configopts', "--with-tcltk-libs='%s'" % tcltk_libs)
 
         # don't add user site directory to sys.path (equivalent to python -s)
-        # This matters e.g. when pythong installs the bundled pip & setuptools (for >= 3.4)
+        # This matters e.g. when python installs the bundled pip & setuptools (for >= 3.4)
         env.setvar('PYTHONNOUSERSITE', '1', verbose=False)
 
         super(EB_Python, self).configure_step()

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -161,13 +161,7 @@ class EB_Python(ConfigureMake):
         # See https://github.com/easybuilders/easybuild-easyconfigs/issues/11009
         for cfg in [os.path.join(os.path.expanduser('~'), name) for name in ('.pydistutils.cfg', 'pydistutils.cfg')]:
             if os.path.exists(cfg):
-                self.log.debug('Found distutils user config file at %s', cfg)
-                contents = read_file(cfg)
-                if any(line.startswith('prefix=') for line in contents.splitlines()):
-                    print_warning('Distutils user config found at %s containing a "prefix=" setting. '
-                                  'Installation might fail due to Python picking up that prefix. '
-                                  'Remove the file if this happens!',
-                                  log=self.log)
+                raise EasyBuildError("Legacy distutils user configuration file found at %s. Aborting.", cfg)
 
         self.cfg.update('configopts', "--enable-shared")
 

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -46,7 +46,7 @@ from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError, print_warning
 from easybuild.tools.config import log_path
 from easybuild.tools.modules import get_software_libdir, get_software_root, get_software_version
-from easybuild.tools.filetools import change_dir, mkdir, symlink, write_file, read_file
+from easybuild.tools.filetools import change_dir, mkdir, symlink, write_file
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
 import easybuild.tools.toolchain as toolchain

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -185,6 +185,11 @@ class EB_Python(ConfigureMake):
         if self.cfg['optimized'] and LooseVersion(self.version) >= LooseVersion('3.5.4'):
             self.cfg.update('configopts', "--enable-optimizations")
 
+        # Pip is included since 3.4 via ensurepip https://docs.python.org/3.4/whatsnew/changelog.html
+        if LooseVersion(self.version) >= LooseVersion('3.4.0'):
+            # Default, but do it explicitely
+            self.cfg.update('configopts', "--with-ensurepip=upgrade")
+
         modules_setup = os.path.join(self.cfg['start_dir'], 'Modules', 'Setup')
         if LooseVersion(self.version) < LooseVersion('3.8.0'):
             modules_setup += '.dist'
@@ -231,6 +236,10 @@ class EB_Python(ConfigureMake):
                 'maj_min_ver': tcltk_maj_min_ver,
             }
             self.cfg.update('configopts', "--with-tcltk-libs='%s'" % tcltk_libs)
+
+        # don't add user site directory to sys.path (equivalent to python -s)
+        # This matters e.g. when pythong installs the bundled pip & setuptools (for >= 3.4)
+        env.setvar('PYTHONNOUSERSITE', '1', verbose=False)
 
         super(EB_Python, self).configure_step()
 
@@ -341,6 +350,16 @@ class EB_Python(ConfigureMake):
             "python -c 'import _ssl'",  # make sure SSL support is enabled one way or another
             "python -c 'import readline'",  # make sure readline support was built correctly
         ]
+
+        if LooseVersion(self.version) >= LooseVersion('3.4.0'):
+            # Check that pip and setuptools are installed
+            custom_paths['files'].extend([
+                os.path.join('bin', pip) for pip in ('pip', 'pip3', 'pip' + self.pyshortver)
+            ])
+            custom_commands.extend([
+                "python -c 'import pip'",
+                "python -c 'import setuptools'",
+            ])
 
         if get_software_root('Tk'):
             # also check whether importing tkinter module works, name is different for Python v2.x and v3.x


### PR DESCRIPTION
Python 3.4 comes with pip and setuptools. This is even required to install (the newer) pip in the EC so not having it is an error.

Furthermore installation of pip/setuptools fails if a distutils user config sets the `prefix` to a different directory as that would be where pip is then installed. See https://github.com/easybuilders/easybuild-easyconfigs/issues/11009
Hence check for that and report a (verbose) warning.