### PR TITLE
improve workaround for JsonCpp dependency in TensorFlow easyblock

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -367,11 +367,12 @@ class EB_TensorFlow(PythonPackage):
                 if not sw_root:
                     continue
                 incpath = os.path.join(sw_root, 'include')
-                if dep_name == 'JsonCpp':
-                    # Need to use the install prefix instead: https://github.com/tensorflow/tensorflow/issues/42303
-                    incpath = sw_root
                 if os.path.exists(incpath):
                     cpaths.append(incpath)
+                    if dep_name == 'JsonCpp' and LooseVersion(self.version) < LooseVersion('2.3'):
+                        # Need to add the install prefix or patch the sources:
+                        # https://github.com/tensorflow/tensorflow/issues/42303
+                        cpaths.append(sw_root)
                     if dep_name == 'protobuf':
                         # Need to set INCLUDEDIR as TF wants to symlink headers from there:
                         # https://github.com/tensorflow/tensorflow/issues/37835


### PR DESCRIPTION
The TensorFlow sources include the json sources as "include/json/..." which is unusual
As a workaround the root folder to JsonCpp is added to CPATH.
However for fixed versions this is not required and the include folder should be added instead.
A patch for 2.3 exists and will be part of all future releases. 2.3+ ECs should hence rather use the patch instead.
To avoid having to change existing ECs not using the patch but allow them to use the patch both folders are added.