### PR TITLE
Add support for including PTX code in PyTorch

### DIFF
--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -52,8 +52,8 @@ class EB_PyTorch(PythonPackage):
             'excluded_tests': [{}, 'Mapping of architecture strings to list of tests to be excluded', CUSTOM],
             'custom_opts': [[], 'List of options for the build/install command. Can be used to change the defaults ' +
                                 'set by the PyTorch EasyBlock, for example ["USE_MKLDNN=0"].', CUSTOM],
-            'ptx': ['latest', 'For which compute architectures PTX code should be generated. Can be '
-                              '"first", "latest", None or any PyTorch supported arch, e.g. "3.7"', CUSTOM],
+            'ptx': ['last', 'For which compute architectures PTX code should be generated. Can be '
+                            '"first", "last", None or any PyTorch supported arch, e.g. "3.7"', CUSTOM],
         })
         extra_vars['download_dep_fail'][0] = True
         extra_vars['sanity_pip_check'][0] = True
@@ -196,7 +196,7 @@ class EB_PyTorch(PythonPackage):
                                      'cuda_compute_capabilities easyconfig parameter or via '
                                      '--cuda-compute-capabilities')
             ptx = self.cfg['ptx']
-            if ptx == 'latest':
+            if ptx == 'last':
                 cuda_cc[-1] += '+PTX'
             elif ptx == 'first':
                 cuda_cc[0] += '+PTX'

--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -196,6 +196,7 @@ class EB_PyTorch(PythonPackage):
                                      'cuda_compute_capabilities easyconfig parameter or via '
                                      '--cuda-compute-capabilities')
             ptx = self.cfg['ptx']
+            cuda_cc = cuda_cc[:]  # Don't modify original list
             if ptx == 'last':
                 cuda_cc[-1] += '+PTX'
             elif ptx == 'first':

--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -54,12 +54,6 @@ class EB_PyTorch(PythonPackage):
                                 'set by the PyTorch EasyBlock, for example ["USE_MKLDNN=0"].', CUSTOM],
             'ptx': ['last', 'For which compute architectures PTX code should be generated. Can be '
                             '"first", "last", None or any PyTorch supported arch, e.g. "3.7"', CUSTOM],
-            'cuda_cache_maxsize': [
-                None,
-                'Maximum size of the cache (in bytes) used by CUDA for JIT compilation of PTX code. '
-                'Use "None" to let EasyBuild choose a value or "0" to disable the cache',
-                CUSTOM
-            ],
         })
         extra_vars['download_dep_fail'][0] = True
         extra_vars['sanity_pip_check'][0] = True
@@ -141,17 +135,6 @@ class EB_PyTorch(PythonPackage):
             symlink(os.path.join(cmake_root, 'bin', 'cmake'), os.path.join(cmake_bin_dir, 'cmake3'))
             path = "%s:%s" % (cmake_bin_dir, os.getenv('PATH'))
             env.setvar('PATH', path)
-        if get_software_root('CUDA'):
-            cuda_cache_maxsize = self.cfg['cuda_cache_maxsize']
-            if cuda_cache_maxsize is None:
-                cuda_cache_maxsize = 1 * 1024 * 1024 * 1024  # 1 GB default value
-            if cuda_cache_maxsize == 0:
-                env.setvar('CUDA_CACHE_DISABLE', '1')
-            else:
-                cuda_cache_dir = tempfile.mkdtemp(suffix='-cuda_cache', dir=self.builddir)
-                env.setvar('CUDA_CACHE_DISABLE', '0')
-                env.setvar('CUDA_CACHE_PATH', cuda_cache_dir)
-                env.setvar('CUDA_CACHE_MAXSIZE', str(cuda_cache_maxsize))
 
     def configure_step(self):
         """Custom configure procedure for PyTorch."""

--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -144,7 +144,7 @@ class EB_PyTorch(PythonPackage):
         if get_software_root('CUDA'):
             cuda_cache_maxsize = self.cfg['cuda_cache_maxsize']
             if cuda_cache_maxsize is None:
-                cuda_cache_maxsize = 1 * 1024 * 1024  # 1 GB default value
+                cuda_cache_maxsize = 1 * 1024 * 1024 * 1024  # 1 GB default value
             if cuda_cache_maxsize == 0:
                 env.setvar('CUDA_CACHE_DISABLE', '1')
             else:

