### PR TITLE
Nwchem test step

### DIFF
--- a/easybuild/easyblocks/n/nwchem.py
+++ b/easybuild/easyblocks/n/nwchem.py
@@ -409,7 +409,7 @@ class EB_NWChem(ConfigureMake):
         """
         Simply test that we can execute the binary - this fails sometimes with PMI errors
         """
-        cmd = os.path.join(self.builddir, 'bin/nwchem')
+        cmd = os.path.join(self.builddir, 'nwchem-%s/bin/LINUX64/nwchem' % self.version)
         (out, _) = run_cmd(cmd, log_all=True, simple=False)
         return out
 

--- a/easybuild/easyblocks/n/nwchem.py
+++ b/easybuild/easyblocks/n/nwchem.py
@@ -405,6 +405,14 @@ class EB_NWChem(ConfigureMake):
 
         super(EB_NWChem, self).cleanup_step()
 
+    def test_step(self):
+        """
+        Simply test that we can execute the binary - this fails sometimes with PMI errors
+        """
+        cmd = os.path.join(self.builddir, 'bin/nwchem')
+        (out, _) = run_cmd(cmd, log_all=True, simple=False)
+        return out
+
     def test_cases_step(self):
         """Run provided list of test cases, or provided examples is no test cases were specified."""
 


### PR DESCRIPTION
NWChem currently does all its testing after installing the software and writing the module. The problem here is that the module is available for people to use, even if there's something very wrong with it.

This PR introduces a simple test to just execute the binary before installing it.

A failure now looks like:
```
== 2020-12-17 11:54:24,620 build_log.py:260 INFO testing...
== 2020-12-17 11:54:24,620 easyblock.py:2842 INFO Starting test step
== 2020-12-17 11:54:24,621 easyblock.py:2848 INFO Running method test_step part of step test
== 2020-12-17 11:54:24,622 run.py:219 INFO running cmd: /dev/shm/build-edmondac-admin/edmondac-admin-2019b/NWChem/7.0.0/intel-2019b-Python-3.7.4/nwchem-7.0.0/bin/LINUX64/nwchem 
== 2020-12-17 11:54:25,601 build_log.py:164 ERROR EasyBuild crashed with an error (at easybuild/2019b/src/easybuild-framework/easybuild/base/exceptions.py:124 in __init__): cmd "/dev/shm/build-edmondac-admin/edmondac-admin-2019b/NWChem/7.0.0/intel-2019b-Python-3.7.4/nwchem-7.0.0/bin/LINUX64/nwchem" exited with exit code 1 and output:
Abort(1091087) on node 0 (rank 0 in comm 0): Fatal error in PMPI_Init: Other MPI error, error stack:
MPIR_Init_thread(136): 
MPID_Init(709).......: 
MPIR_pmi_init(143)...: PMI2_Job_GetId returned 14
```