### PR TITLE
ensure stand-alone Python package being installed is in view when running 'pip check' by loading fake module first

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -703,7 +703,17 @@ class PythonPackage(ExtensionEasyBlock):
             pip_version = det_pip_version()
             if pip_version:
                 if LooseVersion(pip_version) >= LooseVersion('9.0.0'):
+
+                    if not self.is_extension:
+                        # for stand-alone Python package installations (not part of a bundle of extensions),
+                        # we need to load the fake module file, otherwise the Python package being installed
+                        # is not "in view", and we will overlook missing dependencies...
+                        fake_mod_data = self.load_fake_module(purge=True)
+
                     run_cmd("pip check", trace=False)
+
+                    if not self.is_extension:
+                        self.clean_up_fake_module(fake_mod_data)
                 else:
                     raise EasyBuildError("pip >= 9.0.0 is required for running 'pip check', found %s", pip_version)
             else:


### PR DESCRIPTION
Not loading the fake module basically renders `pip check` useless, since the dependencies are only being checked for Python packages which are "in view" (through `$PYTHONPATH`).

This bug only affects stand-alone installation of Python packages (using the `PythonPackage` easyblock, or one that derives from it), not sets of Python packages being installed as extensions (either via `PythonBundle`, or as extensions in the `Python` installations or those of other software like GROMACS).

PRs that should get merged when this is merged (to avoid breaking the installations of easyconfigs):

* [ ] `scikit-learn` 0.23.1 (PR https://github.com/easybuilders/easybuild-easyconfigs/pull/11089)
* [ ] `archspec` 0.1.0 on top of Python 3.7.4 (PR https://github.com/easybuilders/easybuild-easyconfigs/pull/11092)
* [ ] `OpenPIV-0.21.8-intel-2019b-Python-3.7.4.eb` (PR https://github.com/easybuilders/easybuild-easyconfigs/pull/11096)
* [ ] `LiBis-20200428-foss-2019b-Python-3.7.4.eb` (PR https://github.com/easybuilders/easybuild-easyconfigs/pull/11095)
* [ ] `TEtranscripts-2.2.0-foss-2020a.eb` (PR https://github.com/easybuilders/easybuild-easyconfigs/pull/11097)
* ~~`Telescope-1.0.3-foss-2019b-Python-3.7.4.eb`~~ (not an issue as long as `intervaltree` extension in included in Python 3.7.4 installation, see #10969)
* *(more coming, maybe...)