--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -53,7 +53,7 @@ class EB_PyTorch(PythonPackage):
             'custom_opts': [[], 'List of options for the build/install command. Can be used to change the defaults ' +
                                 'set by the PyTorch EasyBlock, for example ["USE_MKLDNN=0"].', CUSTOM],
             'ptx': ['latest', 'For which compute architectures PTX code should be generated. Can be '
-                              '"first", "latest", None or any PyTorch supported architecture, e.g. "3.7"', CUSTOM],
+                              '"first", "latest", None or any PyTorch supported arch, e.g. "3.7"', CUSTOM],
         })
         extra_vars['download_dep_fail'][0] = True
         extra_vars['sanity_pip_check'][0] = True
@@ -206,7 +206,10 @@ class EB_PyTorch(PythonPackage):
                 cuda_cc.append(ptx + '+PTX')
 
             self.log.info('Compiling with specified list of CUDA compute capabilities: %s', ', '.join(cuda_cc))
-            options.append('TORCH_CUDA_ARCH_LIST="%s"' % ';'.join(cuda_cc))
+            # This variable is also used at runtime (e.g. for tests) and if it is not set PyTorch will automatically
+            # determine the compute capability of a GPU in the system and use that which may fail tests if
+            # it is to new for the used nvcc
+            env.setvar('TORCH_CUDA_ARCH_LIST', ';'.join(cuda_cc))
         else:
             # Disable CUDA
             options.append('USE_CUDA=0')

--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -151,7 +151,7 @@ class EB_PyTorch(PythonPackage):
                 cuda_cache_dir = tempfile.mkdtemp(suffix='-cuda_cache', dir=self.builddir)
                 env.setvar('CUDA_CACHE_DISABLE', '0')
                 env.setvar('CUDA_CACHE_PATH', cuda_cache_dir)
-                env.setvar('CUDA_CACHE_MAXSIZE', cuda_cache_maxsize)
+                env.setvar('CUDA_CACHE_MAXSIZE', str(cuda_cache_maxsize))
 
     def configure_step(self):
         """Custom configure procedure for PyTorch."""

--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -51,7 +51,9 @@ class EB_PyTorch(PythonPackage):
         extra_vars.update({
             'excluded_tests': [{}, 'Mapping of architecture strings to list of tests to be excluded', CUSTOM],
             'custom_opts': [[], 'List of options for the build/install command. Can be used to change the defaults ' +
-                                'set by the PyTorch EasyBlock, for example ["USE_MKLDNN=0"].', CUSTOM]
+                                'set by the PyTorch EasyBlock, for example ["USE_MKLDNN=0"].', CUSTOM],
+            'ptx': ['latest', 'For which compute architectures PTX code should be generated. Can be '
+                              '"first", "latest", None or any PyTorch supported architecture, e.g. "3.7"', CUSTOM],
         })
         extra_vars['download_dep_fail'][0] = True
         extra_vars['sanity_pip_check'][0] = True
@@ -193,6 +195,16 @@ class EB_PyTorch(PythonPackage):
                 raise EasyBuildError('List of CUDA compute capabilities must be specified, either via '
                                      'cuda_compute_capabilities easyconfig parameter or via '
                                      '--cuda-compute-capabilities')
+            ptx = self.cfg['ptx']
+            if ptx == 'latest':
+                cuda_cc[-1] += '+PTX'
+            elif ptx == 'first':
+                cuda_cc[0] += '+PTX'
+            elif ptx is not None:
+                if ptx in cuda_cc:
+                    cuda_cc.remove(ptx)
+                cuda_cc.append(ptx + '+PTX')
+
             self.log.info('Compiling with specified list of CUDA compute capabilities: %s', ', '.join(cuda_cc))
             options.append('TORCH_CUDA_ARCH_LIST="%s"' % ';'.join(cuda_cc))
         else:


### PR DESCRIPTION
This adds PTX code to PyTorch by default for any newer architecture than the last selected one.
This can be changed by the new EC option "ptx"

- [ ] Discussion about the cuda cache needs resolving (see below)

QUESTION: What about `cuda_cache_size`? It might be better to make this an easybuild option (similar to `--cuda-compute-capabilities`) instead. E.g. for PyTorch the cache seems to be quite large. Running the test `test_cpp_extensions_aot_no_ninja` alone fills up 1GB

Framework PR: https://github.com/easybuilders/easybuild-framework/pull/3569 If that is merged I can remove the option in this EC