### PR TITLE
unset $COLUMNS if it is set to '0' before running Perl's configure script

### DIFF
--- a/easybuild/easyblocks/p/perl.py
+++ b/easybuild/easyblocks/p/perl.py
@@ -33,6 +33,7 @@ import os
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.config import build_option
+from easybuild.tools.environment import unset_env_vars
 from easybuild.tools.py2vs3 import string_type
 from easybuild.tools.run import run_cmd
 
@@ -90,6 +91,13 @@ class EB_Perl(ConfigureMake):
             configopts.append('-Dsysroot=%s' % sysroot)
 
         configopts = (' '.join(configopts)) % {'installdir': self.installdir}
+
+        # if $COLUMNS is set to 0, 'ls' produces a warning like:
+        #   ls: ignoring invalid width in environment variable COLUMNS: 0
+        # this confuses Perl's Configure script and makes it fail,
+        # so just unset $COLUMNS if it set to 0...
+        if os.getenv('COLUMNS', None) == '0':
+            unset_env_vars(['COLUMNS'])
 
         cmd = './Configure -de %s' % configopts
         run_cmd(cmd, log_all=True, simple=True)


### PR DESCRIPTION
When doing the following:

```shell
export COLUMNS=0; eb Perl-5.30.2-GCCcore-9.3.0.eb
```

`Perl`'s `Configure` script dies with:

```
THIS PACKAGE SEEMS TO BE INCOMPLETE.
```

because `ls` produces a warning:

```
ls: ignoring invalid width in environment variable COLUMNS: 0
```

I'm not sure *why* or how `$COLUMNS` got set to zero (I wasn't doing that myself), but simply undefining it when that's the case fixes the issue...