### PR TITLE
leverage installed OpenSSL/BoringSSL when cURL is used as a dependency for TensorFlow

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -359,6 +359,10 @@ class EB_TensorFlow(PythonPackage):
         for dep_name, tf_name in sorted(dependency_mapping.items(), key=lambda i: i[0].lower()):
             if dep_name in dep_names:
                 system_libs.append(tf_name)
+                # When using cURL (which uses the system OpenSSL), we also need to use "boringssl"
+                # which essentially resolves to using OpenSSL as the API and library names are compatible
+                if dep_name == 'cURL':
+                    system_libs.append('boringssl')
                 # For protobuf we need protobuf and protobuf-python where the latter depends on the former
                 # For includes etc. we need to get the values from protobuf
                 if dep_name == 'protobuf-python':


### PR DESCRIPTION
When using EB provided cURL but NOT using EB/system provided boringssl then TensorFlow will build and use an own version of BoringSSL which causes symbol name conflicts with the OpenSSL used by cURL ultimately leading to crashes. See https://github.com/tensorflow/tensorflow/issues/43878 for details.

As the "system boringssl" simply links `-lssl -lcrypto` we can simply tell TF to use the system "boringssl" which is in fact the system OpenSSL, so all checks out.

Validated via `eb TensorFlow-2.3.1-fosscuda-2019b-Python-3.7.4.eb --rebuild --installpath /tmp/ebinstall --disable-cleanup-tmpdir --disable-cleanup-builddir -r` and then `grep -r X509_VERIFY_PARAM_set_flags $EASYBUILD_BUILDPATH` which shows only a few hits but no files of BoringSSL. Before this PR there are sources from BoringSSL.

Example code to trigger this and stacktrace/core dump (needs an additional package `pip install --user tensorflow_datasets`):

```
import tensorflow_datasets as tfds

builder = tfds.builder('stanford_dogs')
builder.download_and_prepare()
```

**Stack trace**
```
*** Error in `python': free(): invalid pointer: 0x00000000046bfd08 ***
======= Backtrace: =========
/lib64/libc.so.6(+0x81299)[0x7f2b1dba9299]
<prefix>/lib/python3.7/site-packages/tensorflow/python/../libtensorflow_framework.so.2(ASN1_STRING_free+0x35)[0x7f2aac3d0205]
<prefix>/lib/python3.7/site-packages/tensorflow/python/../libtensorflow_framework.so.2(ASN1_primitive_free+0xbd)[0x7f2aac3d371d]
<prefix>/lib/python3.7/site-packages/tensorflow/python/../libtensorflow_framework.so.2(ASN1_template_free+0x8f)[0x7f2aac3d3b1f]
<prefix>/lib/python3.7/site-packages/tensorflow/python/../libtensorflow_framework.so.2(asn1_item_combine_free+0x2a0)[0x7f2aac3d39f0]
<prefix>/lib/python3.7/site-packages/tensorflow/python/../libtensorflow_framework.so.2(ASN1_item_free+0x17)[0x7f2aac3d3a77]
<prefix>/lib/libcurl.so.4(+0x57a20)[0x7f2aaae7ea20]
<prefix>/lib/libcurl.so.4(+0x593fb)[0x7f2aaae803fb]
<prefix>/lib/libcurl.so.4(+0x59fd7)[0x7f2aaae80fd7]
<prefix>/lib/libcurl.so.4(+0x110e2)[0x7f2aaae380e2]
<prefix>/lib/libcurl.so.4(+0x30215)[0x7f2aaae57215]
<prefix>/lib/libcurl.so.4(curl_multi_perform+0x83)[0x7f2aaae58473]
<prefix>/lib/libcurl.so.4(curl_easy_perform+0x11b)[0x7f2aaae50a6b]
<prefix>/lib/python3.7/site-packages/tensorflow/python/_pywrap_tensorflow_internal.so(_ZN10tensorflow15CurlHttpRequest4SendEv+0x2b9)[0x7f2ac88c34f9]
```