### PR TITLE
correctly check whether 'modinc' easyconfig parameter is set to True in CP2K easyblock

### DIFF
--- a/easybuild/easyblocks/c/cp2k.py
+++ b/easybuild/easyblocks/c/cp2k.py
@@ -270,7 +270,7 @@ class EB_CP2K(EasyBlock):
             if isinstance(self.cfg["modinc"], list):
                 modfiles = [os.path.join(modincdir, x) for x in self.cfg["modinc"]]
 
-            elif isinstance(self.cfg["modinc"], bool) and type(self.cfg["modinc"]):
+            elif isinstance(self.cfg["modinc"], bool) and self.cfg["modinc"]:
                 modfiles = glob.glob(os.path.join(modincdir, '*.f90'))
 
             else:


### PR DESCRIPTION
In the current version the result is always `True` now it honors when it is set to `False`

It is possible that this worked though, because IIRC True/False are singletons of their own type so `type(False) == False`