### PR TITLE
fix hardcoded path in NVHPC easyblock to support multiple architectures

### DIFF
--- a/easybuild/easyblocks/n/nvhpc.py
+++ b/easybuild/easyblocks/n/nvhpc.py
@@ -91,6 +91,10 @@ class EB_NVHPC(PackedBinary):
         """Easyblock constructor, define custom class variables specific to NVHPC."""
         super(EB_NVHPC, self).__init__(*args, **kwargs)
 
+        # Ideally we should be using something like `easybuild.tools.systemtools.get_cpu_architecture` here, however,
+        # on `ppc64le` systems this function returns `POWER` instead of `ppc64le`. Since this path needs to reflect
+        # `arch` (https://easybuild.readthedocs.io/en/latest/version-specific/easyconfig_templates.html) the same
+        # procedure from `templates.py` was reused here:
         architecture = 'Linux_%s' % platform.uname()[4]
         self.nvhpc_install_subdir = os.path.join(architecture, self.version)
 

--- a/easybuild/easyblocks/n/nvhpc.py
+++ b/easybuild/easyblocks/n/nvhpc.py
@@ -38,6 +38,7 @@ import fileinput
 import re
 import stat
 import sys
+import platform
 
 from easybuild.easyblocks.generic.packedbinary import PackedBinary
 from easybuild.framework.easyconfig import CUSTOM
@@ -90,8 +91,8 @@ class EB_NVHPC(PackedBinary):
         """Easyblock constructor, define custom class variables specific to NVHPC."""
         super(EB_NVHPC, self).__init__(*args, **kwargs)
 
-        # Potential improvement: get "Linux_x86_64" from easybuild.tools.systemtools' get_cpu_architecture()
-        self.nvhpc_install_subdir = os.path.join('Linux_x86_64', self.version)
+        architecture = 'Linux_%s' % platform.uname()[4]
+        self.nvhpc_install_subdir = os.path.join(architecture, self.version)
 
     def install_step(self):
         """Install by running install command."""


### PR DESCRIPTION
The `nvhpc.py` file contained one hardcoded path which hindered it from
working on multiple architectures.