### PR TITLE
Workaround duplicate prefix path in Eigen CMake config

### DIFF
--- a/easybuild/easyblocks/e/eigen.py
+++ b/easybuild/easyblocks/e/eigen.py
@@ -22,7 +22,7 @@ import shutil
 from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
-from easybuild.tools.filetools import copy_dir, copy_file, mkdir
+from easybuild.tools.filetools import copy_dir, copy_file, mkdir, apply_regex_substitutions
 
 
 class EB_Eigen(CMakeMake):
@@ -30,20 +30,19 @@ class EB_Eigen(CMakeMake):
     Support for building Eigen.
     """
 
-    @staticmethod
-    def extra_options():
-        extra_vars = CMakeMake.extra_options()
-        extra_vars['separate_build_dir'][0] = True
-        return extra_vars
-
     def configure_step(self):
         """Custom configuration procedure for Eigen."""
         # start using CMake for Eigen 3.3.4 and newer versions
-        # not done for older versions, since this implies using CMake as a build dependency,
-        # which is a bit strange for a header-only library like Eigen...
+        # not done for older versions, since this implies using CMake as a build dependency
         if LooseVersion(self.version) >= LooseVersion('3.3.4'):
-            # avoid that include files are installed into include/eigen3/Eigen, should be include/Eigen
-            self.cfg.update('configopts', "-DINCLUDE_INSTALL_DIR=%s" % os.path.join(self.installdir, 'include'))
+            # Install headers as include/Eigen/*.h instead of the default include/eigen3/Eigen/*.h to make it easier
+            # for dependencies to find the headers without setting anything in addition
+            # Note: Path must be relative to the install prefix!
+            self.cfg.update('configopts', "-DINCLUDE_INSTALL_DIR=%s" % 'include')
+            # Patch to make the relative path actually work.
+            regex_subs = [('CACHE PATH "The directory relative to CMAKE_PREFIX_PATH',
+                           'CACHE STRING "The directory relative to CMAKE_PREFIX_PATH')]
+            apply_regex_substitutions(os.path.join(self.cfg['start_dir'], 'CMakeLists.txt'), regex_subs)
             CMakeMake.configure_step(self)
 
     def build_step(self):
@@ -86,14 +85,20 @@ class EB_Eigen(CMakeMake):
             'files': ['include/Eigen/%s' % x for x in include_files],
             'dirs': []
         }
+        custom_commands = []
 
         if LooseVersion(self.version) >= LooseVersion('3.0'):
             custom_paths['files'].append('include/signature_of_eigen3_matrix_library')
 
         if LooseVersion(self.version) >= LooseVersion('3.3.4'):
-            custom_paths['files'].append('share/pkgconfig/eigen3.pc')
+            custom_paths['files'].append(os.path.join('share', 'pkgconfig', 'eigen3.pc'))
+            cmake_config_dir = os.path.join('share', 'eigen3', 'cmake')
+            custom_paths['files'].append(os.path.join(cmake_config_dir, 'Eigen3Config.cmake'))
+            # Check that CMake config files don't contain duplicated prefix
+            custom_commands.append("! grep -q -r '${PACKAGE_PREFIX_DIR}/${PACKAGE_PREFIX_DIR}' %s"
+                                   % os.path.join(self.installdir, cmake_config_dir))
 
-        super(EB_Eigen, self).sanity_check_step(custom_paths=custom_paths)
+        super(EB_Eigen, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
 
     def make_module_req_guess(self):
         """


### PR DESCRIPTION
The current EasyBlock causes a duplicate (install) prefix paths in the CMake files leading to /foo/Eigen/foo/Eigen/include as the paths causing dependencies to choke on that, also mostly minor as we have the full/correct path in CPATH

See https://gitlab.com/libeigen/eigen/-/issues/1990