### PR TITLE
Append module guesses for some modules

### DIFF
--- a/easybuild/easyblocks/c/chapel.py
+++ b/easybuild/easyblocks/c/chapel.py
@@ -55,7 +55,11 @@ class EB_Chapel(ConfigureMake):
         """
         A dictionary of possible directories to look for; this is needed since bin/linux64 of chapel is non standard
         """
-        return {
+        guesses = super(EB_Chapel, self).make_module_req_guess()
+        lib_paths = ['lib', 'lib/linux64', 'lib64']
+        guesses.update({
             'PATH': ['bin', 'bin/linux64', 'bin64'],
-            'LD_LIBRARY_PATH': ['lib', 'lib/linux64', 'lib64'],
-        }
+            'LD_LIBRARY_PATH': lib_paths,
+            'LIBRARY_PATH': lib_paths,
+        })
+        return guesses

--- a/easybuild/easyblocks/i/icc.py
+++ b/easybuild/easyblocks/i/icc.py
@@ -147,10 +147,12 @@ class EB_icc(IntelBase):
         """
         prefix = None
 
+        guesses = super(EB_icc, self).make_module_req_guess()
+
         # guesses per environment variables
         # some of these paths only apply to certain versions, but that doesn't really matter
         # existence of paths is checked by module generator before 'prepend-paths' statements are included
-        guesses = {
+        guesses.update({
             'CLASSPATH': ['daal/lib/daal.jar'],
             # 'include' is deliberately omitted, including it causes problems, e.g. with complex.h and std::complex
             # cfr. https://software.intel.com/en-us/forums/intel-c-compiler/topic/338378
@@ -161,7 +163,7 @@ class EB_icc(IntelBase):
             'MANPATH': ['debugger/gdb/intel64/share/man', 'man/common', 'man/en_US', 'share/man'],
             'PATH': [],
             'TBBROOT': ['tbb'],
-        }
+        })
 
         if self.cfg['m32']:
             # 32-bit toolchain

--- a/easybuild/easyblocks/i/imkl.py
+++ b/easybuild/easyblocks/i/imkl.py
@@ -141,44 +141,44 @@ class EB_imkl(IntelBase):
         """
         A dictionary of possible directories to look for
         """
+        guesses = super(EB_imkl, self).make_module_req_guess()
+
         if LooseVersion(self.version) >= LooseVersion('10.3'):
             if self.cfg['m32']:
                 raise EasyBuildError("32-bit not supported yet for IMKL v%s (>= 10.3)", self.version)
             else:
-                retdict = {
+                guesses.update({
                     'PATH': [],
                     'LD_LIBRARY_PATH': ['lib/intel64', 'mkl/lib/intel64'],
                     'LIBRARY_PATH': ['lib/intel64', 'mkl/lib/intel64'],
                     'MANPATH': ['man', 'man/en_US'],
                     'CPATH': ['mkl/include', 'mkl/include/fftw'],
                     'PKG_CONFIG_PATH': ['mkl/bin/pkgconfig'],
-                }
+                })
                 if LooseVersion(self.version) >= LooseVersion('11.0'):
                     if LooseVersion(self.version) >= LooseVersion('11.3'):
-                        retdict['MIC_LD_LIBRARY_PATH'] = ['lib/intel64_lin_mic', 'mkl/lib/mic']
+                        guesses['MIC_LD_LIBRARY_PATH'] = ['lib/intel64_lin_mic', 'mkl/lib/mic']
                     elif LooseVersion(self.version) >= LooseVersion('11.1'):
-                        retdict['MIC_LD_LIBRARY_PATH'] = ['lib/mic', 'mkl/lib/mic']
+                        guesses['MIC_LD_LIBRARY_PATH'] = ['lib/mic', 'mkl/lib/mic']
                     else:
-                        retdict['MIC_LD_LIBRARY_PATH'] = ['compiler/lib/mic', 'mkl/lib/mic']
-                return retdict
+                        guesses['MIC_LD_LIBRARY_PATH'] = ['compiler/lib/mic', 'mkl/lib/mic']
         else:
             if self.cfg['m32']:
-                return {
+                guesses.update({
                     'PATH': ['bin', 'bin/ia32', 'tbb/bin/ia32'],
                     'LD_LIBRARY_PATH': ['lib', 'lib/32'],
                     'LIBRARY_PATH': ['lib', 'lib/32'],
                     'MANPATH': ['man', 'share/man', 'man/en_US'],
-                    'CPATH': ['include'],
-                }
+                })
 
             else:
-                return {
+                guesses.update({
                     'PATH': ['bin', 'bin/intel64', 'tbb/bin/em64t'],
                     'LD_LIBRARY_PATH': ['lib', 'lib/em64t'],
                     'LIBRARY_PATH': ['lib', 'lib/em64t'],
                     'MANPATH': ['man', 'share/man', 'man/en_US'],
-                    'CPATH': ['include'],
-                }
+                })
+        return guesses
 
     def make_module_extra(self):
         """Overwritten from Application to add extra txt"""

--- a/easybuild/easyblocks/i/impi.py
+++ b/easybuild/easyblocks/i/impi.py
@@ -245,19 +245,16 @@ EULA=accept
         """
         A dictionary of possible directories to look for
         """
+        guesses = super(EB_impi, self).make_module_req_guess()
         if self.cfg['m32']:
             lib_dirs = ['lib', 'lib/ia32', 'ia32/lib']
-            include_dirs = ['include']
-            return {
+            guesses.update({
                 'PATH': ['bin', 'bin/ia32', 'ia32/bin'],
                 'LD_LIBRARY_PATH': lib_dirs,
                 'LIBRARY_PATH': lib_dirs,
-                'MANPATH': ['man'],
-                'CPATH': include_dirs,
                 'MIC_LD_LIBRARY_PATH': ['mic/lib'],
-            }
+            })
         else:
-            guesses = {}
             if LooseVersion(self.version) >= LooseVersion('2019'):
                 # The "release" library is default in v2019. Give it precedence over intel64/lib.
                 # (remember paths are *prepended*, so the last path in the list has highest priority)
@@ -282,7 +279,7 @@ EULA=accept
                 'CPATH': include_dirs,
             })
 
-            return guesses
+        return guesses
 
     def make_module_extra(self, *args, **kwargs):
         """Overwritten from Application to add extra txt"""


### PR DESCRIPTION
Currently the base EasyBlock guesses are ignored leading to missing CMAKE_PREFIX_PATH and similar.
This should make it more robust as the defaults are included.