### PR TITLE
add easyblock to install OpenSSL wrapper for OpenSSL installed in OS, or build and install OpenSSL from source if not available in OS

### DIFF
--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -165,7 +165,7 @@ class EB_OpenSSL_wrapper(Bundle):
                               "Falling back to OpenSSL in EasyBuild")
 
         # Check system include paths for OpenSSL headers
-        cmd = "gcc -E -Wp,-v -xc /dev/null"
+        cmd = "LC_ALL=C gcc -E -Wp,-v -xc /dev/null"
         (out, ec) = run_cmd(cmd, log_all=True, simple=False, trace=False)
 
         sys_include_dirs = []

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -39,6 +39,7 @@ from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import DARWIN, LINUX, get_os_type, get_shared_lib_ext
 from easybuild.tools.build_log import EasyBuildError, print_warning
 
+
 def locate_solib(libobj):
     """
     Return absolute path to loaded library using dlinfo
@@ -53,7 +54,7 @@ def locate_solib(libobj):
     libdl = ctypes.cdll.LoadLibrary(ctypes.util.find_library('dl'))
 
     dlinfo = libdl.dlinfo
-    dlinfo.argtypes  = ctypes.c_void_p, ctypes.c_int, ctypes.c_void_p
+    dlinfo.argtypes = ctypes.c_void_p, ctypes.c_int, ctypes.c_void_p
     dlinfo.restype = ctypes.c_int
 
     libpointer = ctypes.c_void_p()
@@ -61,6 +62,7 @@ def locate_solib(libobj):
     libpath = ctypes.cast(libpointer, ctypes.POINTER(LINKMAP)).contents.l_name
 
     return libpath
+
 
 class EB_OpenSSL_wrapper(Bundle):
     """

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -172,8 +172,14 @@ class EB_OpenSSL_wrapper(Bundle):
             sys_include_dirs.extend(match.groups())
         self.log.debug("Found the following include directories in host system: %s", ', '.join(sys_include_dirs))
 
-        # headers are always in "include/openssl" subdirectories
-        ssl_include_dirs = [os.path.join(include, self.name.lower()) for include in sys_include_dirs]
+        # headers are located in 'include/openssl' by default
+        ssl_include_subdirs = [self.name.lower()]
+        if self.version == '1.1':
+            # but version 1.1 can be installed in 'include/openssl11/openssl' as well
+            # we prefer 'include/openssl' as long as the version of headers matches
+            ssl_include_subdirs.append(os.path.join('openssl11', self.name.lower()))
+
+        ssl_include_dirs = [os.path.join(incd, subd) for incd in sys_include_dirs for subd in ssl_include_subdirs]
         ssl_include_dirs = [include for include in ssl_include_dirs if os.path.isdir(include)]
 
         # verify that the headers match our OpenSSL version

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -41,32 +41,8 @@ from easybuild.easyblocks.generic.bundle import Bundle
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.filetools import change_dir, expand_glob_paths, mkdir, read_file, symlink, which
 from easybuild.tools.run import run_cmd
-from easybuild.tools.systemtools import DARWIN, LINUX, get_os_type, get_shared_lib_ext
+from easybuild.tools.systemtools import DARWIN, LINUX, get_os_type, get_shared_lib_ext, locate_solib
 from easybuild.tools.build_log import EasyBuildError, print_warning
-
-
-def locate_solib(libobj):
-    """
-    Return absolute path to loaded library using dlinfo
-    Based on https://stackoverflow.com/a/35683698
-    """
-    class LINKMAP(ctypes.Structure):
-        _fields_ = [
-            ("l_addr", ctypes.c_void_p),
-            ("l_name", ctypes.c_char_p)
-        ]
-
-    libdl = ctypes.cdll.LoadLibrary(ctypes.util.find_library('dl'))
-
-    dlinfo = libdl.dlinfo
-    dlinfo.argtypes = ctypes.c_void_p, ctypes.c_int, ctypes.c_void_p
-    dlinfo.restype = ctypes.c_int
-
-    libpointer = ctypes.c_void_p()
-    dlinfo(libobj._handle, 2, ctypes.byref(libpointer))
-    libpath = ctypes.cast(libpointer, ctypes.POINTER(LINKMAP)).contents.l_name
-
-    return libpath.decode('utf-8')
 
 
 class EB_OpenSSL_wrapper(Bundle):

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2018-2021 Ghent University
+# Copyright 2021 Vrije Universiteit Brussel
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -101,11 +101,11 @@ class EB_OpenSSL_wrapper(Bundle):
             return
 
         # Check the system libraries of OpenSSL
