### PR TITLE
added support for preinstallopts and installopts to the ncl easyblock

### DIFF
--- a/easybuild/easyblocks/n/ncl.py
+++ b/easybuild/easyblocks/n/ncl.py
@@ -224,7 +224,7 @@ class EB_NCL(EasyBlock):
     def install_step(self):
         """Build in install dir using build_step."""
 
-        cmd = "make Everything"
+        cmd = "%s make Everything %s" % (self.cfg['preinstallopts'], self.cfg['installopts'])
         run_cmd(cmd, log_all=True, simple=True)
 
     def sanity_check_step(self):


### PR DESCRIPTION
This is needed for us because I need to pass CPATH for our installation of freetype in Gentoo. 