### PR TITLE
fix setting of $RUNPARALLEL in h5py easyblock

### DIFF
--- a/easybuild/easyblocks/h/hdf5.py
+++ b/easybuild/easyblocks/h/hdf5.py
@@ -95,7 +95,7 @@ class EB_HDF5(ConfigureMake):
 
         # set RUNPARALLEL if MPI is enabled in this toolchain
         if self.toolchain.options.get('usempi', None):
-            env.setvar('RUNPARALLEL', r'mpirun -np \$\${NPROCS:=2}')
+            env.setvar('RUNPARALLEL', r'mpirun -np $${NPROCS:=3}')
 
         super(EB_HDF5, self).configure_step()
 


### PR DESCRIPTION
 - the MPI tests require at least 3 mpi tasks
 - the old \\$\\${NPROC... caused errors when expanding RUNPARALLEL