### PR TITLE
rework module-only tests to use unique software name (rather than 'foo')

### DIFF
--- a/easybuild/easyblocks/generic/modulerc.py
+++ b/easybuild/easyblocks/generic/modulerc.py
@@ -108,6 +108,8 @@ class ModuleRC(EasyBlock):
                     else:
                         raise EasyBuildError("%s exists but is not a symlink to %s", modulerc_symlink, modulerc)
                 else:
+                    # Make sure folder exists
+                    mkdir(os.path.dirname(modulerc_symlink), parents=True)
                     symlink(modulerc, modulerc_symlink)
                     print_msg("created symlink %s to .modulerc file at %s", modulerc_symlink, modulerc, log=self.log)
 


### PR DESCRIPTION
I experienced a test failure of morthur finding artefacts from Bazel easyblock
This is caused by the test modules all having the same name so
a) Tests are incomplete as they may simply assert things fulfilled by
   previous subtests
b) Tests may wrongly fail as previous tests may add unexpected
   files/folders which are picked up by the next tests

Solution: Use unique names and workaround some limitations discovered by that