### PR TITLE
enable installation of samples for CUDA > 10.1

### DIFF
--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -97,8 +97,11 @@ class EB_CUDA(Binary):
         else:
             install_interpreter = ""
             install_script = "./cuda-installer"
-            self.cfg.update('installopts', "--silent --samples --toolkit --toolkitpath=%s --defaultroot=%s" % (
-                            self.installdir, self.installdir))
+            # samples are installed in two places with identical copies:
+            # self.installdir/samples and $HOME/NVIDIA_CUDA-11.2_Samples
+            # changing the second location to a scratch location (self.builddir) avoids the duplicate
+            self.cfg.update('installopts', "--silent --samples --samplespath=%s --toolkit --toolkitpath=%s --defaultroot=%s" % (
+                            self.builddir, self.installdir, self.installdir))
 
         if LooseVersion("10.0") < LooseVersion(self.version) < LooseVersion("10.2") and get_cpu_architecture() == POWER:
             # Workaround for

--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -99,7 +99,8 @@ class EB_CUDA(Binary):
             install_script = "./cuda-installer"
             # samples are installed in two places with identical copies:
             # self.installdir/samples and $HOME/NVIDIA_CUDA-11.2_Samples
-            # changing the second location (the one under $HOME) to a scratch location using --samples --samplespath=self.builddir
+            # changing the second location (the one under $HOME) to a scratch location using
+            # --samples --samplespath=self.builddir
             # avoids the duplicate and pollution of the home directory of the installer.
             self.cfg.update('installopts',
                             "--silent --samples --samplespath=%s --toolkit --toolkitpath=%s --defaultroot=%s" % (

--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -100,7 +100,8 @@ class EB_CUDA(Binary):
             # samples are installed in two places with identical copies:
             # self.installdir/samples and $HOME/NVIDIA_CUDA-11.2_Samples
             # changing the second location to a scratch location (self.builddir) avoids the duplicate
-            self.cfg.update('installopts', "--silent --samples --samplespath=%s --toolkit --toolkitpath=%s --defaultroot=%s" % (
+            self.cfg.update('installopts',
+                            "--silent --samples --samplespath=%s --toolkit --toolkitpath=%s --defaultroot=%s" % (
                             self.builddir, self.installdir, self.installdir))
 
         if LooseVersion("10.0") < LooseVersion(self.version) < LooseVersion("10.2") and get_cpu_architecture() == POWER:

--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -103,6 +103,12 @@ class EB_CUDA(Binary):
             self.cfg.update('installopts',
                             "--silent --samples --samplespath=%s --toolkit --toolkitpath=%s --defaultroot=%s" % (
                                 self.builddir, self.installdir, self.installdir))
+            # When eb is called via sudo -u someuser -i eb ..., the installer may try to chown samples to the
+            # original user using the SUDO_USER environment variable, which fails
+            if "SUDO_USER" in os.environ:
+                self.log.info("SUDO_USER was defined as '%s', need to unset it to avoid problems..." %
+                              os.environ["SUDO_USER"])
+                del os.environ["SUDO_USER"]
 
         if LooseVersion("10.0") < LooseVersion(self.version) < LooseVersion("10.2") and get_cpu_architecture() == POWER:
             # Workaround for

--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -92,13 +92,12 @@ class EB_CUDA(Binary):
         elif LooseVersion(self.version) > LooseVersion("5") and LooseVersion(self.version) < LooseVersion("10.1"):
             install_interpreter = "perl"
             install_script = "cuda-installer.pl"
-            # note: also including samples (via "-samplespath=%(installdir)s -samples") would require libglut
+            # note: samples are installed by default
             self.cfg.update('installopts', "-verbose -silent -toolkitpath=%s -toolkit" % self.installdir)
         else:
             install_interpreter = ""
             install_script = "./cuda-installer"
-            # note: also including samples (via "-samplespath=%(installdir)s -samples") would require libglut
-            self.cfg.update('installopts', "--silent --toolkit --toolkitpath=%s --defaultroot=%s" % (
+            self.cfg.update('installopts', "--silent --samples --toolkit --toolkitpath=%s --defaultroot=%s" % (
                             self.installdir, self.installdir))
 
         if LooseVersion("10.0") < LooseVersion(self.version) < LooseVersion("10.2") and get_cpu_architecture() == POWER:
@@ -219,6 +218,8 @@ class EB_CUDA(Binary):
             'dirs': ["include"],
         }
 
+        if LooseVersion(self.version) > LooseVersion('5'):
+            custom_paths['files'].append(os.path.join('samples', 'Makefile'))
         if LooseVersion(self.version) < LooseVersion('7'):
             custom_paths['files'].append(os.path.join('open64', 'bin', 'nvopencc'))
         if LooseVersion(self.version) >= LooseVersion('7'):

--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -99,8 +99,8 @@ class EB_CUDA(Binary):
             install_script = "./cuda-installer"
             # samples are installed in two places with identical copies:
             # self.installdir/samples and $HOME/NVIDIA_CUDA-11.2_Samples
-            # changing the second location (the one under $HOME) to a scratch location (self.builddir) avoids the
-            # duplicate and pollution of the home directory of the installer.
+            # changing the second location (the one under $HOME) to a scratch location using --samples --samplespath=self.builddir
+            # avoids the duplicate and pollution of the home directory of the installer.
             self.cfg.update('installopts',
                             "--silent --samples --samplespath=%s --toolkit --toolkitpath=%s --defaultroot=%s" % (
                                 self.builddir, self.installdir, self.installdir))

--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -99,7 +99,8 @@ class EB_CUDA(Binary):
             install_script = "./cuda-installer"
             # samples are installed in two places with identical copies:
             # self.installdir/samples and $HOME/NVIDIA_CUDA-11.2_Samples
-            # changing the second location to a scratch location (self.builddir) avoids the duplicate
+            # changing the second location (the one under $HOME) to a scratch location (self.builddir) avoids the
+            # duplicate and pollution of the home directory of the installer.
             self.cfg.update('installopts',
                             "--silent --samples --samplespath=%s --toolkit --toolkitpath=%s --defaultroot=%s" % (
                                 self.builddir, self.installdir, self.installdir))

--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -102,7 +102,7 @@ class EB_CUDA(Binary):
             # changing the second location to a scratch location (self.builddir) avoids the duplicate
             self.cfg.update('installopts',
                             "--silent --samples --samplespath=%s --toolkit --toolkitpath=%s --defaultroot=%s" % (
-                            self.builddir, self.installdir, self.installdir))
+                                self.builddir, self.installdir, self.installdir))
 
         if LooseVersion("10.0") < LooseVersion(self.version) < LooseVersion("10.2") and get_cpu_architecture() == POWER:
             # Workaround for


### PR DESCRIPTION
For CUDA > 5 and < 10.1 they are installed by default.
For CUDA > 10.1 we need to add --samples to the installer command
line.
I could not find any evidence of libglut being needed as osdependency
(even for CUDA 6), so deleted those comments.