### PR TITLE
add support for ignoring numpy test result

### DIFF
--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -68,23 +68,6 @@ class EB_numpy(FortranPythonPackage):
         self.sitecfgfn = 'site.cfg'
         self.testinstall = True
 
-        if self.cfg['ignore_test_result']:
-            test_code = 'numpy.test(verbose=2)'
-        else:
-            if LooseVersion(self.version) >= LooseVersion('1.15'):
-                # Numpy 1.15+ returns a True on success. Hence invert to get a failure value
-                test_code = 'sys.exit(not numpy.test(verbose=2))'
-            else:
-                # Return value is a TextTestResult. Check the errors member for any error
-                test_code = 'sys.exit(len(numpy.test(verbose=2).errors) > 0)'
-
-        # Prepend imports
-        test_code = "import sys; import numpy; " + test_code
-
-        # LDFLAGS should not be set when testing numpy/scipy, because it overwrites whatever numpy/scipy sets
-        # see http://projects.scipy.org/numpy/ticket/182
-        self.testcmd = "unset LDFLAGS && cd .. && %%(python)s -c '%s'" % test_code
-
     def configure_step(self):
         """Configure numpy build by composing site.cfg contents."""
 
@@ -231,6 +214,26 @@ class EB_numpy(FortranPythonPackage):
 
     def test_step(self):
         """Run available numpy unit tests, and more."""
+
+        # determine command to use to run numpy test suite,
+        # and whether test results should be ignored or not
+        if self.cfg['ignore_test_result']:
+            test_code = 'numpy.test(verbose=2)'
+        else:
+            if LooseVersion(self.version) >= LooseVersion('1.15'):
+                # Numpy 1.15+ returns a True on success. Hence invert to get a failure value
+                test_code = 'sys.exit(not numpy.test(verbose=2))'
+            else:
+                # Return value is a TextTestResult. Check the errors member for any error
+                test_code = 'sys.exit(len(numpy.test(verbose=2).errors) > 0)'
+
+        # Prepend imports
+        test_code = "import sys; import numpy; " + test_code
+
+        # LDFLAGS should not be set when testing numpy/scipy, because it overwrites whatever numpy/scipy sets
+        # see http://projects.scipy.org/numpy/ticket/182
+        self.testcmd = "unset LDFLAGS && cd .. && %%(python)s -c '%s'" % test_code
+
         super(EB_numpy, self).test_step()
 
         # temporarily install numpy, it doesn't alow to be used straight from the source dir

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -56,6 +56,7 @@ class EB_numpy(FortranPythonPackage):
         """Easyconfig parameters specific to numpy."""
         extra_vars = ({
             'blas_test_time_limit': [500, "Time limit (in ms) for 1000x1000 matrix dot product BLAS test", CUSTOM],
+            'ignore_test_result': [False, "Run numpy test suite, but ignore test result (only log)", CUSTOM],
         })
         return FortranPythonPackage.extra_options(extra_vars=extra_vars)
 
@@ -66,14 +67,20 @@ class EB_numpy(FortranPythonPackage):
         self.sitecfg = None
         self.sitecfgfn = 'site.cfg'
         self.testinstall = True
-        if LooseVersion(self.version) >= LooseVersion('1.15'):
-            # Numpy 1.15+ returns a True on success. Hence invert to get a failure value
-            test_code = 'sys.exit(not numpy.test(verbose=2))'
+
+        if self.cfg['ignore_test_result']:
+            test_code = 'numpy.test(verbose=2)'
         else:
-            # Return value is a TextTestResult. Check the errors member for any error
-            test_code = 'sys.exit(len(numpy.test(verbose=2).errors) > 0)'
+            if LooseVersion(self.version) >= LooseVersion('1.15'):
+                # Numpy 1.15+ returns a True on success. Hence invert to get a failure value
+                test_code = 'sys.exit(not numpy.test(verbose=2))'
+            else:
+                # Return value is a TextTestResult. Check the errors member for any error
+                test_code = 'sys.exit(len(numpy.test(verbose=2).errors) > 0)'
+
         # Prepend imports
         test_code = "import sys; import numpy; " + test_code
+
         # LDFLAGS should not be set when testing numpy/scipy, because it overwrites whatever numpy/scipy sets
         # see http://projects.scipy.org/numpy/ticket/182
         self.testcmd = "unset LDFLAGS && cd .. && %%(python)s -c '%s'" % test_code


### PR DESCRIPTION
The changes made in #2238 make the numpy easyblock trip over failing tests (rightfully so), which wasn't the case before.

A handful of `numpy` tests are failing in specific circumstances (like on an AMD Rome system when using `intel/2020a`, see https://github.com/easybuilders/easybuild-easyconfigs/issues/11836) which are likely going to be (very) difficult to fix (in this specific case, we're probably hitting a bug in `imkl` 2020 update 1).

The changes made here make it possible to opt-in to ignoring failing numpy test results (via a hook, for example), such that the installation can actually be completed.