### PR TITLE
guard 'module unload' statements in modules for Cray* toolchains

### DIFF
--- a/easybuild/easyblocks/generic/craytoolchain.py
+++ b/easybuild/easyblocks/generic/craytoolchain.py
@@ -76,7 +76,9 @@ class CrayToolchain(Bundle):
         # unload statements for other PrgEnv modules
         prgenv_unloads = ['']
         for prgenv in [prgenv for prgenv in KNOWN_PRGENVS if not prgenv_mod.startswith(prgenv)]:
-            prgenv_unloads.append(self.module_generator.unload_module(prgenv).strip())
+            is_loaded_guard = self.module_generator.is_loaded(prgenv)
+            unload_stmt = self.module_generator.unload_module(prgenv).strip()
+            prgenv_unloads.append(self.module_generator.conditional_statement(is_loaded_guard, unload_stmt))
 
         # load statement for selected PrgEnv module (only when not loaded yet)
         prgenv_load = self.module_generator.load_module(prgenv_mod, recursive_unload=False)


### PR DESCRIPTION
Some module tools trigger an error when unloading modules for which the corresponding module file does not exist, so it's better to guard the `module unload` statements.

This results in the following change in the generated module file (using [CrayCCE-20.08.eb](https://github.com/eth-cscs/production/blob/master/easybuild/easyconfigs/c/CrayCCE/CrayCCE-20.08.eb)):

```diff
$ diff -u modules/all/CrayCCE/20.08.old modules/all/CrayCCE/20.08
--- modules/all/CrayCCE/20.08.old	2020-12-16 22:11:08.332746000 +0100
+++ modules/all/CrayCCE/20.08	2020-12-16 22:11:21.817132000 +0100
@@ -24,9 +24,18 @@

 conflict CrayCCE

-module unload PrgEnv-gnu
-module unload PrgEnv-intel
-module unload PrgEnv-pgi
+if { [ is-loaded PrgEnv-gnu ] } {
+    module unload PrgEnv-gnu
+}
+
+if { [ is-loaded PrgEnv-intel ] } {
+    module unload PrgEnv-intel
+}
+
+if { [ is-loaded PrgEnv-pgi ] } {
+    module unload PrgEnv-pgi
+}
+

 if { ![ is-loaded PrgEnv-cray ] } {
     module load PrgEnv-cray

fixes #2283