### PR TITLE
Make TensorFlow use system/EasyBuild installed libraries

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -182,10 +182,12 @@ def get_system_libs_for_version(tf_version, as_valid_libs=False):
         ('termcolor', '2.1.0:'): 'termcolor_archive',
         ('wrapt', '2.1.0:'): 'wrapt',
     }
-    dependency_mapping = {dep_name: tf_name for (dep_name, version_range), tf_name in available_system_libs.items()
-                          if is_version_ok(version_range)}
-    python_mapping = {pkg_name: tf_name for (pkg_name, version_range), tf_name in python_system_libs.items()
-                      if is_version_ok(version_range)}
+    dependency_mapping = dict((dep_name, tf_name)
+                              for (dep_name, version_range), tf_name in available_system_libs.items()
+                              if is_version_ok(version_range))
+    python_mapping = dict((pkg_name, tf_name)
+                          for (pkg_name, version_range), tf_name in python_system_libs.items()
+                          if is_version_ok(version_range))
 
     if as_valid_libs:
         tf_names = [tf_name for tf_name, version_range in unused_system_libs.items()

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -93,10 +93,10 @@ def get_system_libs_from_tf(source_dir):
     result = []
     if os.path.exists(syslibs_path):
         txt = read_file(syslibs_path)
-        m = re.search(r'VALID_LIBS = \[(.*?)\]', txt, re.DOTALL)
-        if not m:
+        valid_libs_match = re.search(r'VALID_LIBS\s*=\s*\[(.*?)\]', txt, re.DOTALL)
+        if not valid_libs_match:
             raise EasyBuildError('VALID_LIBS definition not found in %s', syslibs_path)
-        result = split_tf_libs_txt(m.group(1))
+        result = split_tf_libs_txt(valid_libs_match.group(1))
     return result
 
 

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -824,10 +824,6 @@ class EB_TensorFlow(PythonPackage):
         ]
         res = super(EB_TensorFlow, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
 
-        # determine top-level directory
-        # start_dir is not set when TensorFlow is installed as an extension, then fall back to ext_dir
-        topdir = self.start_dir or self.ext_dir
-
         # test installation using MNIST tutorial examples
         if self.cfg['runtest']:
             pythonpath = os.getenv('PYTHONPATH', '')
@@ -845,7 +841,7 @@ class EB_TensorFlow(PythonPackage):
             for mnist_py in mnist_pys:
                 datadir = tempfile.mkdtemp(suffix='-tf-%s-data' % os.path.splitext(mnist_py)[0])
                 logdir = tempfile.mkdtemp(suffix='-tf-%s-logs' % os.path.splitext(mnist_py)[0])
-                mnist_py = os.path.join(topdir, 'tensorflow', 'examples', 'tutorials', 'mnist', mnist_py)
+                mnist_py = os.path.join(self.start_dir, 'tensorflow', 'examples', 'tutorials', 'mnist', mnist_py)
                 cmd = "%s %s --data_dir %s --log_dir %s" % (self.python_cmd, mnist_py, datadir, logdir)
                 run_cmd(cmd, log_all=True, simple=True, log_ok=True)
 


### PR DESCRIPTION
TensorFlow allows using already installed libs. This avoids problems with the bundled TF libs (e.g. in 2.3.0) and speeds up the build process.

closes #1996

edit: now requires ~~https://github.com/easybuilders/easybuild-framework/pull/3426~~