### PR TITLE
update TensorFlow easyblock to put Bazel build files in build directory + avoid unnecessary runtime patching

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -404,11 +404,13 @@ class EB_TensorFlow(PythonPackage):
 
     def setup_build_dirs(self):
         """Setup temporary build directories"""
-        tmpdir = tempfile.mkdtemp(suffix='-bazel-tf')
+        # Tensorflow/Bazel needs a couple of directories where it stores build cache and artefacts
+        tmpdir = tempfile.mkdtemp(suffix='-bazel-tf', dir=self.builddir)
         self.output_root_dir = os.path.join(tmpdir, 'output_root')
         self.output_base_dir = os.path.join(tmpdir, 'output_base')
         self.output_user_root_dir = os.path.join(tmpdir, 'output_user_root')
         self.wrapper_dir = os.path.join(tmpdir, 'wrapper_bin')
+        # This (likely) needs to be a subdir of output_base
         self.install_base_dir = os.path.join(self.output_base_dir, 'inst_base')
 
     def configure_step(self):

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -788,12 +788,6 @@ class EB_TensorFlow(PythonPackage):
 
     def install_step(self):
         """Custom install procedure for TensorFlow."""
-
-        # avoid that pip (ab)uses $HOME/.cache/pip
-        # cfr. https://pip.pypa.io/en/stable/reference/pip_install/#caching
-        env.setvar('XDG_CACHE_HOME', tempfile.gettempdir())
-        self.log.info("Using %s as pip cache directory", os.environ['XDG_CACHE_HOME'])
-
         # find .whl file that was built, and install it using 'pip install'
         if ("-rc" in self.version):
             whl_version = self.version.replace("-rc", "rc")

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -700,13 +700,14 @@ class EB_TensorFlow(PythonPackage):
             self.patch_crosstool_files()
 
         # compose "bazel build" command with all its options...
-        cmd = [self.cfg['prebuildopts'],
-               'bazel',
-               '--output_base=%s' % self.output_base_dir,
-               '--install_base=%s' % self.install_base_dir,
-               '--output_user_root=%s' % self.output_user_root_dir,
-               'build'
-               ]
+        cmd = [
+            self.cfg['prebuildopts'],
+            'bazel',
+            '--output_base=%s' % self.output_base_dir,
+            '--install_base=%s' % self.install_base_dir,
+            '--output_user_root=%s' % self.output_user_root_dir,
+            'build',
+        ]
 
         # build with optimization enabled
         # cfr. https://docs.bazel.build/versions/master/user-manual.html#flag--compilation_mode


### PR DESCRIPTION
Currently we used /tmp (or better: tempdir as set by EB options) to put bazel build files in. However often users set builddir to some fast storage (e.g. /dev/shm) so using that instead can speed up the build of TensorFlow. This PR solves that and also  unifies some settings of various directories used

Additionally it removes some patches:
- The configure.py patch doesn't apply since 1.12.0: https://github.com/tensorflow/tensorflow/commit/56a99d6c28fd0ff238bd834bd32c2d3fc894b86c As this hasn't caused any issues yet it can be removed. It tried building some TF 2.x and 1.15 versions and no .cache/bazel folder is created
- Also I was told that TF is much more friendly to new toolchains. I hence tested removing our various, extensive patching of CROSSTOOL files with some TF 2.x ECs and it seems to be indeed no longer required. Bazel/TF seem to detect the built-in directories just well, so no need to manually specify them. I don't know when that happened (and am unsure how to find that) so I simply used 2.0 as the cutoff point. We've got 1.13.1 for 2019a, so I could test and use that as well, if wanted. Factoring this out into a separate function greatly simplifies the code making it more readable.