-        for n, libssl in enumerate(self.openssl_libs[0]):
+        for idx, libssl in enumerate(self.openssl_libs[0]):
             self.ssl_syslib = find_library_path(libssl)
             if self.ssl_syslib:
-                # reduce matrix of library names to this one
-                self.openssl_libs = zip(*self.openssl_libs)[n]
+                # reduce matrix of library names to the family of this one
+                self.openssl_libs = list(zip(*self.openssl_libs))[idx]
                 break
 
         if self.ssl_syslib:

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -64,7 +64,9 @@ def locate_solib(libobj):
 
 class EB_OpenSSL_wrapper(Bundle):
     """
-    Create a wrapper .modulerc file for OpenSSL
+    Locate the installation files of OpenSSL in the host system.
+    If available, wrap the system OpenSSL by symlinking all installation files
+    Fall back to the bundled component otherwise.
     """
 
     @staticmethod
@@ -77,7 +79,7 @@ class EB_OpenSSL_wrapper(Bundle):
         return extra_vars
 
     def __init__(self, *args, **kwargs):
-        """Define the names of OpenSSL shared objects"""
+        """Locate the installation files of OpenSSL in the host system"""
         super(EB_OpenSSL_wrapper, self).__init__(*args, **kwargs)
 
         # Libraries packaged in OpenSSL

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -28,6 +28,7 @@ EasyBuild support for installing a wrapper module file for OpenSSL
 @author: Alex Domingo (Vrije Universiteit Brussel)
 """
 import ctypes
+import ctypes.macholib.dyld
 import os
 import re
 
@@ -35,8 +36,10 @@ from easybuild.framework.easyblock import EasyBlock
 from easybuild.tools.filetools import expand_glob_paths, find_glob_pattern, mkdir, read_file, symlink, which
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
+from easybuild.tools.systemtools import get_shared_lib_ext
+from easybuild.tools.systemtools import DARWIN, LINUX, get_os_type, get_shared_lib_ext
 
-def locate_lib(libobj):
+def locate_solib(libobj):
     """
     Return absolute path to loaded library using dlinfo
     Based on https://stackoverflow.com/a/35683698
@@ -68,23 +71,35 @@ class EB_OpenSSL_wrapper(EasyBlock):
         """Define the names of OpenSSL shared objects"""
         super(EB_OpenSSL_wrapper, self).__init__(*args, **kwargs)
 
-        # Check the system library of OpenSSL
-        self.openssl_libs = ['libssl.so', 'libcrypto.so']
+        # Libraries packaged in OpenSSL
+        self.openssl_libs = ['libssl', 'libcrypto']
 
+        # Check the system library of OpenSSL
         libssl = {
-            '1.0': 'libssl.so.10',
-            '1.1': 'libssl.so.1.1',
+            '1.0': {LINUX: 'libssl.so.10', DARWIN: 'libssl.1.0.dylib'},
+            '1.1': {LINUX: 'libssl.so.1.1', DARWIN: 'libssl.1.1.dylib'},
         }
 
+        os_type = get_os_type()
+
         try:
-            libssl_so = libssl[self.version]
+            libssl_so = libssl[self.version][os_type]
             libssl_obj = ctypes.cdll.LoadLibrary(libssl_so)
         except OSError:
             self.ssl_syslib = None
             self.log.debug("Library '%s' not found in host system", libssl_so)
         else:
-            self.ssl_syslib = locate_lib(libssl_obj)
-            self.log.debug("Found library '%s' in: %s", libssl_so, self.ssl_syslib)
+            # ctypes.util.find_library only accepts unversioned library names
+            if os_type == LINUX:
+                # find path to library with dlinfo
+                self.ssl_syslib = locate_solib(libssl_obj)
+            elif os_type == DARWIN:
+                # ctypes.macholib.dyld.dyld_find accepts file names and returns full path
+                self.ssl_syslib = ctypes.macholib.dyld.dyld_find(libssl_so)
+            else:
+                raise EasyBuildError("Unknown host system type: %s", os_type)
+
+        self.log.debug("Found library '%s' in: %s", libssl_so, self.ssl_syslib)
 
         # Check system include paths for OpenSSL headers
         cmd = "gcc -E -Wp,-v -xc /dev/null"
@@ -129,20 +144,20 @@ class EB_OpenSSL_wrapper(EasyBlock):
 
     def install_step(self):
         """Symlink target OpenSSL installation"""
+        shlib_ext = get_shared_lib_ext()
 
         if self.ssl_syslib and self.ssl_syshead:
             # The host system already provides the necessary OpenSSL files
