### PR TITLE
Check SciPy test results

### DIFF
--- a/easybuild/easyblocks/s/scipy.py
+++ b/easybuild/easyblocks/s/scipy.py
@@ -46,7 +46,17 @@ class EB_scipy(FortranPythonPackage):
         super(EB_scipy, self).__init__(*args, **kwargs)
 
         self.testinstall = True
-        self.testcmd = "cd .. && %(python)s -c 'import numpy; import scipy; scipy.test(verbose=2)'"
+        if LooseVersion(self.version) >= LooseVersion('1.0'):
+            # SciPy 1.0+ returns a True on success. Hence invert to get a failure value
+            test_code = 'sys.exit(not scipy.test(verbose=2))'
+        else:
+            # Return value is a TextTestResult. Check the errors member for any error
+            test_code = 'sys.exit(len(scipy.test(verbose=2).errors) > 0)'
+        # Prepend imports
+        test_code = "import sys; import scipy; " + test_code
+        # LDFLAGS should not be set when testing numpy/scipy, because it overwrites whatever numpy/scipy sets
+        # see http://projects.scipy.org/numpy/ticket/182
+        self.testcmd = "unset LDFLAGS && cd .. && %%(python)s -c '%s'" % test_code
 
     def configure_step(self):
         """Custom configure step for scipy: set extra installation options when needed."""


### PR DESCRIPTION
Similar to #2238 but for SciPy

Supersedes #1744

Note: With SciPy-bundle-2019.03-foss-2019a.eb I get a failure due to a precision issue -.- Same with the 2019b

Those are very small failures, e.g. `-0.00077271310043404 !=          -0.000772713100434114  (rdiff          9.569216326469691e-14)` or `"Arrays are not almost equal to 5 decimals" ... Max absolute difference: 1.5497208e-05`

This is an AMD and Intel CPUs (x86)