### PR TITLE
enhance extension filter for Python packages to ignore user site dir when for checking Python package extensions

### DIFF
--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -53,7 +53,7 @@ from easybuild.tools.systemtools import get_shared_lib_ext
 import easybuild.tools.toolchain as toolchain
 
 
-EXTS_FILTER_PYTHON_PACKAGES = ('python -c "import %(ext_name)s"', "")
+EXTS_FILTER_PYTHON_PACKAGES = ('PYTHONNOUSERSITE=1 python -c "import %(ext_name)s"', "")
 
 # magic value for unlimited stack size
 UNLIMITED = 'unlimited'


### PR DESCRIPTION
The `EXTS_FILTER_PYTHON_PACKAGES` is used as the default for checking whether to skip installing an extension. Now it excludes the user site dir and hence does not wrongly skip installing a package when it is present in the user folder.