+            ssl_lib_pattern = ['%s*.%s*' % (lib_so, shlib_ext) for lib_so in self.openssl_libs]
             ssl_lib_pattern = [
-                os.path.join(os.path.dirname(self.ssl_syslib), '%s*' % lib_so) for lib_so in self.openssl_libs
+                os.path.join(os.path.dirname(self.ssl_syslib), '%s' % ptrn) for ptrn in ssl_lib_pattern
             ]
             ssl_include_path = self.ssl_syshead
             ssl_bin = which(self.name.lower())
         else:
             # Use OpenSSL from EasyBuild
             ssl_root = get_software_root(self.name)
-            ssl_lib_pattern = [
-                os.path.join(ssl_root, 'lib', '*.so*'),
-            ]
+            ssl_lib_pattern = [os.path.join(ssl_root, 'lib', '*.%s*' % shlib_ext)]
             ssl_include_path = os.path.join(get_software_root(self.name), 'include', self.name.lower())
             ssl_bin = os.path.join(ssl_root, 'bin', self.name.lower())
 
@@ -171,10 +186,11 @@ class EB_OpenSSL_wrapper(EasyBlock):
 
     def sanity_check_step(self):
         """Custom sanity check for OpenSSL wrapper."""
+        shlib_ext = get_shared_lib_ext()
 
         ssl_bin = os.path.join('bin', self.name.lower())
         ssl_include_dir = os.path.join('include', self.name.lower())
