### PR TITLE
make OpenCV easyblock aware of protobuf, libwebp and OpenEXR dependencies provided via EasyBuild

### DIFF
--- a/easybuild/easyblocks/o/opencv.py
+++ b/easybuild/easyblocks/o/opencv.py
@@ -116,8 +116,8 @@ class EB_OpenCV(CMakeMake):
                 self.cfg.update('configopts', '-DWITH_CUDA=OFF')
 
         # configure for dependency libraries
-        for dep in ['JasPer', 'libjpeg-turbo', 'libpng', 'LibTIFF', 'zlib']:
-            if dep in ['libpng', 'LibTIFF']:
+        for dep in ['JasPer', 'libjpeg-turbo', 'libpng', 'LibTIFF', 'libwebp', 'OpenEXR', 'zlib']:
+            if dep in ['libpng', 'LibTIFF', 'libwebp']:
                 # strip off 'lib'
                 opt_name = dep[3:].upper()
             elif dep == 'libjpeg-turbo':
@@ -128,6 +128,8 @@ class EB_OpenCV(CMakeMake):
             shlib_ext = get_shared_lib_ext()
             if dep == 'zlib':
                 lib_file = 'libz.%s' % shlib_ext
+            elif dep == 'OpenEXR':
+                lib_file = 'libIex.%s' % shlib_ext
             else:
                 lib_file = 'lib%s.%s' % (opt_name.lower(), shlib_ext)
 

--- a/easybuild/easyblocks/o/opencv.py
+++ b/easybuild/easyblocks/o/opencv.py
@@ -135,16 +135,19 @@ class EB_OpenCV(CMakeMake):
             shlib_ext = get_shared_lib_ext()
             if dep == 'zlib':
                 lib_file = 'libz.%s' % shlib_ext
-            elif dep == 'OpenEXR':
-                lib_file = 'libIex.%s' % shlib_ext
             else:
                 lib_file = 'lib%s.%s' % (opt_name.lower(), shlib_ext)
 
             dep_root = get_software_root(dep)
             if dep_root:
-                self.cfg.update('configopts', '-D%s_INCLUDE_DIR=%s' % (opt_name, os.path.join(dep_root, 'include')))
-                libdir = get_software_libdir(dep, only_one=True)
-                self.cfg.update('configopts', '-D%s_LIBRARY=%s' % (opt_name, os.path.join(dep_root, libdir, lib_file)))
+                if dep == 'OpenEXR':
+                    self.cfg.update('configopts', '-D%s_ROOT=%s' % (opt_name, dep_root))
+                else:
+                    inc_path = os.path.join(dep_root, 'include')
+                    self.cfg.update('configopts', '-D%s_INCLUDE_DIR=%s' % (opt_name, inc_path))
+                    libdir = get_software_libdir(dep, only_one=True)
+                    lib_path = os.path.join(dep_root, libdir, lib_file)
+                    self.cfg.update('configopts', '-D%s_LIBRARY=%s' % (opt_name, lib_path))
 
         # configure optimisation for CPU architecture
         # see https://github.com/opencv/opencv/wiki/CPU-optimizations-build-options

--- a/easybuild/easyblocks/o/opencv.py
+++ b/easybuild/easyblocks/o/opencv.py
@@ -115,6 +115,13 @@ class EB_OpenCV(CMakeMake):
             else:
                 self.cfg.update('configopts', '-DWITH_CUDA=OFF')
 
+        # disable bundled protobuf if it is a dependency
+        if 'BUILD_PROTOBUF' not in self.cfg['configopts']:
+            if get_software_root('protobuf'):
+                self.cfg.update('configopts', '-DBUILD_PROTOBUF=OFF')
+            else:
+                self.cfg.update('configopts', '-DBUILD_PROTOBUF=ON')
+
         # configure for dependency libraries
         for dep in ['JasPer', 'libjpeg-turbo', 'libpng', 'LibTIFF', 'libwebp', 'OpenEXR', 'zlib']:
             if dep in ['libpng', 'LibTIFF', 'libwebp']:


### PR DESCRIPTION
Three changes:
* OpenCV builds its own protobuf, it should only be done if protobuf is not a dependency, otherwise conflicts may arise between the two libraries of protobuf
* Forces OpenCV to use external libwebp if declared as dependency
* Forces OpenCV to use external OpenEXR if declared as dependency