### PR TITLE
Make OpenBLAS respect the parallelism set by easybuild

### DIFF
--- a/easybuild/easyblocks/o/openblas.py
+++ b/easybuild/easyblocks/o/openblas.py
@@ -27,6 +27,7 @@ class EB_OpenBLAS(ConfigureMake):
             'FC': os.getenv('FC'),
             'USE_OPENMP': '1',
             'USE_THREAD': '1',
+            'MAKE_NB_JOBS': '-1',  # Disable internal parallelism to let EB choose
         }
 
         if '%s=' % TARGET in self.cfg['buildopts']:


### PR DESCRIPTION
OpenBLAS builds in parallel by default using all cores it finds. Passing `MAKE_NB_JOBS=-1` makes it respect `make -j<n>`