### PR TITLE
Add option to disable connecting to PyPi from pip

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -239,6 +239,8 @@ class PythonPackage(ExtensionEasyBlock):
             'download_dep_fail': [None, "Fail if downloaded dependencies are detected", CUSTOM],
             'install_target': ['install', "Option to pass to setup.py", CUSTOM],
             'pip_ignore_installed': [True, "Let pip ignore installed Python packages (i.e. don't remove them)", CUSTOM],
+            'pip_no_index': [None, "Pass --no-index to pip to disable connecting to PyPi entirely which also disables "
+                                   "the pip version check. Enabled by default when pip_ignore_installed=True", CUSTOM],
             'req_py_majver': [None, "Required major Python version (only relevant when using system Python)", CUSTOM],
             'req_py_minver': [None, "Required minor Python version (only relevant when using system Python)", CUSTOM],
             'sanity_pip_check': [False, "Run 'pip check' to ensure all required Python packages are installed "
@@ -345,6 +347,10 @@ class PythonPackage(ExtensionEasyBlock):
 
             if self.cfg.get('zipped_egg', False):
                 self.cfg.update('installopts', '--egg')
+
+            pip_no_index = self.cfg.get('pip_no_index', None)
+            if pip_no_index or (pip_no_index is None and self.cfg.get('download_dep_fail')):
+                self.cfg.update('installopts', '--no-index')
 
             # avoid that pip (ab)uses $HOME/.cache/pip
             # cfr. https://pip.pypa.io/en/stable/reference/pip_install/#caching


### PR DESCRIPTION
Pip does periodically check for new versions of pip on PyPi which can be disabled with `--disable-pip-version-check`
We certainly want to disable that as it is of no use for us.

However we want even more: pip should not connect to PyPi at all to e.g. download dependencies. This can be done with `--no-index` which implies `--disable-pip-version-check`.

To be safe I added an option which is by default only enabled when `download_dep_fail` is enabled, although I think enabling always by default makes more sense. But I guess that's for EB 5.

--> Faster installations of Python packages and no unwanted network traffic.