### PR TITLE
make WRF and WPS easyblocks aware of (pre)configopts

### DIFF
--- a/easybuild/easyblocks/w/wps.py
+++ b/easybuild/easyblocks/w/wps.py
@@ -204,7 +204,7 @@ class EB_WPS(EasyBlock):
         # fetch option number based on build type option and selected build type
         build_type_question = r"\s*(?P<nr>[0-9]+).\s*%s\s*\(?%s\)?\s*\n" % (build_type_option, knownbuildtypes[bt])
 
-        cmd = ' '.join([ self.cfg['preconfigopts'],'./configure',self.cfg['configopts']])
+        cmd = ' '.join([self.cfg['preconfigopts'], './configure', self.cfg['configopts']])
         qa = {}
         no_qa = [".*compiler is.*"]
         std_qa = {

--- a/easybuild/easyblocks/w/wps.py
+++ b/easybuild/easyblocks/w/wps.py
@@ -204,7 +204,7 @@ class EB_WPS(EasyBlock):
         # fetch option number based on build type option and selected build type
         build_type_question = r"\s*(?P<nr>[0-9]+).\s*%s\s*\(?%s\)?\s*\n" % (build_type_option, knownbuildtypes[bt])
 
-        cmd = "./configure"
+        cmd = ' '.join([ self.cfg['preconfigopts'],'./configure',self.cfg['configopts']])
         qa = {}
         no_qa = [".*compiler is.*"]
         std_qa = {

--- a/easybuild/easyblocks/w/wrf.py
+++ b/easybuild/easyblocks/w/wrf.py
@@ -186,7 +186,7 @@ class EB_WRF(EasyBlock):
             build_type_question = r"\s*(?P<nr>[0-9]+).\s*%s\s*\(%s\)" % (build_type_option, bt)
 
         # run configure script
-        cmd = ' '.join([ self.cfg['preconfigopts'],'./configure',self.cfg['configopts']])
+        cmd = ' '.join([self.cfg['preconfigopts'], './configure', self.cfg['configopts']])
         qa = {
             # named group in match will be used to construct answer
             "Compile for nesting? (1=basic, 2=preset moves, 3=vortex following) [default 1]:": "1",

--- a/easybuild/easyblocks/w/wrf.py
+++ b/easybuild/easyblocks/w/wrf.py
@@ -186,7 +186,7 @@ class EB_WRF(EasyBlock):
             build_type_question = r"\s*(?P<nr>[0-9]+).\s*%s\s*\(%s\)" % (build_type_option, bt)
 
         # run configure script
-        cmd = "./configure"
+        cmd = ' '.join([ self.cfg['preconfigopts'],'./configure',self.cfg['configopts']])
         qa = {
             # named group in match will be used to construct answer
             "Compile for nesting? (1=basic, 2=preset moves, 3=vortex following) [default 1]:": "1",


### PR DESCRIPTION
Added as part of the work to add big endian support at Sheffield's HPC.