### PR TITLE
add support for post install commands for python extensions

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -59,9 +59,15 @@ from easybuild.tools.hooks import CONFIGURE_STEP, BUILD_STEP, TEST_STEP, INSTALL
 # not 'easy_install' deliberately, to avoid that pkg installations listed in easy-install.pth get preference
 # '.' is required at the end when using easy_install/pip in unpacked source dir
 EASY_INSTALL_TARGET = "easy_install"
-EASY_INSTALL_INSTALL_CMD = "%(python)s setup.py " + EASY_INSTALL_TARGET + " --prefix=%(prefix)s %(installopts)s %(loc)s %(postextinstallcmds)s"
+EASY_INSTALL_INSTALL_CMD = (
+    "%(python)s setup.py " +
+    EASY_INSTALL_TARGET +
+    " --prefix=%(prefix)s %(installopts)s %(loc)s %(postextinstallcmds)s"
+)
 PIP_INSTALL_CMD = "pip install --prefix=%(prefix)s %(installopts)s %(loc)s %(postextinstallcmds)s"
-SETUP_PY_INSTALL_CMD = "%(python)s setup.py %(install_target)s --prefix=%(prefix)s %(installopts)s %(postextinstallcmds)s"
+SETUP_PY_INSTALL_CMD = (
+    "%(python)s setup.py %(install_target)s --prefix=%(prefix)s %(installopts)s %(postextinstallcmds)s"
+)
 SETUP_PY_DEVELOP_CMD = "%(python)s setup.py develop --prefix=%(prefix)s %(installopts)s %(postextinstallcmds)s"
 UNKNOWN = 'UNKNOWN'
 

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -59,10 +59,10 @@ from easybuild.tools.hooks import CONFIGURE_STEP, BUILD_STEP, TEST_STEP, INSTALL
 # not 'easy_install' deliberately, to avoid that pkg installations listed in easy-install.pth get preference
 # '.' is required at the end when using easy_install/pip in unpacked source dir
 EASY_INSTALL_TARGET = "easy_install"
-EASY_INSTALL_INSTALL_CMD = "%(python)s setup.py " + EASY_INSTALL_TARGET + " --prefix=%(prefix)s %(installopts)s %(loc)s"
-PIP_INSTALL_CMD = "pip install --prefix=%(prefix)s %(installopts)s %(loc)s"
-SETUP_PY_INSTALL_CMD = "%(python)s setup.py %(install_target)s --prefix=%(prefix)s %(installopts)s"
-SETUP_PY_DEVELOP_CMD = "%(python)s setup.py develop --prefix=%(prefix)s %(installopts)s"
+EASY_INSTALL_INSTALL_CMD = "%(python)s setup.py " + EASY_INSTALL_TARGET + " --prefix=%(prefix)s %(installopts)s %(loc)s %(postextinstallcmds)s"
+PIP_INSTALL_CMD = "pip install --prefix=%(prefix)s %(installopts)s %(loc)s %(postextinstallcmds)s"
+SETUP_PY_INSTALL_CMD = "%(python)s setup.py %(install_target)s --prefix=%(prefix)s %(installopts)s %(postextinstallcmds)s"
+SETUP_PY_DEVELOP_CMD = "%(python)s setup.py develop --prefix=%(prefix)s %(installopts)s %(postextinstallcmds)s"
 UNKNOWN = 'UNKNOWN'
 
 
@@ -259,6 +259,8 @@ class PythonPackage(ExtensionEasyBlock):
                                            "to be the requirements file.", CUSTOM],
             'use_setup_py_develop': [False, "Install using '%s' (deprecated)" % SETUP_PY_DEVELOP_CMD, CUSTOM],
             'zipped_egg': [False, "Install as a zipped eggs (requires use_easy_install)", CUSTOM],
+            'postextinstallcmds': ['', "List of additional commands to execute "
+                                       "after installation as an extension", CUSTOM],
         })
         # Use PYPI_SOURCE as the default for source_urls.
         # As PyPi ignores the casing in the path part of the URL (but not the filename) we can always use PYPI_SOURCE.
@@ -503,6 +505,10 @@ class PythonPackage(ExtensionEasyBlock):
             # add --requirement option when requested, in the right place (i.e. right before the location specification)
             loc = "--requirement %s" % loc
 
