### PR TITLE
Fix for building GCC with --sysroot on ppc64le

### DIFF
--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -319,7 +319,7 @@ class EB_GCC(ConfigureMake):
             gcc_config_headers = glob.glob(os.path.join('gcc', 'config', '*', '*linux*.h'))
             regex_subs = [
                 ('(_DYNAMIC_LINKER.*[":])/lib', r'\1%s/lib' % sysroot),
-                ('(DYNAMIC_LINKER_PREFIX\s+) ""', r'\1"%s"' % sysroot),
+                ('(DYNAMIC_LINKER_PREFIX\\s+) ""', r'\1"%s"' % sysroot),
             ]
             for gcc_config_header in gcc_config_headers:
                 apply_regex_substitutions(gcc_config_header, regex_subs)

--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -319,7 +319,7 @@ class EB_GCC(ConfigureMake):
             gcc_config_headers = glob.glob(os.path.join('gcc', 'config', '*', '*linux*.h'))
             regex_subs = [
                 ('(_DYNAMIC_LINKER.*[":])/lib', r'\1%s/lib' % sysroot),
-                ('(DYNAMIC_LINKER_PREFIX\\s+) ""', r'\1"%s"' % sysroot),
+                ('(DYNAMIC_LINKER_PREFIX\\s+)""', r'\1"%s"' % sysroot),
             ]
             for gcc_config_header in gcc_config_headers:
                 apply_regex_substitutions(gcc_config_header, regex_subs)

--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -315,8 +315,12 @@ class EB_GCC(ConfigureMake):
             # prefix dynamic linkers with sysroot
             # this patches lines like:
             # #define GLIBC_DYNAMIC_LINKER64 "/lib64/ld-linux-x86-64.so.2"
+            # for PowerPC (rs6000) we have to set DYNAMIC_LINKER_PREFIX to sysroot
             gcc_config_headers = glob.glob(os.path.join('gcc', 'config', '*', '*linux*.h'))
-            regex_subs = [('(_DYNAMIC_LINKER.*[":])/lib', r'\1%s/lib' % sysroot)]
+            regex_subs = [
+                ('(_DYNAMIC_LINKER.*[":])/lib', r'\1%s/lib' % sysroot),
+                ('(DYNAMIC_LINKER_PREFIX\s+) ""', r'\1"%s"' % sysroot),
+            ]
             for gcc_config_header in gcc_config_headers:
                 apply_regex_substitutions(gcc_config_header, regex_subs)
 


### PR DESCRIPTION
When using `--sysroot` (and  `--rpath`) on `ppc64le` (and possibly more PowerPC systems), the dynamic linker does not get injected into executables correctly: it will pick up the one from the host, instead of the one from the `sysroot` location.

I ran into the same issue when building Gentoo Prefix on a `ppc64le` system, see:
https://bugs.gentoo.org/755551

The proposed fix there solved that issue, see here for an extensive description of the cause and solution:
https://755551.bugs.gentoo.org/attachment.cgi?id=684058

So I'm now including a similar fix here.