### PR TITLE
prefer default value for extra options in easyblock tests

### DIFF
--- a/test/easyblocks/init_easyblocks.py
+++ b/test/easyblocks/init_easyblocks.py
@@ -151,11 +151,16 @@ def template_init_test(self, easyblock, name='foo', version='1.3.2'):
         extra_options = app_class.extra_options()
         check_extra_options_format(extra_options)
 
-        # extend easyconfig to make sure mandatory custom easyconfig paramters are defined
+        # extend easyconfig to make sure mandatory custom easyconfig parameters are defined
         extra_txt = ''
         for (key, val) in extra_options.items():
             if val[2] == MANDATORY:
-                extra_txt += '%s = "foo"\n' % key
+                # use default value if any is set, otherwise use "foo"
+                if val[0]:
+                    test_param = val[0]
+                else:
+                    test_param = 'foo'
+                extra_txt += '%s = "%s"\n' % (key, test_param)
 
         # write easyconfig file
         self.writeEC(ebname, name=name, version=version, extratxt=extra_txt)


### PR DESCRIPTION
Use the default value for mandatory extra options which have one and fallback to `foo` only if if the default is not set (`None`, `False` or empty).

This allows having extra options with a limited number of valid options and check for those. Raising an error if the provided option is not one of the allowed values.

For instance, as it is done for `queue_cmd` in the relion easyblock (PR #2274 ) at https://github.com/easybuilders/easybuild-easyblocks/blob/59a50773183dc7b6d4579833d4bd7018af5d4c5a/easybuild/easyblocks/r/relion.py#L53