### PR TITLE
Use on_error rather than deprecated log_error named argument for which function

### DIFF
--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -42,6 +42,7 @@ from distutils.version import LooseVersion
 from easybuild.easyblocks.generic.binary import Binary
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.config import IGNORE
 from easybuild.tools.filetools import adjust_permissions, copy_dir, patch_perl_script_autoflush
 from easybuild.tools.filetools import remove_file, symlink, which, write_file
 from easybuild.tools.run import run_cmd, run_cmd_qa
@@ -194,7 +195,7 @@ class EB_CUDA(Binary):
         for comp in (self.cfg['host_compilers'] or []):
             create_wrapper('nvcc_%s' % comp, comp)
 
-        ldconfig = which('ldconfig', log_ok=False, log_error=False)
+        ldconfig = which('ldconfig', log_ok=False, on_error=IGNORE)
         sbin_dirs = ['/sbin', '/usr/sbin']
         if not ldconfig:
             # ldconfig is usually in /sbin or /usr/sbin

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -43,7 +43,7 @@ from easybuild.easyblocks.python import EXTS_FILTER_PYTHON_PACKAGES
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools import run
 from easybuild.tools.build_log import EasyBuildError, print_warning
-from easybuild.tools.config import build_option
+from easybuild.tools.config import build_option, IGNORE
 from easybuild.tools.filetools import adjust_permissions, apply_regex_substitutions, copy_file, mkdir, resolve_path
 from easybuild.tools.filetools import is_readable, read_file, which, write_file, remove_file
 from easybuild.tools.modules import get_software_root, get_software_version, get_software_libdir
@@ -845,7 +845,7 @@ class EB_TensorFlow(PythonPackage):
         # determine number of cores/GPUs to use for tests
         max_num_test_jobs = int(self.cfg['test_max_parallel'] or self.cfg['parallel'])
         if self._with_cuda:
-            if not which('nvidia-smi', log_error=False):
+            if not which('nvidia-smi', on_error=IGNORE):
                 print_warning('Could not find nvidia-smi. Assuming a system without GPUs and skipping GPU tests!')
                 num_gpus_to_use = 0
             elif os.environ.get('CUDA_VISIBLE_DEVICES') == '-1':


### PR DESCRIPTION
Followup to https://github.com/easybuilders/easybuild-framework/pull/3661 using the non-deprecated param

CC @smoors 