### PR TITLE
Enhance Python easyblock: install pip2 when available, tweak defaults, create unversioned pip symlink

### DIFF
--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -224,6 +224,9 @@ class EB_Python(ConfigureMake):
         self.cfg['exts_defaultclass'] = "PythonPackage"
         self.cfg['exts_filter'] = EXTS_FILTER_PYTHON_PACKAGES
 
+        # don't add user site directory to sys.path (equivalent to python -s)
+        env.setvar('PYTHONNOUSERSITE', '1')
+
         # don't pass down any build/install options that may have been specified
         # 'make' options do not make sense for when building/installing Python libraries (usually via 'python setup.py')
         msg = "Unsetting '%s' easyconfig parameter before building/installing extensions: %s"
@@ -244,12 +247,6 @@ class EB_Python(ConfigureMake):
                                              "you must set 'use_pip=True' for pip&setuptools. "
                                              "Found 'use_pip=False' (maybe by default) for %s.",
                                              ext['name'])
-
-    def extensions_step(self, *args, **kwargs):
-        """Install extensions (PythonPackages)"""
-        # don't add user site directory to sys.path (equivalent to python -s)
-        env.setvar('PYTHONNOUSERSITE', '1')
-        super(EB_Python, self).extensions_step(*args, **kwargs)
 
     def auto_detect_lto_support(self):
         """Return True, if LTO should be enabled for current toolchain"""

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -448,8 +448,9 @@ class EB_Python(ConfigureMake):
 
         if self._has_ensure_pip():
             # Check that pip and setuptools are installed
