### PR TITLE
pass down compilation flags from build environment for ESMF

### DIFF
--- a/easybuild/easyblocks/e/esmf.py
+++ b/easybuild/easyblocks/e/esmf.py
@@ -60,6 +60,10 @@ class EB_ESMF(ConfigureMake):
             compiler = comp_family.lower()
         env.setvar('ESMF_COMPILER', compiler)
 
+        if self.toolchain.options.get('optarch'):
+            env.setvar('ESMF_F90COMPILEOPTS', os.getenv('F90FLAGS'))
+            env.setvar('ESMF_CXXCOMPILEOPTS', os.getenv('CXXFLAGS'))
+
         # specify MPI communications library
         comm = None
         mpi_family = self.toolchain.mpi_family()

--- a/easybuild/easyblocks/e/esmf.py
+++ b/easybuild/easyblocks/e/esmf.py
@@ -60,9 +60,8 @@ class EB_ESMF(ConfigureMake):
             compiler = comp_family.lower()
         env.setvar('ESMF_COMPILER', compiler)
 
-        if self.toolchain.options.get('optarch'):
-            env.setvar('ESMF_F90COMPILEOPTS', os.getenv('F90FLAGS'))
-            env.setvar('ESMF_CXXCOMPILEOPTS', os.getenv('CXXFLAGS'))
+        env.setvar('ESMF_F90COMPILEOPTS', os.getenv('F90FLAGS'))
+        env.setvar('ESMF_CXXCOMPILEOPTS', os.getenv('CXXFLAGS'))
 
         # specify MPI communications library
         comm = None


### PR DESCRIPTION
The build of ESMF uses its own set of flags and mostly ignores the standard flags in the environment. This PR passes the flags from EB to the build of ESMF if `optarch` is set in `toolchainopts`.

Building ESMF with EB flags vastly improves the number of tests that pass (`make unit_tests`):
* current `develop`: Found 3478 non-exhaustive multi-processor unit tests, 285 passed and 3193 failed
* this PR: Found 3478 non-exhaustive multi-processor unit tests, 3209 passed and 269 failed.

Update: after further tests, the improvements seem to boil down to having a proper `optarch`
* setting `ESMF_F90COMPILEOPTS=-O2 -ftree-vectorize -fno-math-errno -fPIC` results in 229 passed and 3249 failed unit tests
* setting `ESMF_F90COMPILEOPTS=-O2 -ftree-vectorize -march=native -fno-math-errno -fPIC` results in 3209 passed and 269 failed unit tests