### PR TITLE
fix two bugs in GROMACS easyblock when using GCC & MKL for FFT and BLAS/LAPACK

### DIFF
--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -329,7 +329,7 @@ class EB_GROMACS(CMakeMake):
             if get_software_root('imkl'):
                 # using MKL for FFT, so it will also be used for BLAS/LAPACK
                 self.cfg.update('configopts', '-DGMX_FFT_LIBRARY=mkl -DMKL_INCLUDE_DIR="%s" ' %
-                    os.path.join(os.getenv('MKLROOT'), 'include'))
+                                os.path.join(os.getenv('MKLROOT'), 'include'))
                 libs = os.getenv('LAPACK_STATIC_LIBS').split(',')
                 mkl_libs = [os.path.join(os.getenv('LAPACK_LIB_DIR'), lib) for lib in libs if lib != 'libgfortran.a']
                 mkl_libs = ['-Wl,--start-group'] + mkl_libs + ['-Wl,--end-group -lpthread -lm -ldl']

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -328,10 +328,11 @@ class EB_GROMACS(CMakeMake):
 
             if get_software_root('imkl'):
                 # using MKL for FFT, so it will also be used for BLAS/LAPACK
-                self.cfg.update('configopts', '-DGMX_FFT_LIBRARY=mkl -DMKL_INCLUDE_DIR="$EBROOTMKL/mkl/include" ')
+                self.cfg.update('configopts', '-DGMX_FFT_LIBRARY=mkl -DMKL_INCLUDE_DIR="%s" ' %
+                    os.path.join(os.getenv('MKLROOT'), 'include'))
                 libs = os.getenv('LAPACK_STATIC_LIBS').split(',')
                 mkl_libs = [os.path.join(os.getenv('LAPACK_LIB_DIR'), lib) for lib in libs if lib != 'libgfortran.a']
-                mkl_libs = ['-Wl,--start-group'] + mkl_libs + ['-Wl,--end-group']
+                mkl_libs = ['-Wl,--start-group'] + mkl_libs + ['-Wl,--end-group -lpthread -lm -ldl']
                 self.cfg.update('configopts', '-DMKL_LIBRARIES="%s" ' % ';'.join(mkl_libs))
             else:
                 for libname in ['BLAS', 'LAPACK']:

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -326,10 +326,11 @@ class EB_GROMACS(CMakeMake):
             else:
                 self.cfg.update('configopts', "-DGMX_OPENMP=OFF")
 
-            if get_software_root('imkl'):
+            imkl_root = get_software_root('imkl')
+            if imkl_root:
                 # using MKL for FFT, so it will also be used for BLAS/LAPACK
-                self.cfg.update('configopts', '-DGMX_FFT_LIBRARY=mkl -DMKL_INCLUDE_DIR="%s" ' %
-                                os.path.join(os.getenv('MKLROOT'), 'include'))
+                imkl_include = os.path.join(imkl_root, 'mkl', 'include')
+                self.cfg.update('configopts', '-DGMX_FFT_LIBRARY=mkl -DMKL_INCLUDE_DIR="%s" ' % imkl_include)
                 libs = os.getenv('LAPACK_STATIC_LIBS').split(',')
                 mkl_libs = [os.path.join(os.getenv('LAPACK_LIB_DIR'), lib) for lib in libs if lib != 'libgfortran.a']
                 mkl_libs = ['-Wl,--start-group'] + mkl_libs + ['-Wl,--end-group -lpthread -lm -ldl']


### PR DESCRIPTION
First change eliminates the (wrong) variable `$EBROOTMKL` from the easyblock as per discussion of @boegel and @mboisson on EasyBuild Slack.

Secondly GROMACS 2020.4' cmake was refusing to use MKL as FFT library (using the `gomkl-2020a` toolchain), which was fixed by appending `-lpthread -lm -ldl` to `-DMKL_LIBRARIES`.