### PR TITLE
Improve Python package version check and add unversioned_packages EC param

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -829,7 +829,7 @@ class PythonPackage(ExtensionEasyBlock):
                                        'Check that the name from `pip list` is used which may be different than the '
                                        'module name.' % unversioned_package)
                             else:
-                                msg = ('Package %s in unversioned_packages Has a version of %s which is valid. '
+                                msg = ('Package %s in unversioned_packages has a version of %s which is valid. '
                                        'Please remove it from unversioned_packages.' % (unversioned_package, version))
                             pip_check_errors.append(msg)
 

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -806,10 +806,15 @@ class PythonPackage(ExtensionEasyBlock):
                     faulty_pkg_names = [pkg['name'] for pkg in pkgs if pkg['version'] == faulty_version]
                     self.log.info('Found %s invalid packages out of %s packages', len(faulty_pkg_names), len(pkgs))
                     if faulty_pkg_names:
-                        raise EasyBuildError("The following Python packages were not installed correctly and show a "
-                                             "version of '%s':\n%s\nThis may be solved by using the whl file instead "
-                                             "as the source. See e.g. the SOURCE*_WHL templates",
-                                             '\n'.join(faulty_pkg_names), faulty_version)
+                        msg = (
+                            "The following Python packages were likely not installed correctly because they show a "
+                            "version of '%s':\n%s\n"
+                            "This may be solved by using a *-none-any.whl file as the source instead. "
+                            "See e.g. the SOURCE*_WHL templates.\n"
+                            "Otherwise you could check if the package provides a version at all or if e.g. poetry is "
+                            "required (check the source for a pyproject.toml and see PEP517 for details on that)."
+                         ) % (faulty_version, '\n'.join(faulty_pkg_names))
+                        raise EasyBuildError(msg)
 
                     if not self.is_extension:
                         self.clean_up_fake_module(fake_mod_data)


### PR DESCRIPTION
This fixes a format argument confusion in the check for a 0.0.0 version and enhances the error message.
As an escape hatch I added an EC param `unversioned_packages` which contains Python package names which should not trigger a failure on a 0.0.0 version as a last resort, e.g. as of recently in the opencarp package: https://github.com/easybuilders/easybuild-easyconfigs/pull/12462

As those checks can be annoying as they run after a potentially long installation I bundled all error messages together.

As it is impossible to detect the package name used by `pip list` automatically, the `unversioned_packages` must be set even in ECs using other ECs which have such packages. I expect that to be very rare though.
As an explanation: EC "python-protobuf` has a modulename of "google.protobuf" and a pip name of "protobuf". The Keras-* packages are likely similar. Reason is that the name used by pip is in the meta data of the package and could theoretically be anything, IIUC