### PR TITLE
fix comment in NVHPC/AOCC easyblocks

### DIFF
--- a/easybuild/easyblocks/a/aocc.py
+++ b/easybuild/easyblocks/a/aocc.py
@@ -75,7 +75,7 @@ class EB_AOCC(PackedBinary):
             raise EasyBuildError('\n'.join(error_lines))
 
     def install_step(self):
-        # EULA for AOCC must be accepted via --accept-eula EasyBuild configuration option,
+        # EULA for AOCC must be accepted via --accept-eula-for EasyBuild configuration option,
         # or via 'accept_eula = True' in easyconfig file
         self.check_accepted_eula(more_info='http://developer.amd.com/wordpress/media/files/AOCC_EULA.pdf')
 

--- a/easybuild/easyblocks/n/nvhpc.py
+++ b/easybuild/easyblocks/n/nvhpc.py
@@ -101,7 +101,7 @@ class EB_NVHPC(PackedBinary):
     def install_step(self):
         """Install by running install command."""
 
-        # EULA for NVHPC must be accepted via --accept-eula EasyBuild configuration option,
+        # EULA for NVHPC must be accepted via --accept-eula-for EasyBuild configuration option,
         # or via 'accept_eula = True' in easyconfig file
         self.check_accepted_eula(more_info='https://docs.nvidia.com/hpc-sdk/eula/index.html')
 


### PR DESCRIPTION
Should mention `--accept-eula-for` rather than deprecated `--accept-eula` (cfr. https://github.com/easybuilders/easybuild-framework/pull/3630)