### PR TITLE
enable sanity_pip_check by default for Python easyconfigs if pip >= 9.0 will be installed

### DIFF
--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -140,6 +140,8 @@ class EB_Python(ConfigureMake):
             # which is voluntarily or accidentally installed multiple times.
             # Example: Upgrading to a higher version after installing new dependencies.
             'pip_ignore_installed': False,
+            # Python installations must be clean. Requires pip >= 9
+            'sanity_pip_check': LooseVersion(self._get_pip_ext_version() or '0.0') >= LooseVersion('9.0'),
         }
 
         exts_default_options = self.cfg.get_ref('exts_default_options')
@@ -153,6 +155,14 @@ class EB_Python(ConfigureMake):
             if not self._has_ensure_pip():
                 raise EasyBuildError("The ensurepip module required to install pip (requested by install_pip=True) "
                                      "is not available in Python %s", self.version)
+
+    def _get_pip_ext_version(self):
+        """Return the pip version from exts_list or None"""
+        for ext in self.cfg.get_ref('exts_list'):
+            # Must be (at least) a name-version tuple
+            if isinstance(ext, tuple) and len(ext) >= 2 and ext[0] == 'pip':
+                return ext[1]
+        return None
 
     def patch_step(self, *args, **kwargs):
         """


### PR DESCRIPTION
This detects issues with e.g. missing dependencies early and ensures that our base Python installations are clean/correct.

- [x] Requires ~~#2388~~