+        postextinstallcmds = self.cfg.get('postextinstallcmds')
+        if postextinstallcmds:
+            postextinstallcmds = ' && ' + ' && '.join(postextinstallcmds)
+
         cmd.extend([
             self.cfg['preinstallopts'],
             self.install_cmd % {
@@ -511,6 +517,7 @@ class PythonPackage(ExtensionEasyBlock):
                 'loc': loc,
                 'prefix': prefix,
                 'python': self.python_cmd,
+                'postextinstallcmds': postextinstallcmds,
             },
         ])
 

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -59,16 +59,10 @@ from easybuild.tools.hooks import CONFIGURE_STEP, BUILD_STEP, TEST_STEP, INSTALL
 # not 'easy_install' deliberately, to avoid that pkg installations listed in easy-install.pth get preference
 # '.' is required at the end when using easy_install/pip in unpacked source dir
 EASY_INSTALL_TARGET = "easy_install"
-EASY_INSTALL_INSTALL_CMD = (
-    "%(python)s setup.py " +
-    EASY_INSTALL_TARGET +
-    " --prefix=%(prefix)s %(installopts)s %(loc)s %(postextinstallcmds)s"
-)
-PIP_INSTALL_CMD = "pip install --prefix=%(prefix)s %(installopts)s %(loc)s %(postextinstallcmds)s"
-SETUP_PY_INSTALL_CMD = (
-    "%(python)s setup.py %(install_target)s --prefix=%(prefix)s %(installopts)s %(postextinstallcmds)s"
-)
-SETUP_PY_DEVELOP_CMD = "%(python)s setup.py develop --prefix=%(prefix)s %(installopts)s %(postextinstallcmds)s"
+EASY_INSTALL_INSTALL_CMD = "%(python)s setup.py " + EASY_INSTALL_TARGET + " --prefix=%(prefix)s %(installopts)s %(loc)s"
+PIP_INSTALL_CMD = "pip install --prefix=%(prefix)s %(installopts)s %(loc)s"
+SETUP_PY_INSTALL_CMD = "%(python)s setup.py %(install_target)s --prefix=%(prefix)s %(installopts)s"
+SETUP_PY_DEVELOP_CMD = "%(python)s setup.py develop --prefix=%(prefix)s %(installopts)s"
 UNKNOWN = 'UNKNOWN'
 
 
@@ -265,8 +259,8 @@ class PythonPackage(ExtensionEasyBlock):
                                            "to be the requirements file.", CUSTOM],
             'use_setup_py_develop': [False, "Install using '%s' (deprecated)" % SETUP_PY_DEVELOP_CMD, CUSTOM],
             'zipped_egg': [False, "Install as a zipped eggs (requires use_easy_install)", CUSTOM],
-            'postextinstallcmds': ['', "List of additional commands to execute "
-                                       "after installation as an extension", CUSTOM],
+            'ext_postinstallcmds': [None, "List of additional commands to execute "
+                                          "after installation as an extension", CUSTOM],
         })
         # Use PYPI_SOURCE as the default for source_urls.
         # As PyPi ignores the casing in the path part of the URL (but not the filename) we can always use PYPI_SOURCE.
@@ -511,10 +505,6 @@ class PythonPackage(ExtensionEasyBlock):
             # add --requirement option when requested, in the right place (i.e. right before the location specification)
             loc = "--requirement %s" % loc
 
-        postextinstallcmds = self.cfg.get('postextinstallcmds')
-        if postextinstallcmds:
-            postextinstallcmds = ' && ' + ' && '.join(postextinstallcmds)
-
         cmd.extend([
             self.cfg['preinstallopts'],
             self.install_cmd % {
@@ -523,9 +513,18 @@ class PythonPackage(ExtensionEasyBlock):
                 'loc': loc,
                 'prefix': prefix,
                 'python': self.python_cmd,
-                'postextinstallcmds': postextinstallcmds,
             },
         ])
+
+        ext_postinstallcmds = self.cfg['ext_postinstallcmds']
+        if ext_postinstallcmds is not None:
+            # make sure we have a list or tuple of commands
+            if not isinstance(ext_postinstallcmds, (list, tuple)):
+                raise EasyBuildError("Invalid value for 'ext_postinstallcmds', should be list or tuple of strings.")
+            for _cmd in ext_postinstallcmds:
+                if not isinstance(_cmd, string_type):
+                    raise EasyBuildError("Invalid element in 'ext_postinstallcmds', not a string: %s", _cmd)
+            cmd.append(' && ' + ' && '.join(ext_postinstallcmds))
 
         return ' '.join(cmd)
 


### PR DESCRIPTION
post install commands can be done with a hack if using `python setup.py install`:
```
'installopts': ' && some_post_install_stuff',
```
with pip however, this hack is not possible.

this PR adds support for post install commands for each individual extension, so one can use it in the same way as the usual `postinstallcmds`:
```
'ext_postinstallcmds': [list of commands]',
```