### PR TITLE
add custom easyblock to support installation of new Intel compilers (v2021.x, oneAPI)

### DIFF
--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -90,6 +90,9 @@ class Bundle(EasyBlock):
 
             comp_cfg = self.cfg.copy()
 
+            comp_cfg['name'] = comp_name
+            comp_cfg['version'] = comp_version
+
             easyblock = comp_specs.get('easyblock') or self.cfg['default_easyblock']
             if easyblock is None:
                 raise EasyBuildError("No easyblock specified for component %s v%s", comp_cfg['name'],
@@ -103,8 +106,6 @@ class Bundle(EasyBlock):
             extra_opts = comp_cfg.easyblock.extra_options()
             comp_cfg.extend_params(copy.deepcopy(extra_opts))
 
-            comp_cfg['name'] = comp_name
-            comp_cfg['version'] = comp_version
             comp_cfg.generate_template_values()
 
             # do not inherit easyblock to use from parent (since that would result in an infinite loop in install_step)

--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -414,7 +414,8 @@ class IntelBase(EasyBlock):
         Actual installation for versions 2021.x onwards.
         """
         # require that EULA is accepted
-        self.check_accepted_eula()
+        intel_eula_url = 'https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html'
+        self.check_accepted_eula(name='Intel-oneAPI', more_info=intel_eula_url)
 
         # exactly one "source" file is expected: the (offline) installation script
         if len(self.src) == 1:

--- a/easybuild/easyblocks/i/intel_compilers.py
+++ b/easybuild/easyblocks/i/intel_compilers.py
@@ -31,7 +31,7 @@ import os
 from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.intelbase import IntelBase
-from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.build_log import EasyBuildError, print_msg
 
 
 class EB_intel_minus_compilers(IntelBase):
@@ -76,6 +76,19 @@ class EB_intel_minus_compilers(IntelBase):
             # Fortran Compiler & Fortran Compiler Classic
             'intel.oneapi.lin.ifort-compiler',
         ]
+
+    def install_step(self):
+        """
+        Install step: install each 'source file' one by one.
+        To install a patch release of Intel oneAPI compilers, we need to install the HPC Toolkit first,
+        and then separate updates for the C++ and Fortran compilers...
+        """
+        srcs = self.src[:]
+        cnt = len(srcs)
+        for idx, src in enumerate(srcs):
+            print_msg("installing part %d/%s (%s)..." % (idx + 1, cnt, src['name']))
+            self.src = [src]
+            super(EB_intel_minus_compilers, self).install_step()
 
     def sanity_check_step(self):
         """

--- a/easybuild/easyblocks/i/intel_compilers.py
+++ b/easybuild/easyblocks/i/intel_compilers.py
@@ -1,0 +1,124 @@
+# #
+# Copyright 2021-2021 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+# #
+"""
+EasyBuild support for installing Intel compilers, implemented as an easyblock
+
+@author: Kenneth Hoste (Ghent University)
+"""
+import os
+from distutils.version import LooseVersion
+
+from easybuild.easyblocks.generic.intelbase import IntelBase
+from easybuild.tools.build_log import EasyBuildError
+
+
+class EB_intel_minus_compilers(IntelBase):
+    """
+    Support for installing Intel compilers, starting with verion 2021.x (oneAPI)
+    """
+
+    def __init__(self, *args, **kwargs):
+        """
+        Easyblock constructor: check version
+        """
+        super(EB_intel_minus_compilers, self).__init__(*args, **kwargs)
+
+        # this easyblock is only valid for recent versions of the Intel compilers (2021.x, oneAPI)
+        if LooseVersion(self.version) < LooseVersion('2021'):
+            raise EasyBuildError("Invalid version %s, should be >= 2021.x" % self.version)
+
+        self.compilers_subdir = os.path.join('compiler', 'latest', 'linux')
+
+    def prepare_step(self, *args, **kwargs):
+        """
+        Prepare environment for installing.
+
+        Specify that oneAPI versions of Intel compilers don't require a runtime license.
+        """
+        # avoid that IntelBase trips over not having license info specified
+        kwargs['requires_runtime_license'] = False
+
+        super(EB_intel_minus_compilers, self).prepare_step(*args, **kwargs)
+
+    def configure_step(self):
+        """Configure installation: specify components to install."""
+
+        # redefine $HOME, to avoid that anything is stored in $HOME/intel (like the 'installercache' database)
+        os.environ['HOME'] = self.builddir
+
+        # see output of "<script> -a --list-components"
+        self.install_components = [
+            # oneAPI DPC++/C++ Compiler & C++ Compiler Classic
+            'intel.oneapi.lin.dpcpp-cpp-compiler-pro',
+            # Fortran Compiler & Fortran Compiler Classic
+            'intel.oneapi.lin.ifort-compiler',
+        ]
+
+    def sanity_check_step(self):
+        """
+        Custom sanity check for Intel compilers.
+        """
+
+        classic_compiler_cmds = ['icc', 'icpc', 'ifort']
+        oneapi_compiler_cmds = [
+            'dpcpp',  # Intel oneAPI Data Parallel C++ compiler
+            'icx',  # oneAPI Intel C compiler
+            'icpx',  # oneAPI Intel C++ compiler
+            'ifx',  # oneAPI Intel Fortran compiler
+        ]
+        bindir = os.path.join(self.compilers_subdir, 'bin')
+        classic_compiler_paths = [os.path.join(bindir, x) for x in oneapi_compiler_cmds]
+        oneapi_compiler_paths = [os.path.join(bindir, 'intel64', x) for x in classic_compiler_cmds]
+
+        custom_paths = {
+            'files': classic_compiler_paths + oneapi_compiler_paths,
+            'dirs': [self.compilers_subdir],
+        }
+
+        custom_commands = ["which %s" % c for c in classic_compiler_cmds + oneapi_compiler_cmds]
+        custom_commands.extend("%s --version" % c for c in classic_compiler_cmds + oneapi_compiler_cmds)
+
+        super(EB_intel_minus_compilers, self).sanity_check_step(custom_paths=custom_paths,
+                                                                custom_commands=custom_commands)
+
+    def make_module_req_guess(self):
+        """
+        Paths to consider for prepend-paths statements in module file
+        """
+        libdirs = [
+            'lib',
+            os.path.join('lib', 'x64'),
+            os.path.join('compiler', 'lib', 'intel64_lin'),
+        ]
+        libdirs = [os.path.join(self.compilers_subdir, x) for x in libdirs]
+        guesses = {
+            'PATH': [
+                os.path.join(self.compilers_subdir, 'bin'),
+                os.path.join(self.compilers_subdir, 'bin', 'intel64'),
+            ],
+            'LD_LIBRARY_PATH': libdirs,
+            'LIBRARY_PATH': libdirs,
+        }
+        return guesses

--- a/easybuild/easyblocks/i/intel_compilers.py
+++ b/easybuild/easyblocks/i/intel_compilers.py
@@ -72,8 +72,8 @@ class EB_intel_minus_compilers(IntelBase):
     def install_step(self):
         """
         Install step: install each 'source file' one by one.
-        To install a patch release of Intel oneAPI compilers, we need to install the HPC Toolkit first,
-        and then separate updates for the C++ and Fortran compilers...
+        Installing the Intel compilers could be done via a single installation file (HPC Toolkit),
+        or with separate installation files (patch releases of the C++ and Fortran compilers).
         """
         srcs = self.src[:]
         cnt = len(srcs)

--- a/easybuild/easyblocks/i/intel_compilers.py
+++ b/easybuild/easyblocks/i/intel_compilers.py
@@ -63,19 +63,11 @@ class EB_intel_minus_compilers(IntelBase):
         super(EB_intel_minus_compilers, self).prepare_step(*args, **kwargs)
 
     def configure_step(self):
-        """Configure installation: specify components to install."""
+        """Configure installation."""
 
         # redefine $HOME for install step, to avoid that anything is stored in $HOME/intel
         # (like the 'installercache' database)
         self.cfg['preinstallopts'] += " HOME=%s " % self.builddir
-
-        # see output of "<script> -a --list-components"
-        self.install_components = [
-            # oneAPI DPC++/C++ Compiler & C++ Compiler Classic
-            'intel.oneapi.lin.dpcpp-cpp-compiler-pro',
-            # Fortran Compiler & Fortran Compiler Classic
-            'intel.oneapi.lin.ifort-compiler',
-        ]
 
     def install_step(self):
         """

--- a/easybuild/easyblocks/i/intel_compilers.py
+++ b/easybuild/easyblocks/i/intel_compilers.py
@@ -111,8 +111,9 @@ class EB_intel_minus_compilers(IntelBase):
             'dirs': [self.compilers_subdir],
         }
 
-        custom_commands = ["which %s" % c for c in classic_compiler_cmds + oneapi_compiler_cmds]
-        custom_commands.extend("%s --version" % c for c in classic_compiler_cmds + oneapi_compiler_cmds)
+        all_compiler_cmds = classic_compiler_cmds + oneapi_compiler_cmds
+        custom_commands = ["which %s" % c for c in all_compiler_cmds]
+        custom_commands.extend("%s --version | grep %s" % (c, self.version) for c in all_compiler_cmds)
 
         super(EB_intel_minus_compilers, self).sanity_check_step(custom_paths=custom_paths,
                                                                 custom_commands=custom_commands)

--- a/easybuild/easyblocks/i/intel_compilers.py
+++ b/easybuild/easyblocks/i/intel_compilers.py
@@ -49,7 +49,7 @@ class EB_intel_minus_compilers(IntelBase):
         if LooseVersion(self.version) < LooseVersion('2021'):
             raise EasyBuildError("Invalid version %s, should be >= 2021.x" % self.version)
 
-        self.compilers_subdir = os.path.join('compiler', 'latest', 'linux')
+        self.compilers_subdir = os.path.join('compiler', self.version, 'linux')
 
     def prepare_step(self, *args, **kwargs):
         """

--- a/test/easyblocks/init_easyblocks.py
+++ b/test/easyblocks/init_easyblocks.py
@@ -212,6 +212,9 @@ def suite():
         elif os.path.basename(easyblock) == 'systemmpi.py':
             # use OpenMPI as name when testing SystemMPI easyblock
             innertest = make_inner_test(easyblock, name='OpenMPI', version='system')
+        elif os.path.basename(easyblock) == 'intel_compilers.py':
+            # custom easyblock for intel-compilers (oneAPI) requires v2021.x or newer
+            innertest = make_inner_test(easyblock, name='intel-compilers', version='2021.1')
         else:
             innertest = make_inner_test(easyblock)
 

--- a/test/easyblocks/module.py
+++ b/test/easyblocks/module.py
@@ -396,6 +396,9 @@ def suite():
             # exactly one dependency is included with ModuleRC generic easyblock (and name must match)
             extra_txt = 'dependencies = [("foo", "1.2.3.4.5")]'
             innertest = make_inner_test(easyblock, name='foo', version='1.2.3.4', extra_txt=extra_txt)
+        elif eb_fn == 'intel_compilers.py':
+            # custom easyblock for intel-compilers (oneAPI) requires v2021.x or newer
+            innertest = make_inner_test(easyblock, name='intel-compilers', version='2021.1')
         else:
             # Make up some unique name
             innertest = make_inner_test(easyblock, name=eb_fn.replace('.', '-') + '-sw')


### PR DESCRIPTION
* enhance `IntelBase` to implement installation procedure for 2021.x versions of Intel tools
* add new custom easyblock for `intel-compilers`, to be used with Intel oneAPI HPC Base toolkit v2021 & newer
* + small bug fix in `Bundle` that I hit when working on this

requires
* ~~https://github.com/easybuilders/easybuild-framework/pull/3535~~ (support for `--accept-eula`)
* ~~https://github.com/easybuilders/easybuild-framework/pull/3546~~ to allow using custom name when calling `check_accepted_eula`