### PR TITLE
Updated numpy easyblock to use read_file for patch.

### DIFF
--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -42,7 +42,7 @@ from easybuild.easyblocks.generic.fortranpythonpackage import FortranPythonPacka
 from easybuild.easyblocks.generic.pythonpackage import det_pylibdir
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import change_dir, mkdir, remove_dir
+from easybuild.tools.filetools import change_dir, mkdir, read_file, remove_dir
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
 from distutils.version import LooseVersion
@@ -142,7 +142,7 @@ class EB_numpy(FortranPythonPackage):
                 # patches are either strings (extension) or dicts (easyblock)
                 if isinstance(patch, dict):
                     patch = patch['path']
-                if patch_wl_regex.search(open(patch, 'r').read()):
+                if patch_wl_regex.search(read_file(patch)):
                     patch_found = True
                     break
             if not patch_found:


### PR DESCRIPTION
This fixes issue #2393 (for numpy.py only).