### PR TITLE
Exclude bottleneck tests in PyTorch

### DIFF
--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -225,6 +225,8 @@ class EB_PyTorch(PythonPackage):
         env.setvar('XDG_CACHE_HOME', os.path.join(self.tmpdir, '.cache'))
         # Pretend to be on FB CI which disables some tests, especially those which download stuff
         env.setvar('SANDCASTLE', '1')
+        # Skip this test(s) which is very flaky
+        env.setvar('SKIP_TEST_BOTTLENECK', '1')
         # Parse excluded_tests and flatten into space separated string
         excluded_tests = []
         for arch, tests in self.cfg['excluded_tests'].items():


### PR DESCRIPTION
This excludes a test which runs some kind of profiler. That exits often with an error code but no output at all, so the reason for the failure is unknown. This seems to be common enough there exists an official env var to skip those tests