### PR TITLE
make sure self.start_dir is set to a full path before constructing installation command in RPackage easyblock

### DIFF
--- a/easybuild/easyblocks/generic/rpackage.py
+++ b/easybuild/easyblocks/generic/rpackage.py
@@ -132,7 +132,10 @@ class RPackage(ExtensionEasyBlock):
         else:
             prefix = ''
 
-        loc = self.start_dir or self.ext_dir or self.ext_src
+        if self.start_dir:
+            loc = os.path.join(self.ext_dir or os.path.sep, self.start_dir)
+        else:
+            loc = self.ext_dir or self.ext_src
 
         cmd = ' '.join([
             self.cfg['preinstallopts'],


### PR DESCRIPTION
currently `start_dir` is not prefixed for RPackage extensions, requiring the full path to be specified.
this is fixed by prepending `start_dir` with `ext_dir`.