### PR TITLE
Enable CTEST_OUTPUT_ON_FAILURE for CMake test_step

### DIFF
--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -242,3 +242,9 @@ class CMakeMake(ConfigureMake):
         (out, _) = run_cmd(command, log_all=True, simple=False)
 
         return out
+
+    def test_step(self):
+        """CMake specific test setup"""
+        # When using ctest for tests (default) then show verbose output if a test fails
+        setvar('CTEST_OUTPUT_ON_FAILURE', 'True')
+        super(CMakeMake, self).test_step()


### PR DESCRIPTION
This allows to see the output of failing tests which might help finding the issue

While being at it: I'd like to provide an easy/easier way to run tests when building with CMake. It really bothers me that we don't test by default with configuremake based ECs (including meson, cmake, ...)

When using CMake the default setting to use is `-DBUILD_TESTING=ON`, although many projects already set it as default, which enables building the tests. Then you can do `make test` for makefile generators. Or more generically `ctest --build-config <cfg>`
So I'm thinking if there should be an option which enables the flag and the test or if a set `runtest` should automatically add the flag. I think using the `ctest` command would required adding `build_type` to iteratable options but that would be a good idea anyway