### PR TITLE
remove duplicate empty line in tbb easyblock which makes code linter check fail

### DIFF
--- a/easybuild/easyblocks/t/tbb.py
+++ b/easybuild/easyblocks/t/tbb.py
@@ -177,7 +177,6 @@ class EB_tbb(IntelBase, ConfigureMake):
             else:
                 raise EasyBuildError("Failed to isolate location of libraries: %s", cand_lib_paths)
 
-
     def sanity_check_step(self):
         """Custom sanity check for TBB"""
         custom_paths = {


### PR DESCRIPTION
Linter check fails after #2103 was merged (CI approved the PR before we introduced the linter check...)