### PR TITLE
Limit travis to only python2.6 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,46 +5,9 @@ env:
   matrix:
     - ENV_MOD_VERSION=3.2.10 EASYBUILD_MODULES_TOOL=EnvironmentModulesC EASYBUILD_MODULE_SYNTAX=Tcl
     - LMOD_VERSION=6.6.3
-    - LMOD_VERSION=6.6.3 EASYBUILD_MODULE_SYNTAX=Tcl
-    - LMOD_VERSION=7.8.5
-    - LMOD_VERSION=7.8.5 EASYBUILD_MODULE_SYNTAX=Tcl
-    # Tmod 4.1.4 is used in RHEL8
-    - ENV_MOD_VERSION=4.1.4 EASYBUILD_MODULES_TOOL=EnvironmentModules EASYBUILD_MODULE_SYNTAX=Tcl
 matrix:
   # mark build as finished as soon as job has failed
   fast_finish: true
-  include:
-    # also test default configuration with Python 2.7
-    - python: 2.7
-      env: LMOD_VERSION=7.8.5
-      dist: xenial
-    # also test with Python 3.6
-    - python: 3.6
-      env: LMOD_VERSION=6.6.3
-      dist: xenial
-    - python: 3.6
-      env: LMOD_VERSION=6.5.1 EASYBUILD_MODULE_SYNTAX=Tcl
-      dist: xenial
-    - python: 3.6
-      env: LMOD_VERSION=7.8.5
-      dist: xenial
-    - python: 3.6
-      env: LMOD_VERSION=7.8.5 EASYBUILD_MODULE_SYNTAX=Tcl
-      dist: xenial
-    - python: 3.6
-      env: ENV_MOD_VERSION=3.2.10 EASYBUILD_MODULES_TOOL=EnvironmentModulesC EASYBUILD_MODULE_SYNTAX=Tcl
-      dist: xenial
-    - python: 3.6
-      env: ENV_MOD_VERSION=4.1.4 EASYBUILD_MODULES_TOOL=EnvironmentModules EASYBUILD_MODULE_SYNTAX=Tcl
-      dist: xenial
-    # also test most common configuration with Python 3.5 and 3.7
-    - python: 3.5
-      env: LMOD_VERSION=7.8.5
-      dist: xenial
-    - python: 3.7
-      dist: xenial
-      env: LMOD_VERSION=7.8.5
-      dist: xenial
 addons:
   apt:
     packages:


### PR DESCRIPTION
And only test a single combination of Lmod and Tmod. All other
combinations are covered by github actions.