### PR TITLE
use 'main' rather than 'master' branch in test suite configuration

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
           # first determine which branch of easybuild-framework repo to install
           BRANCH=develop
-          if [ "x$GITHUB_BASE_REF" = 'xmaster' ]; then BRANCH=master; fi
+          if [ "x$GITHUB_BASE_REF" = 'xmain' ]; then BRANCH=main; fi
           if [ "x$GITHUB_BASE_REF" = 'x4.x' ]; then BRANCH=4.x; fi
           echo "Using easybuild-framework branch $BRANCH (\$GITHUB_BASE_REF $GITHUB_BASE_REF)"
           git clone -b $BRANCH --depth 10 --single-branch https://github.com/easybuilders/easybuild-framework.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ addons:
 install:
     # install easybuild-framework (and dependencies)
     # prefer clone & easy_install over easy_install directly in order to obtain information of what was installed exactly
-    # use framework 'develop' branch, except when testing 'master'
+    # use framework 'develop' branch, except when testing 'main'
     - BRANCH=develop
-    - if [ "x$TRAVIS_BRANCH" = 'xmaster' ]; then BRANCH=master; fi
+    - if [ "x$TRAVIS_BRANCH" = 'xmain' ]; then BRANCH=main; fi
     - if [ "x$TRAVIS_BRANCH" = 'x4.x' ]; then BRANCH=4.x; fi
     - echo "Using easybuild-framework branch $BRANCH (\$TRAVIS_BRANCH $TRAVIS_BRANCH)"
     - git clone -b $BRANCH --depth 10 --single-branch https://github.com/easybuilders/easybuild-framework.git


### PR DESCRIPTION
We're making the necessary changes to rename the `master` branch to `main`.

Currently both are available (and they're identical), but we'll remove `master` as soon as we're done with making the necessary changes.

See also https://github.com/easybuilders/easybuild-framework/pull/3589