### PR TITLE
add support for skipping steps in Python packages installed as extension + print progress on individual steps for installing Python packages as extensions

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -43,13 +43,14 @@ from easybuild.base import fancylogger
 from easybuild.easyblocks.python import EBPYTHONPREFIXES, EXTS_FILTER_PYTHON_PACKAGES
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
-from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.build_log import EasyBuildError, print_msg
 from easybuild.tools.config import build_option
 from easybuild.tools.filetools import mkdir, remove_dir, which
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.py2vs3 import string_type
 from easybuild.tools.run import run_cmd
 from easybuild.tools.utilities import nub
+from easybuild.tools.hooks import CONFIGURE_STEP, BUILD_STEP, TEST_STEP, INSTALL_STEP
 
 
 # not 'easy_install' deliberately, to avoid that pkg installations listed in easy-install.pth get preference
@@ -655,10 +656,26 @@ class PythonPackage(ExtensionEasyBlock):
         super(PythonPackage, self).run(*args, **kwargs)
 
         # configure, build, test, install
-        self.configure_step()
-        self.build_step()
-        self.test_step()
-        self.install_step()
+        # See EasyBlock.get_steps
+        steps = [
+            (CONFIGURE_STEP, 'configuring', [lambda x: x.configure_step], True),
+            (BUILD_STEP, 'building', [lambda x: x.build_step], True),
+            (TEST_STEP, 'testing', [lambda x: x.test_step], True),
+            (INSTALL_STEP, "installing", [lambda x: x.install_step], True),
+        ]
+        self.skip = False  # --skip does not apply here
+        self.silent = build_option('silent')
+        # See EasyBlock.run_all_steps
+        for (step_name, descr, step_methods, skippable) in steps:
+            if self._skip_step(step_name, skippable):
+                print_msg("\t%s [skipped]" % descr, log=self.log, silent=self.silent)
+            else:
+                if self.dry_run:
+                    self.dry_run_msg("\t%s... [DRY RUN]\n", descr)
+                else:
+                    print_msg("\t%s..." % descr, log=self.log, silent=self.silent)
+                    for step_method in step_methods:
+                        step_method(self)()
 
     def load_module(self, *args, **kwargs):
         """

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -667,7 +667,7 @@ class PythonPackage(ExtensionEasyBlock):
         self.silent = build_option('silent')
         # See EasyBlock.run_all_steps
         for (step_name, descr, step_methods, skippable) in steps:
-            if self._skip_step(step_name, skippable):
+            if self.skip_step(step_name, skippable):
                 print_msg("\t%s [skipped]" % descr, log=self.log, silent=self.silent)
             else:
                 if self.dry_run:


### PR DESCRIPTION
(~~requires https://github.com/easybuilders/easybuild-framework/pull/3561~~)

Follow-up to https://github.com/easybuilders/easybuild-framework/pull/3524: Currently the test_step is not skipped for PythonPackages in extensions, e.g. TensorFlow for which https://github.com/easybuilders/easybuild-framework/pull/3524 was intended.
This reuses the `skip_step` machinery from EasyBlock including the status output, which might be useful for things like TensorFlow which have build and test steps taking longer, although this gets quite verbose.

Idea: Don't print a newline, so we have "configuring... building... testing... installing..." there. Maybe we can use `\r` to replace the line altogether?

Example output: 

```
== fetching files...
== creating build dir, resetting environment...
== unpacking...
== patching...
== preparing...
== configuring...
== building...
== testing...
== installing...
== taking care of extensions...
== installing extension Markdown 3.3.3 (1/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension pyasn1-modules 0.2.8 (2/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension rsa 4.6 (3/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension cachetools 4.2.0 (4/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension google-auth 1.24.0 (5/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension oauthlib 3.1.0 (6/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension requests-oauthlib 1.3.0 (7/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension google-auth-oauthlib 0.4.2 (8/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension Werkzeug 1.0.1 (9/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension absl-py 0.11.0 (10/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension astunparse 1.6.3 (11/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension grpcio 1.32.0 (12/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension tensorboard-plugin-wit 1.7.0 (13/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension tensorboard 2.4.0 (14/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension google-pasta 0.2.0 (15/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension termcolor 1.1.0 (16/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension tensorflow-estimator 2.4.0 (17/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension gast 0.3.3 (18/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension opt-einsum 3.3.0 (19/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension wrapt 1.12.1 (20/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension Keras-Preprocessing 1.1.2 (21/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension dill 0.3.3 (22/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension tblib 1.7.0 (23/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension portpicker 1.3.1 (24/25)...
== 	configuring...
== 	building...
== 	testing...
== 	installing...
== installing extension TensorFlow 2.4.0 (25/25)...
== 	configuring...
== 	building...

```