-        ssl_libs = [os.path.join('lib', libso) for libso in self.openssl_libs]
+        ssl_libs = [os.path.join('lib', '%s.%s' % (libso, shlib_ext)) for libso in self.openssl_libs]
 
         custom_paths = {
             'files': [ssl_bin] + ssl_libs,

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -104,8 +104,8 @@ class EB_OpenSSL_wrapper(Bundle):
         for idx, libssl in enumerate(self.openssl_libs[0]):
             self.ssl_syslib = find_library_path(libssl)
             if self.ssl_syslib:
-                # reduce matrix of library names to the family of this one
-                self.openssl_libs = list(zip(*self.openssl_libs))[idx]
+                # reduce matrix of library names to the family of the one found
+                self.openssl_libs = [lib_name[idx] for lib_name in self.openssl_libs]
                 break
 
         if self.ssl_syslib:
@@ -239,8 +239,8 @@ class EB_OpenSSL_wrapper(Bundle):
             symlink(self.ssl_sysbin, os.path.join(bin_dir, self.name.lower()))
 
         else:
-            # without wrapping, reduce matrix of library names to first items
-            self.openssl_libs = [libs[0] for libs in self.openssl_libs]
+            # without wrapping, reduce matrix of library names to the first option in each family
+            self.openssl_libs = [lib_name[0] for lib_name in self.openssl_libs]
 
             # install OpenSSL component
             super(EB_OpenSSL_wrapper, self).install_step()

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -124,7 +124,6 @@ class EB_OpenSSL_wrapper(Bundle):
         # Directory with engine libraries
         if self.system_ssl['lib']:
             lib_dir = os.path.dirname(self.system_ssl['lib'])
-            openssl_engine = self.target_ssl_engine
             lib_engines_dir = [
                 os.path.join(lib_dir, 'openssl', self.target_ssl_engine),
                 os.path.join(lib_dir, self.target_ssl_engine),

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -77,7 +77,7 @@ class EB_OpenSSL_wrapper(Bundle):
         os_type = get_os_type()
         if self.version in openssl_libext and os_type in openssl_libext[self.version]:
             # generate matrix of versioned .so filenames
-            self.openssl_libs = [
+            system_versioned_libs = [
                 ['%s.%s' % (lib, ext) for ext in openssl_libext[self.version][os_type]]
                 for lib in openssl_libs
             ]
@@ -85,54 +85,60 @@ class EB_OpenSSL_wrapper(Bundle):
             raise EasyBuildError("Don't know name of OpenSSL system library for version %s and OS type %s",
                                  self.version, os_type)
 
+        # by default target the first option of each OpenSSL library,
+        # which corresponds to installation from source
+        self.target_ssl_libs = [lib_name[0] for lib_name in system_versioned_libs]
+
         # folders containing engines libraries
-        self.openssl_engines = {
+        openssl_engines = {
             '1.0': 'engines',
             '1.1': 'engines-1.1',
         }
+        self.target_ssl_engine = openssl_engines[self.version]
 
         # Paths to system libraries and headers of OpenSSL
-        self.ssl_syslib = None
-        self.ssl_sysheader = None
-        self.ssl_sysengines = None
-        self.ssl_sysbin = None
+        self.system_ssl = {
+            'lib': None,
+            'include': None,
+            'engines': None,
+            'bin': None,
+        }
 
         if not self.cfg.get('wrap_system_openssl'):
-            # without wrapping, reduce matrix of library names to a simple list with first option in each family
-            self.openssl_libs = [lib_name[0] for lib_name in self.openssl_libs]
             return
 
         # Check the system libraries of OpenSSL
-        for idx, libssl in enumerate(self.openssl_libs[0]):
-            self.ssl_syslib = find_library_path(libssl)
-            if self.ssl_syslib:
-                # reduce matrix of library names to a simple list with the family of the one found
-                self.openssl_libs = [lib_name[idx] for lib_name in self.openssl_libs]
+        # (only needs first library in openssl_libs to find path to libraries)
+        for idx, libssl in enumerate(system_versioned_libs[0]):
+            self.system_ssl['lib'] = find_library_path(libssl)
+            if self.system_ssl['lib']:
+                # change target libraries to the ones found in the system
+                self.target_ssl_libs = [lib_name[idx] for lib_name in system_versioned_libs]
                 break
 
-        if self.ssl_syslib:
-            self.log.info("Found library '%s' in: %s", openssl_libs[0], self.ssl_syslib)
+        if self.system_ssl['lib']:
+            self.log.info("Found library '%s' in: %s", openssl_libs[0], self.system_ssl['lib'])
         else:
             self.log.info("Library '%s' not found!", openssl_libs[0])
 
         # Directory with engine libraries
-        if self.ssl_syslib:
-            lib_dir = os.path.dirname(self.ssl_syslib)
-            openssl_engine = self.openssl_engines[self.version]
+        if self.system_ssl['lib']:
+            lib_dir = os.path.dirname(self.system_ssl['lib'])
+            openssl_engine = self.target_ssl_engine
             lib_engines_dir = [
-                os.path.join(lib_dir, 'openssl', openssl_engine),
-                os.path.join(lib_dir, openssl_engine),
+                os.path.join(lib_dir, 'openssl', self.target_ssl_engine),
+                os.path.join(lib_dir, self.target_ssl_engine),
             ]
 
             for engines_path in lib_engines_dir:
                 if os.path.isdir(engines_path):
-                    self.ssl_sysengines = engines_path
-                    self.log.debug("Found OpenSSL engines in: %s", self.ssl_sysengines)
+                    self.system_ssl['engines'] = engines_path
+                    self.log.debug("Found OpenSSL engines in: %s", self.system_ssl['engines'])
                     break
 
-            if not self.ssl_sysengines:
-                self.ssl_syslib = None
-                print_warning("Found OpenSSL in host system, but not its engines."
+            if not self.system_ssl['engines']:
+                self.system_ssl['lib'] = None
+                print_warning("Found OpenSSL in host system, but not its engines. "
                               "Falling back to OpenSSL in EasyBuild")
 
         # Check system include paths for OpenSSL headers
@@ -148,7 +154,7 @@ class EB_OpenSSL_wrapper(Bundle):
         ssl_include_subdirs = [self.name.lower()]
         if self.version == '1.1':
             # but version 1.1 can be installed in 'include/openssl11/openssl' as well, for example in CentOS 7
-            # we prefer 'include/openssl' as long as the version of headers matches
+            # prefer 'include/openssl' as long as the version of headers matches
             ssl_include_subdirs.append(os.path.join('openssl11', self.name.lower()))
 
         ssl_include_dirs = [os.path.join(incd, subd) for incd in sys_include_dirs for subd in ssl_include_subdirs]
@@ -165,8 +171,8 @@ class EB_OpenSSL_wrapper(Bundle):
                 if header_majmin_version:
                     header_majmin_version = header_majmin_version.group(1)
                     if re.match('^' + header_majmin_version, self.version):
-                        self.ssl_sysheader = include_dir
-                        self.log.info("Found OpenSSL headers in host system: %s", self.ssl_sysheader)
+                        self.system_ssl['include'] = include_dir
+                        self.log.info("Found OpenSSL headers in host system: %s", self.system_ssl['include'])
                         break
                     else:
                         self.log.debug("Header major/minor version '%s' doesn't match with %s",
@@ -176,54 +182,54 @@ class EB_OpenSSL_wrapper(Bundle):
             else:
                 self.log.debug("OpenSSL header file %s not found")
 
-        if not self.ssl_sysheader:
-            self.log.info("OpenSSL headers not found in host system")
+        if not self.system_ssl['include']:
+            self.log.info("OpenSSL headers not found in host system. "
+                          "Falling back to OpenSSL in EasyBuild")
 
         # Check system OpenSSL binary
         if self.version == '1.1':
             # prefer 'openssl11' over 'openssl' with v1.1
-            self.ssl_sysbin = which('openssl11')
+            self.system_ssl['bin'] = which('openssl11')
 
-        if not self.ssl_sysbin:
-            self.ssl_sysbin = which(self.name.lower())
+        if not self.system_ssl['bin']:
+            self.system_ssl['bin'] = which(self.name.lower())
 
     def fetch_step(self, *args, **kwargs):
         """Fetch sources if OpenSSL component is needed"""
-        if not all([self.ssl_syslib, self.ssl_sysheader]):
+        if not all([self.system_ssl['lib'], self.system_ssl['include']]):
             super(EB_OpenSSL_wrapper, self).fetch_step(*args, **kwargs)
 
     def extract_step(self):
         """Extract sources if OpenSSL component is needed"""
-        if not all([self.ssl_syslib, self.ssl_sysheader]):
+        if not all([self.system_ssl['lib'], self.system_ssl['include']]):
             super(EB_OpenSSL_wrapper, self).extract_step()
 
     def install_step(self):
         """Symlink target OpenSSL installation"""
 
-        if self.ssl_syslib and self.ssl_sysheader:
+        if self.system_ssl['lib'] and self.system_ssl['include']:
             # note: symlink to individual files, not directories,
             # since directory symlinks get resolved easily...
 
             # link OpenSSL libraries in system
             lib64_dir = os.path.join(self.installdir, 'lib64')
-            lib64_engines_dir = os.path.join(lib64_dir, os.path.basename(self.ssl_sysengines))
+            lib64_engines_dir = os.path.join(lib64_dir, os.path.basename(self.system_ssl['engines']))
             mkdir(lib64_engines_dir, parents=True)
 
             # link existing known libraries
-            ssl_syslibdir = os.path.dirname(self.ssl_syslib)
-            lib_files = [os.path.join(ssl_syslibdir, x) for x in self.openssl_libs]
+            ssl_syslibdir = os.path.dirname(self.system_ssl['lib'])
+            lib_files = [os.path.join(ssl_syslibdir, x) for x in self.target_ssl_libs]
             for libso in lib_files:
                 symlink(libso, os.path.join(lib64_dir, os.path.basename(libso)))
 
             # link engines library files
-            lib64_engines_dir = os.path.join(lib64_dir, os.path.basename(self.ssl_sysengines))
-            engine_lib_pattern = [os.path.join(self.ssl_sysengines, '*')]
+            engine_lib_pattern = [os.path.join(self.system_ssl['engines'], '*')]
             for engine_lib in expand_glob_paths(engine_lib_pattern):
                 symlink(engine_lib, os.path.join(lib64_engines_dir, os.path.basename(engine_lib)))
 
             # relative symlink for unversioned libraries
             cwd = change_dir(lib64_dir)
-            for libso in self.openssl_libs:
+            for libso in self.target_ssl_libs:
                 unversioned_lib = '%s.%s' % (libso.split('.')[0], get_shared_lib_ext())
                 symlink(libso, unversioned_lib, use_abspath_source=False)
             change_dir(cwd)
@@ -231,14 +237,14 @@ class EB_OpenSSL_wrapper(Bundle):
             # link OpenSSL headers in system
             include_dir = os.path.join(self.installdir, 'include', self.name.lower())
             mkdir(include_dir, parents=True)
-            include_pattern = [os.path.join(self.ssl_sysheader, '*')]
+            include_pattern = [os.path.join(self.system_ssl['include'], '*')]
             for header_file in expand_glob_paths(include_pattern):
                 symlink(header_file, os.path.join(include_dir, os.path.basename(header_file)))
 
             # link OpenSSL binary in system
             bin_dir = os.path.join(self.installdir, 'bin')
             mkdir(bin_dir)
-            symlink(self.ssl_sysbin, os.path.join(bin_dir, self.name.lower()))
+            symlink(self.system_ssl['bin'], os.path.join(bin_dir, self.name.lower()))
 
         else:
             # install OpenSSL component
@@ -248,13 +254,15 @@ class EB_OpenSSL_wrapper(Bundle):
         """Custom sanity check for OpenSSL wrapper."""
         shlib_ext = get_shared_lib_ext()
 
+        ssl_libs = ['%s.%s' % (libso.split('.')[0], shlib_ext) for libso in self.target_ssl_libs]
+        ssl_libs.extend(self.target_ssl_libs)
+
         ssl_files = [os.path.join('bin', self.name.lower())]
-        ssl_files.extend(os.path.join('lib', libso) for libso in self.openssl_libs)
-        ssl_files.extend(os.path.join('lib', '%s.%s' % (libso.split('.')[0], shlib_ext)) for libso in self.openssl_libs)
+        ssl_files.extend(os.path.join('lib', libso) for libso in ssl_libs)
 
         ssl_dirs = [
             os.path.join('include', self.name.lower()),
-            os.path.join('lib', self.openssl_engines[self.version]),
+            os.path.join('lib', self.target_ssl_engine),
         ]
 
         custom_paths = {

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -34,7 +34,7 @@ from easybuild.easyblocks.generic.bundle import Bundle
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.filetools import change_dir, expand_glob_paths, mkdir, read_file, symlink, which
 from easybuild.tools.run import run_cmd
-from easybuild.tools.systemtools import DARWIN, LINUX, get_os_type, get_shared_lib_ext, find_library_path, locate_solib
+from easybuild.tools.systemtools import DARWIN, LINUX, get_os_type, get_shared_lib_ext, find_library_path
 from easybuild.tools.build_log import EasyBuildError, print_warning
 
 

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -1,0 +1,184 @@
+##
+# Copyright 2018-2021 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for installing a wrapper module file for OpenSSL
+
+@author: Alex Domingo (Vrije Universiteit Brussel)
+"""
+import ctypes
+import os
+import re
+
+from easybuild.framework.easyblock import EasyBlock
+from easybuild.tools.filetools import expand_glob_paths, find_glob_pattern, mkdir, read_file, symlink, which
+from easybuild.tools.modules import get_software_root
+from easybuild.tools.run import run_cmd
+
+def locate_lib(libobj):
+    """
+    Return absolute path to loaded library using dlinfo
+    Based on https://stackoverflow.com/a/35683698
+    """
+    class LINKMAP(ctypes.Structure):
+        _fields_ = [
+            ("l_addr", ctypes.c_void_p),
+            ("l_name", ctypes.c_char_p)
+        ]
+
+    libdl = ctypes.cdll.LoadLibrary(ctypes.util.find_library('dl'))
+
+    dlinfo = libdl.dlinfo
+    dlinfo.argtypes  = ctypes.c_void_p, ctypes.c_int, ctypes.c_void_p
+    dlinfo.restype = ctypes.c_int
+
+    libpointer = ctypes.c_void_p()
+    dlinfo(libobj._handle, 2, ctypes.byref(libpointer))
+    libpath = ctypes.cast(libpointer, ctypes.POINTER(LINKMAP)).contents.l_name
+
+    return libpath
+
+class EB_OpenSSL_wrapper(EasyBlock):
+    """
+    Create a wrapper .modulerc file for OpenSSL
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Define the names of OpenSSL shared objects"""
+        super(EB_OpenSSL_wrapper, self).__init__(*args, **kwargs)
+
+        # Check the system library of OpenSSL
+        self.openssl_libs = ['libssl.so', 'libcrypto.so']
+
+        libssl = {
+            '1.0': 'libssl.so.10',
+            '1.1': 'libssl.so.1.1',
+        }
+
+        try:
+            libssl_so = libssl[self.version]
+            libssl_obj = ctypes.cdll.LoadLibrary(libssl_so)
+        except OSError:
+            self.ssl_syslib = None
+            self.log.debug("Library '%s' not found in host system", libssl_so)
+        else:
+            self.ssl_syslib = locate_lib(libssl_obj)
+            self.log.debug("Found library '%s' in: %s", libssl_so, self.ssl_syslib)
+
+        # Check system include paths for OpenSSL headers
+        cmd = "gcc -E -Wp,-v -xc /dev/null"
+        (out, ec) = run_cmd(cmd, log_all=True, simple=False, trace=False)
+
+        sys_include_dirs = []
+        for match in re.finditer(r'^\s(/[^\0\n]*)+', out, re.MULTILINE):
+            sys_include_dirs.extend(match.groups())
+        self.log.debug("Found the following include directories in host system: %s", ', '.join(sys_include_dirs))
+
+        # headers are always in "include/openssl" subdirectories
+        ssl_include_dirs = [os.path.join(include, self.name.lower()) for include in sys_include_dirs]
+        ssl_include_dirs = [include for include in ssl_include_dirs if os.path.isdir(include)]
+
+        # verify that the headers match our OpenSSL version
+        self.ssl_syshead = None
+        for include in ssl_include_dirs:
+            opensslv = read_file(os.path.join(include, 'opensslv.h'))
+            header_majmin_version = re.search("SHLIB_VERSION_NUMBER\s\"([0-9]+\.[0-9]+)", opensslv, re.M)
+            if re.match("^{}".format(*header_majmin_version.groups()), self.version):
+                self.ssl_syshead = include
+                self.log.debug("Found OpenSSL headers in host system: %s", ', '.join(self.ssl_syshead))
+
+        if not self.ssl_syshead:
+            self.log.debug("OpenSSL headers not found in host system")
+
+    def prepare_step(self, *args, **kwargs):
+        """Use OpenSSL dependency in host systems without OpenSSL"""
+        if self.ssl_syslib and self.ssl_syshead:
+            self.cfg['dependencies'] = [dep for dep in self.cfg['dependencies'] if dep['name'] != self.name]
+            self.log.debug("Host system provides OpenSSL, removing OpenSSL from list of dependencies")
+
+        super(EB_OpenSSL_wrapper, self).prepare_step(*args, **kwargs)
+
+    def configure_step(self):
+        """Do nothing."""
+        pass
+
+    def build_step(self):
+        """Do nothing."""
+        pass
+
+    def install_step(self):
+        """Symlink target OpenSSL installation"""
+
+        if self.ssl_syslib and self.ssl_syshead:
+            # The host system already provides the necessary OpenSSL files
+            ssl_lib_pattern = [
+                os.path.join(os.path.dirname(self.ssl_syslib), '%s*' % lib_so) for lib_so in self.openssl_libs
+            ]
+            ssl_include_path = self.ssl_syshead
+            ssl_bin = which(self.name.lower())
+        else:
+            # Use OpenSSL from EasyBuild
+            ssl_root = get_software_root(self.name)
+            ssl_lib_pattern = [
+                os.path.join(ssl_root, 'lib', '*.so*'),
+            ]
+            ssl_include_path = os.path.join(get_software_root(self.name), 'include', self.name.lower())
+            ssl_bin = os.path.join(ssl_root, 'bin', self.name.lower())
+
+        # Link OpenSSL libraries
+        lib64_dir = os.path.join(self.installdir, 'lib64')
+        mkdir(lib64_dir)
+        symlink('lib64', 'lib')
+
+        ssl_lib_files = expand_glob_paths(ssl_lib_pattern)
+        for libso in ssl_lib_files:
+            symlink(libso, os.path.join(lib64_dir, os.path.basename(libso)))
+
+        # Link OpenSSL headers
+        include_dir = os.path.join(self.installdir, 'include')
+        mkdir(include_dir)
+        symlink(ssl_include_path, os.path.join(include_dir, self.name.lower()))
+
+        # Link OpenSSL binary
+        bin_dir = os.path.join(self.installdir, 'bin')
+        mkdir(bin_dir)
+        symlink(ssl_bin, os.path.join(bin_dir, self.name.lower()))
+
+    def make_module_dep(self):
+        """Make module file without OpenSSL dependency."""
+        return ''
+
+    def sanity_check_step(self):
+        """Custom sanity check for OpenSSL wrapper."""
+
+        ssl_bin = os.path.join('bin', self.name.lower())
+        ssl_include_dir = os.path.join('include', self.name.lower())
+        ssl_libs = [os.path.join('lib', libso) for libso in self.openssl_libs]
+
+        custom_paths = {
+            'files': [ssl_bin] + ssl_libs,
+            'dirs': [ssl_include_dir]
+        }
+
+        super(EB_OpenSSL_wrapper, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -104,6 +104,7 @@ class EB_OpenSSL_wrapper(Bundle):
 
         os_type = get_os_type()
         if self.version in openssl_libext and os_type in openssl_libext[self.version]:
+            # generate names of versioned .so files
             self.openssl_libs = ['%s.%s' % (lib, openssl_libext[self.version][os_type]) for lib in openssl_libs]
         else:
             raise EasyBuildError("Don't know name of OpenSSL system library for version %s and OS type %s",
@@ -217,7 +218,6 @@ class EB_OpenSSL_wrapper(Bundle):
 
     def install_step(self):
         """Symlink target OpenSSL installation"""
-        shlib_ext = get_shared_lib_ext()
 
         if self.ssl_syslib and self.ssl_sysheader:
             # Link OpenSSL libraries in system
@@ -242,7 +242,7 @@ class EB_OpenSSL_wrapper(Bundle):
             # link unversioned libraries
             for libso in self.openssl_libs:
                 versioned_lib = os.path.join(lib64_dir, libso)
-                unversioned_lib = os.path.join(lib64_dir, '%s.%s' % (libso.split('.')[0], shlib_ext))
+                unversioned_lib = os.path.join(lib64_dir, '%s.%s' % (libso.split('.')[0], get_shared_lib_ext()))
                 symlink(versioned_lib, unversioned_lib)
 
             # Link OpenSSL headers in system

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -98,13 +98,15 @@ class EB_OpenSSL_wrapper(Bundle):
         self.ssl_sysbin = None
 
         if not self.cfg.get('wrap_system_openssl'):
+            # without wrapping, reduce matrix of library names to a simple list with first option in each family
+            self.openssl_libs = [lib_name[0] for lib_name in self.openssl_libs]
             return
 
         # Check the system libraries of OpenSSL
         for idx, libssl in enumerate(self.openssl_libs[0]):
             self.ssl_syslib = find_library_path(libssl)
             if self.ssl_syslib:
-                # reduce matrix of library names to the family of the one found
+                # reduce matrix of library names to a simple list with the family of the one found
                 self.openssl_libs = [lib_name[idx] for lib_name in self.openssl_libs]
                 break
 
@@ -239,9 +241,6 @@ class EB_OpenSSL_wrapper(Bundle):
             symlink(self.ssl_sysbin, os.path.join(bin_dir, self.name.lower()))
 
         else:
-            # without wrapping, reduce matrix of library names to the first option in each family
-            self.openssl_libs = [lib_name[0] for lib_name in self.openssl_libs]
-
             # install OpenSSL component
             super(EB_OpenSSL_wrapper, self).install_step()
 

--- a/test/easyblocks/init_easyblocks.py
+++ b/test/easyblocks/init_easyblocks.py
@@ -205,16 +205,20 @@ def suite():
     easyblocks = [eb for eb in all_pys if not eb.endswith('__init__.py') and '/test/' not in eb]
 
     for easyblock in easyblocks:
+        easyblock_fn = os.path.basename(easyblock)
         # dynamically define new inner functions that can be added as class methods to InitTest
-        if os.path.basename(easyblock) == 'systemcompiler.py':
+        if easyblock_fn == 'systemcompiler.py':
             # use GCC as name when testing SystemCompiler easyblock
             innertest = make_inner_test(easyblock, name='GCC', version='system')
-        elif os.path.basename(easyblock) == 'systemmpi.py':
+        elif easyblock_fn == 'systemmpi.py':
             # use OpenMPI as name when testing SystemMPI easyblock
             innertest = make_inner_test(easyblock, name='OpenMPI', version='system')
-        elif os.path.basename(easyblock) == 'intel_compilers.py':
+        elif easyblock_fn == 'intel_compilers.py':
             # custom easyblock for intel-compilers (oneAPI) requires v2021.x or newer
             innertest = make_inner_test(easyblock, name='intel-compilers', version='2021.1')
+        elif easyblock_fn == 'openssl_wrapper.py':
+            # easyblock to create OpenSSL wrapper expects an OpenSSL version
+            innertest = make_inner_test(easyblock, version='1.1')
         else:
             innertest = make_inner_test(easyblock)
 

--- a/test/easyblocks/module.py
+++ b/test/easyblocks/module.py
@@ -399,6 +399,9 @@ def suite():
         elif eb_fn == 'intel_compilers.py':
             # custom easyblock for intel-compilers (oneAPI) requires v2021.x or newer
             innertest = make_inner_test(easyblock, name='intel-compilers', version='2021.1')
+        elif eb_fn == 'openssl_wrapper.py':
+            # easyblock to create OpenSSL wrapper expects an OpenSSL version
+            innertest = make_inner_test(easyblock, name='OpenSSL-wrapper', version='1.1')
         else:
             # Make up some unique name
             innertest = make_inner_test(easyblock, name=eb_fn.replace('.', '-') + '-sw')


### PR DESCRIPTION
Fixes issue https://github.com/easybuilders/easybuild-easyconfigs/issues/11895

This easyblock looks for the installation files of OpenSSL in the host system to wrap them in the EB installation directory with symlinks
* it searches the library in the host system by loading the respective `libssl.so` in Python and retrieve the path to the library file using `dlinfo` in Linux and `ctypes.macholib.dyld.dyld_find` in Mac OS.
* it searches the headers of the required version of OpenSSL  (v1.0.x or v1.1.x) in the include paths of `gcc` in the system.

This method does not need to crawl through any environment variables, is resilient to installations in exotic paths and integrates well within the EB environment.

Why symlinking?
* it provides a transparent way to update OpenSSL without breaking dynamic links and _probably_ without breaking rpaths either. Any packages build with the wrappers in place should use the paths to the installation directory of the wrapper, not the actual libraries in the system or EB.

If the host system lacks the libs or headers of the required version of OpenSSL, the easyblock builds and installs any component included in the easyconfig bundle (`EB_OpenSSL_wrapper` is based on `Bundle`). This approach has the advantage of automatically disabling the installation of a fallback OpenSSL in EB if the host system already has the required files. Moreover, if the fallback is installed, the result is identical to any other installation of OpenSSL in EB.

Easyconfigs can be found in https://github.com/easybuilders/easybuild-easyconfigs/pull/12858

edit: requires ~~https://github.com/easybuilders/easybuild-framework/pull/3682~~ + ~~https://github.com/easybuilders/easybuild-framework/pull/3683~~