### PR TITLE
enhance OpenFOAM easyblock to add symlinks for libraries to ensure 'mpi' versions have preference over 'dummy' versions

### DIFF
--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -331,7 +331,7 @@ class EB_OpenFOAM(EasyBlock):
             run_cmd(cmd_tmpl % cmd, log_all=True, simple=True, log_output=True)
 
     def det_psubdir(self):
-        """Determine the installtion directory for OpenFOAM libraries."""
+        """Determine the platform-specific installation directory for OpenFOAM."""
         # OpenFOAM >= 3.0.0 can use 64 bit integers
         # same goes for OpenFOAM-Extend >= 4.1
         if 'extend' in self.name.lower():

--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -373,7 +373,8 @@ class EB_OpenFOAM(EasyBlock):
             adjust_permissions(fullpath, stat.S_IROTH, add=True, recursive=True, ignore_errors=True)
             adjust_permissions(fullpath, stat.S_IXOTH, add=True, recursive=True, onlydirs=True, ignore_errors=True)
 
-        # create symlinks in lib directory to libraries in mpi subdirectory
+        # create symlinks in the lib directory to all libraries in the mpi subdirectory
+        # to make sure they take precedence over the libraries in the dummy subdirectory
         shlib_ext = get_shared_lib_ext()
         psubdir = self.det_psubdir()
         openfoam_extend_v3 = 'extend' in self.name.lower() and self.looseversion >= LooseVersion('3.0')
@@ -382,12 +383,10 @@ class EB_OpenFOAM(EasyBlock):
         else:
             libdir = os.path.join(self.installdir, self.openfoamdir, "platforms", psubdir, "lib")
         mpilibsdir = os.path.join(libdir, "mpi")
-        print(mpilibsdir)
         if os.path.exists(mpilibsdir):
             for lib in glob.glob(os.path.join(mpilibsdir, "*.%s" % shlib_ext)):
                 libname = os.path.basename(lib)
                 dst = os.path.join(libdir, libname)
-                print(lib, os.path.join("mpi", libname))
                 os.symlink(os.path.join("mpi", libname), dst)
 
     def sanity_check_step(self):


### PR DESCRIPTION
Some OpenFOAM tools, e.g. `snappyHexMesh` have MPI issues when RPATH is being used, because `platforms/linux64GccDPInt32Opt/lib/mpi` is not added to RPATH, while `platforms/linux64GccDPInt32Opt/lib` and `platforms/linux64GccDPInt32Opt/lib/dummy` are. This will make some tools pick up, for instance, `libPstream.so` from `lib/dummy`, while they should use the one from `lib/mpi`. The result is that they will not run with the `-parallel` flag, i.e. that they don't support MPI.

Spack seems to solve this issue by making symlinks in `lib` to all libraries in `lib/mpi`. Since `lib` takes precedence over `dummy` in the RPATH, the affected tools will then pick up the correct libraries (with MPI support).
This PR adds similar functionality to the `install_step`.

I've (only) tested this with `OpenFOAM/8-foss-2020a`, and it seems to work well for that version.

Also see: https://github.com/EESSI/software-layer/issues/24
and: https://github.com/easybuilders/easybuild-easyblocks/issues/1193