### PR TITLE
add gurobi_cl to default sanity checks of gurobi easyblock

### DIFF
--- a/easybuild/easyblocks/g/gurobi.py
+++ b/easybuild/easyblocks/g/gurobi.py
@@ -61,7 +61,8 @@ class EB_Gurobi(Tarball):
             'dirs': [],
         }
 
-        custom_commands = []
+        custom_commands = ["gurobi_cl --help"]
+
         if get_software_root('Python'):
             custom_commands.append("python -c 'import gurobipy'")
 


### PR DESCRIPTION
This is currently done in a few easyconfigs of Gurobi, but it can be done by default.