### PR TITLE
set $EB_INSTALLPYTHON in module generated for EasyBuild rather than setting $EB_PYTHON, to allow overriding Python command to be used for running EasyBuild with $EB_PYTHON

### DIFF
--- a/easybuild/easyblocks/e/easybuildmeta.py
+++ b/easybuild/easyblocks/e/easybuildmeta.py
@@ -219,7 +219,8 @@ class EB_EasyBuildMeta(PythonPackage):
 
     def make_module_extra(self):
         """
-        Set $EB_INSTALLPYTHON to ensure that this EasyBuild installation uses the same Python executable it was installed with (unless overridden by $EB_PYTHON).
+        Set $EB_INSTALLPYTHON to ensure that this EasyBuild installation uses the same Python executable it was
+        installed with (unless overridden by $EB_PYTHON).
         """
         txt = super(EB_EasyBuildMeta, self).make_module_extra()
         txt += self.module_generator.set_environment('EB_INSTALLPYTHON', self.python_cmd)

--- a/easybuild/easyblocks/e/easybuildmeta.py
+++ b/easybuild/easyblocks/e/easybuildmeta.py
@@ -219,10 +219,10 @@ class EB_EasyBuildMeta(PythonPackage):
 
     def make_module_extra(self):
         """
-        Set $EB_PYTHON to ensure that this EasyBuild installation uses the same Python executable it was installed with.
+        Set $EB_INSTALLPYTHON to ensure that this EasyBuild installation uses the same Python executable it was installed with (unless overridden by $EB_PYTHON).
         """
         txt = super(EB_EasyBuildMeta, self).make_module_extra()
-        txt += self.module_generator.set_environment('EB_PYTHON', self.python_cmd)
+        txt += self.module_generator.set_environment('EB_INSTALLPYTHON', self.python_cmd)
         return txt
 
     def make_module_step(self, fake=False):

--- a/easybuild/easyblocks/e/easybuildmeta.py
+++ b/easybuild/easyblocks/e/easybuildmeta.py
@@ -220,7 +220,7 @@ class EB_EasyBuildMeta(PythonPackage):
     def make_module_extra(self):
         """
         Set $EB_INSTALLPYTHON to ensure that this EasyBuild installation uses the same Python executable it was
-        installed with (unless overridden by $EB_PYTHON).
+        installed with (which can still be overridden by the user with $EB_PYTHON).
         """
         txt = super(EB_EasyBuildMeta, self).make_module_extra()
         txt += self.module_generator.set_environment('EB_INSTALLPYTHON', self.python_cmd)


### PR DESCRIPTION
Closes #2078
Requires ~~https://github.com/easybuilders/easybuild-framework/pull/3428~~ (which replaced ~~https://github.com/easybuilders/easybuild-framework/pull/3394~~)