### PR TITLE
Set LD_LIBRARY_PATH to PyTorch lib folder

### DIFF
--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -241,4 +241,6 @@ class EB_PyTorch(PythonPackage):
 
         guesses = super(EB_PyTorch, self).make_module_req_guess()
         guesses['CMAKE_PREFIX_PATH'] = [os.path.join(self.pylibdir, 'torch')]
+        # Required to dynamically load libcaffe2_nvrtc.so
+        guesses['LD_LIBRARY_PATH'] = [os.path.join(self.pylibdir, 'torch', 'lib')]
         return guesses


### PR DESCRIPTION
This is the replacement for what was in previous ECs: `postinstallcmds = ['cp -a %(builddir)s/%(namelower)s-%(version)s/torch/lib*/* %(installdir)s/lib/']` and fixes issues with loading `libcaffe2_nvrtc.so` which is loaded via `dlopen` from PyTorch.

Reproducible with `python -c "import ctypes; ctypes.CDLL('libcaffe2_nvrtc.so')"` although that is not what is the "official" way. That seems to be JIT compiling some code for CUDA kernels for which I couldn't find how to specifically do that. In case someone knows how to do that that would be good to add to the test cases.

Setting the LD_LIBRARY_PATH is also what Pytorch itself does in at least one of its CI tests