### PR TITLE
Added support for OpenFOAM v2012 layout

### DIFF
--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -392,16 +392,16 @@ class EB_OpenFOAM(EasyBlock):
 
         # OpenFOAM v2012 puts mpi into eb-mpi
         if self.looseversion >= LooseVersion("2012"):
-            mpidir = "eb-mpi"
+            mpilibssubdir = "eb-mpi"
         else:
-            mpidir = "mpi"
-        mpilibsdir = os.path.join(libdir, mpidir)
+            mpilibssubdir = "mpi"
+        mpilibsdir = os.path.join(libdir, mpilibssubdir)
 
         if os.path.exists(mpilibsdir):
             for lib in glob.glob(os.path.join(mpilibsdir, "*.%s" % shlib_ext)):
                 libname = os.path.basename(lib)
                 dst = os.path.join(libdir, libname)
-                os.symlink(os.path.join(mpidir, libname), dst)
+                os.symlink(os.path.join(mpilibssubdir, libname), dst)
 
     def sanity_check_step(self):
         """Custom sanity check for OpenFOAM"""
@@ -447,13 +447,13 @@ class EB_OpenFOAM(EasyBlock):
         else:
             # OpenFOAM v2012 puts mpi into eb-mpi
             if self.looseversion >= LooseVersion("2012"):
-                mpidir = "eb-mpi"
+                mpilibssubdir = "eb-mpi"
             else:
-                mpidir = "mpi"
+                mpilibssubdir = "mpi"
 
             # there must be a dummy one and an mpi one for both
-            libs = [os.path.join(libsdir, x, "libPstream.%s" % shlib_ext) for x in ["dummy", mpidir]] + \
-                   [os.path.join(libsdir, x, "libptscotchDecomp.%s" % shlib_ext) for x in ["dummy", mpidir]] +\
+            libs = [os.path.join(libsdir, x, "libPstream.%s" % shlib_ext) for x in ["dummy", mpilibssubdir]] + \
+                   [os.path.join(libsdir, x, "libptscotchDecomp.%s" % shlib_ext) for x in ["dummy", mpilibssubdir]] +\
                    [os.path.join(libsdir, "libscotchDecomp.%s" % shlib_ext)] + \
                    [os.path.join(libsdir, "dummy", "libscotchDecomp.%s" % shlib_ext)]
 

--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -389,12 +389,19 @@ class EB_OpenFOAM(EasyBlock):
             libdir = os.path.join(self.installdir, self.openfoamdir, "lib", psubdir)
         else:
             libdir = os.path.join(self.installdir, self.openfoamdir, "platforms", psubdir, "lib")
-        mpilibsdir = os.path.join(libdir, "mpi")
+
+        # OpenFOAM v2012 puts mpi into eb-mpi
+        if self.looseversion >= LooseVersion("2012"):
+            mpidir = "eb-mpi"
+        else:
+            mpidir = "mpi"
+        mpilibsdir = os.path.join(libdir, mpidir)
+
         if os.path.exists(mpilibsdir):
             for lib in glob.glob(os.path.join(mpilibsdir, "*.%s" % shlib_ext)):
                 libname = os.path.basename(lib)
                 dst = os.path.join(libdir, libname)
-                os.symlink(os.path.join("mpi", libname), dst)
+                os.symlink(os.path.join(mpidir, libname), dst)
 
     def sanity_check_step(self):
         """Custom sanity check for OpenFOAM"""
@@ -438,9 +445,15 @@ class EB_OpenFOAM(EasyBlock):
             else:
                 libs.extend([os.path.join(libsdir, "libparMetisDecomp.%s" % shlib_ext)])
         else:
+            # OpenFOAM v2012 puts mpi into eb-mpi
+            if self.looseversion >= LooseVersion("2012"):
+                mpidir = "eb-mpi"
+            else:
+                mpidir = "mpi"
+
             # there must be a dummy one and an mpi one for both
-            libs = [os.path.join(libsdir, x, "libPstream.%s" % shlib_ext) for x in ["dummy", "mpi"]] + \
-                   [os.path.join(libsdir, x, "libptscotchDecomp.%s" % shlib_ext) for x in ["dummy", "mpi"]] +\
+            libs = [os.path.join(libsdir, x, "libPstream.%s" % shlib_ext) for x in ["dummy", mpidir]] + \
+                   [os.path.join(libsdir, x, "libptscotchDecomp.%s" % shlib_ext) for x in ["dummy", mpidir]] +\
                    [os.path.join(libsdir, "libscotchDecomp.%s" % shlib_ext)] + \
                    [os.path.join(libsdir, "dummy", "libscotchDecomp.%s" % shlib_ext)]
 


### PR DESCRIPTION
This patch resolves sanity check error with new OpenFOAM v2012 layout proposed in pr #11876. 

Mpi related libraries are located in platform/..../eb-mpi rather than in platform/..../mpi.