+            py_maj_version = self.version.split('.')[0]
             custom_paths['files'].extend([
-                os.path.join('bin', pip) for pip in ('pip', 'pip3', 'pip' + self.pyshortver)
+                os.path.join('bin', pip) for pip in ('pip', 'pip' + py_maj_version, 'pip' + self.pyshortver)
             ])
             custom_commands.extend([
                 "python -c 'import pip'",

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -136,6 +136,10 @@ class EB_Python(ConfigureMake):
 
         super(EB_Python, self).patch_step(*args, **kwargs)
 
+        if self._has_ensure_pip():
+            # Ignore user site dir. -E ignores PYTHONNOUSERSITE, so we have to add -s
+            apply_regex_substitutions('configure', [(r"(PYTHON_FOR_BUILD=.*-E)'", r"\1 -s'")])
+
         # if we're installing Python with an alternate sysroot,
         # we need to patch setup.py which includes hardcoded paths like /usr/include and /lib64;
         # this fixes problems like not being able to build the _ssl module ("Could not build the ssl module")

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -133,17 +133,13 @@ class EB_Python(ConfigureMake):
             self.pythonpath = os.path.join(easybuild_subdir, 'python')
 
         ext_defaults = {
-            # The only installed packages at this point are default installed ones, e.g. pip&setuptools
-            # And we want to upgrade them cleanly, i.e. uninstall them
+            # We should enable this (by default) for all extensions because the only installed packages at this point
+            # (i.e. those in the site-packages folder) are the default installed ones, e.g. pip & setuptools.
+            # And we must upgrade them cleanly, i.e. uninstall them first. This also applies to any other package
+            # which is voluntarily or accidentally installed multiple times.
+            # Example: Upgrading to a higher version after installing new dependencies.
             'pip_ignore_installed': False,
-            # Python installations must be clean. Requires pip >= 9
-            'sanity_pip_check': LooseVersion(self._get_pip_ext_version() or '0') >= LooseVersion('9'),
         }
-        # Some older ECs break if we enable download_dep_fail due to missing packages
-        # Since Python 2.7.14 (and all Python 3 versions) we usually enable download_dep_fail in the ECs
-        # already so this should not lead to failures
-        if LooseVersion(self.version) >= LooseVersion('2.7.14'):
-            ext_defaults['download_dep_fail'] = True
 
         exts_default_options = self.cfg.get_ref('exts_default_options')
         for key in ext_defaults:
@@ -156,14 +152,6 @@ class EB_Python(ConfigureMake):
             if not self._has_ensure_pip():
                 raise EasyBuildError("The ensurepip module required to install pip (requested by install_pip=True) "
                                      "is not available in Python %s", self.version)
-
-    def _get_pip_ext_version(self):
-        """Return the pip version from exts_list or None"""
-        for ext in self.cfg.get_ref('exts_list'):
-            # Must be (at least) a name-version tuple
-            if isinstance(ext, tuple) and len(ext) >= 2 and ext[0] == 'pip':
-                return ext[1]
-        return None
 
     def patch_step(self, *args, **kwargs):
         """

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -248,7 +248,7 @@ class EB_Python(ConfigureMake):
     def extensions_step(self, *args, **kwargs):
         """Install extensions (PythonPackages)"""
         # don't add user site directory to sys.path (equivalent to python -s)
-        env.setvar('PYTHONNOUSERSITE', '1', verbose=False)
+        env.setvar('PYTHONNOUSERSITE', '1')
         super(EB_Python, self).extensions_step(*args, **kwargs)
 
     def auto_detect_lto_support(self):
@@ -363,7 +363,7 @@ class EB_Python(ConfigureMake):
 
         # don't add user site directory to sys.path (equivalent to python -s)
         # This matters e.g. when python installs the bundled pip & setuptools (for >= 3.4)
-        env.setvar('PYTHONNOUSERSITE', '1', verbose=False)
+        env.setvar('PYTHONNOUSERSITE', '1')
 
         super(EB_Python, self).configure_step()
 

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -137,8 +137,8 @@ class EB_Python(ConfigureMake):
             # The only installed packages at this point are default installed ones, e.g. pip&setuptools
             # And we want to upgrade them cleanly, i.e. uninstall them
             'pip_ignore_installed': False,
-            # Python installations must be clean
-            'sanity_pip_check': True,
+            # Python installations must be clean. Requires pip >= 9
+            'sanity_pip_check': LooseVersion(self._get_pip_ext_version() or '0') >= LooseVersion('9'),
         }
         exts_default_options = self.cfg.get_ref('exts_default_options')
         for key in ext_defaults:
@@ -151,6 +151,14 @@ class EB_Python(ConfigureMake):
             if not self._has_ensure_pip():
                 raise EasyBuildError("The ensurepip module required to install pip (requested by install_pip=True) "
                                      "is not available in Python %s", self.version)
+
+    def _get_pip_ext_version(self):
+        """Return the pip version from exts_list or None"""
+        for ext in self.cfg.get_ref('exts_list'):
+            # Must be (at least) a name-version tuple
+            if isinstance(ext, tuple) and len(ext) >= 2 and ext[0] == 'pip':
+                return ext[1]
+        return None
 
     def patch_step(self, *args, **kwargs):
         """

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -200,10 +200,17 @@ class EB_Python(ConfigureMake):
         self.cfg['exts_defaultclass'] = "PythonPackage"
         self.cfg['exts_filter'] = EXTS_FILTER_PYTHON_PACKAGES
 
-        # The only installed packages at this point are default installed ones, e.g. pip&setuptools
-        # And we want to upgrade them cleanly, i.e. uninstall them
-        if 'pip_ignore_installed' not in self.cfg['exts_default_options']:
-            self.cfg['exts_default_options']['pip_ignore_installed'] = False
+        ext_defaults = {
+            'download_dep_fail': True,
+            # The only installed packages at this point are default installed ones, e.g. pip&setuptools
+            # And we want to upgrade them cleanly, i.e. uninstall them
+            'pip_ignore_installed': False,
+            # Python installations must be clean
+            'sanity_pip_check': True,
+        }
+        for key, value in ext_defaults.items():
+            if key not in self.cfg['exts_default_options']:
+                self.cfg['exts_default_options'][key] = value
 
         # don't pass down any build/install options that may have been specified
         # 'make' options do not make sense for when building/installing Python libraries (usually via 'python setup.py')

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -43,6 +43,7 @@ from distutils.version import LooseVersion
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.framework.easyconfig.easyconfig import disable_templating
 from easybuild.tools.build_log import EasyBuildError, print_warning
 from easybuild.tools.config import build_option, log_path
 from easybuild.tools.modules import get_software_libdir, get_software_root, get_software_version
@@ -136,9 +137,12 @@ class EB_Python(ConfigureMake):
             # Python installations must be clean
             'sanity_pip_check': True,
         }
-        for key, value in ext_defaults.items():
-            if key not in self.cfg['exts_default_options']:
-                self.cfg['exts_default_options'][key] = value
+        # Disable templating to update the underlying values
+        with disable_templating(self.cfg):
+            for key, value in ext_defaults.items():
+                if key not in self.cfg['exts_default_options']:
+                    self.cfg['exts_default_options'][key] = value
+        self.log.info("exts_default_options: %s", self.cfg['exts_default_options'])
 
     def patch_step(self, *args, **kwargs):
         """

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -128,6 +128,18 @@ class EB_Python(ConfigureMake):
             easybuild_subdir = log_path()
             self.pythonpath = os.path.join(easybuild_subdir, 'python')
 
+        ext_defaults = {
+            'download_dep_fail': True,
+            # The only installed packages at this point are default installed ones, e.g. pip&setuptools
+            # And we want to upgrade them cleanly, i.e. uninstall them
+            'pip_ignore_installed': False,
+            # Python installations must be clean
+            'sanity_pip_check': True,
+        }
+        for key, value in ext_defaults.items():
+            if key not in self.cfg['exts_default_options']:
+                self.cfg['exts_default_options'][key] = value
+
     def patch_step(self, *args, **kwargs):
         """
         Custom patch step for Python:
@@ -199,18 +211,6 @@ class EB_Python(ConfigureMake):
         # build and install additional packages with PythonPackage easyblock
         self.cfg['exts_defaultclass'] = "PythonPackage"
         self.cfg['exts_filter'] = EXTS_FILTER_PYTHON_PACKAGES
-
-        ext_defaults = {
-            'download_dep_fail': True,
-            # The only installed packages at this point are default installed ones, e.g. pip&setuptools
-            # And we want to upgrade them cleanly, i.e. uninstall them
-            'pip_ignore_installed': False,
-            # Python installations must be clean
-            'sanity_pip_check': True,
-        }
-        for key, value in ext_defaults.items():
-            if key not in self.cfg['exts_default_options']:
-                self.cfg['exts_default_options'][key] = value
 
         # don't pass down any build/install options that may have been specified
         # 'make' options do not make sense for when building/installing Python libraries (usually via 'python setup.py')

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -133,13 +133,18 @@ class EB_Python(ConfigureMake):
             self.pythonpath = os.path.join(easybuild_subdir, 'python')
 
         ext_defaults = {
-            'download_dep_fail': True,
             # The only installed packages at this point are default installed ones, e.g. pip&setuptools
             # And we want to upgrade them cleanly, i.e. uninstall them
             'pip_ignore_installed': False,
             # Python installations must be clean. Requires pip >= 9
             'sanity_pip_check': LooseVersion(self._get_pip_ext_version() or '0') >= LooseVersion('9'),
         }
+        # Some older ECs break if we enable download_dep_fail due to missing packages
+        # Since Python 2.7.14 (and all Python 3 versions) we usually enable download_dep_fail in the ECs
+        # already so this should not lead to failures
+        if LooseVersion(self.version) >= LooseVersion('2.7.14'):
+            ext_defaults['download_dep_fail'] = True
+
         exts_default_options = self.cfg.get_ref('exts_default_options')
         for key in ext_defaults:
             if key not in exts_default_options:

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -208,6 +208,12 @@ class EB_Python(ConfigureMake):
                 self.log.debug(msg, param, self.cfg[param])
             self.cfg[param] = ''
 
+    def extensions_step(self, *args, **kwargs):
+        """Install extensions (PythonPackages)"""
+        # don't add user site directory to sys.path (equivalent to python -s)
+        env.setvar('PYTHONNOUSERSITE', '1', verbose=False)
+        super(EB_Python, self).extensions_step(*args, **kwargs)
+
     def auto_detect_lto_support(self):
         """Return True, if LTO should be enabled for current toolchain"""
         result = False

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -376,9 +376,14 @@ class EB_Python(ConfigureMake):
 
         super(EB_Python, self).install_step()
 
+        # Create non-versioned symlinks for python and pip
         python_binary_path = os.path.join(self.installdir, 'bin', 'python')
         if not os.path.isfile(python_binary_path):
-            symlink(python_binary_path + self.pyshortver, python_binary_path)
+            symlink('python' + self.pyshortver, python_binary_path, use_abspath_source=False)
+        if self._has_ensure_pip():
+            pip_binary_path = os.path.join(self.installdir, 'bin', 'pip')
+            if not os.path.isfile(pip_binary_path):
+                symlink('pip' + self.pyshortver, pip_binary_path, use_abspath_source=False)
 
         if self.cfg['ebpythonprefixes']:
             write_file(os.path.join(self.installdir, self.pythonpath, 'sitecustomize.py'), SITECUSTOMIZE)

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -237,7 +237,7 @@ class EB_Python(ConfigureMake):
 
         if self.install_pip:
             # When using ensurepip, then pip must be used to upgrade pip and setuptools
-            # Otherwise it will only copy new files leading to a combination of of files from the old and new version
+            # Otherwise it will only copy new files leading to a combination of files from the old and new version
             use_pip_default = self.cfg['exts_default_options'].get('use_pip')
             # self.exts is populated in fetch_step
             for ext in self.exts:

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -200,6 +200,11 @@ class EB_Python(ConfigureMake):
         self.cfg['exts_defaultclass'] = "PythonPackage"
         self.cfg['exts_filter'] = EXTS_FILTER_PYTHON_PACKAGES
 
+        # The only installed packages at this point are default installed ones, e.g. pip&setuptools
+        # And we want to upgrade them cleanly, i.e. uninstall them
+        if 'pip_ignore_installed' not in self.cfg['exts_default_options']:
+            self.cfg['exts_default_options']['pip_ignore_installed'] = False
+
         # don't pass down any build/install options that may have been specified
         # 'make' options do not make sense for when building/installing Python libraries (usually via 'python setup.py')
         msg = "Unsetting '%s' easyconfig parameter before building/installing extensions: %s"

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -112,7 +112,8 @@ class EB_Python(ConfigureMake):
             'ebpythonprefixes': [True, "Create sitecustomize.py and allow use of $EBPYTHONPREFIXES", CUSTOM],
             'install_pip': [False,
                             "Use the ensurepip module (Python 2.7.9+, 3.4+) to install the bundled versions "
-                            "of pip and setuptools into Python. You _must_ then use pip for upgrading pip&setuptools!",
+                            "of pip and setuptools into Python. You _must_ then use pip for upgrading "
+                            "pip & setuptools by installing newer versions as extensions!",
                             CUSTOM],
             'optimized': [True, "Build with expensive, stable optimizations (PGO, etc.) (version >= 3.5.4)", CUSTOM],
             'ulimit_unlimited': [False, "Ensure stack size limit is set to '%s' during build" % UNLIMITED, CUSTOM],
@@ -245,7 +246,7 @@ class EB_Python(ConfigureMake):
                 if ext['name'] in ('pip', 'setuptools'):
                     if not ext.get('options', {}).get('use_pip', use_pip_default):
                         raise EasyBuildError("When using ensurepip to install pip (requested by install_pip=True) "
-                                             "you must set 'use_pip=True' for pip&setuptools. "
+                                             "you must set 'use_pip=True' for the pip & setuptools extensions. "
                                              "Found 'use_pip=False' (maybe by default) for %s.",
                                              ext['name'])
 


### PR DESCRIPTION
Installing pip from the core Python allows easier installing of packages and avoids the fallback to using setup.py and egg files which can't be easily upgraded

I added an option `install_pip` for installing an initial pip+setuptools which may become the default in EB 5.0. However when that is used, then `pip` MUST be used to upgrade those 2 later in the EC or otherwise the initial version is not properly removed/updated but merely half-way patched (or with pip even kept and silently used)
Hence an additional check is added to catch this case.

This is a **breaking change**, however I see no viable alternative to fix the current bug. See https://github.com/easybuilders/easybuild-easyblocks/pull/2388#issuecomment-829118636 for more details.
Current ECs are fixed in https://github.com/easybuilders/easybuild-easyconfigs/pull/12650

The remaining changes are closely related:
- When installing pip or checking for extensions the user site dir should be ignored
- Creating the symlink `pip` to `pip2/3` spares the ECs to do that in `installopts`
- Set download_dep_fail by default. However it may fail in case we missed to install some deps in the EC which is the case for old ECs, hence I choose to only do it in recent Python 2 and in Python 3.
- Set sanity_pip_check by default, if the installed pip is new enough. If `pip check` doesn't succeed for the core Python package something is wrong... 
- **Disable** '--ignore-installed` by default which is important as we update pip and setuptools. For the other packages it has no effect, as there can't be an installed package which we would want to ignore when installing Python itself.

The last one is critical as `--ignore-installed` does not properly update but only add new files, not changing existing files leads to a mix of versions and issues such as https://github.com/easybuilders/easybuild-easyconfigs/pull/12757