### PR TITLE
enhance sanity check for Clang to verify if CUDA offload library was produced

### DIFF
--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -481,10 +481,16 @@ class EB_Clang(CMakeMake):
 
         if 'NVPTX' in self.cfg['build_targets']:
             arch = get_cpu_architecture()
-            if arch == POWER:
-                # The 'libomptarget.rtl' on POWER systems is identified using
-                # the following arch
+            # Check architecture explicitly since Clang uses potentially
+            # different names
+            if arch == X86_64:
+                arch = 'x86_64'
+            elif arch == POWER:
                 arch = 'ppc64'
+            elif arch == AARCH64:
+                arch = 'aarch64'
+            else:
+                print_warning("Unknown CPU architecture (%s) for OpenMP offloading!" % arch)
             custom_paths['files'].extend(["lib/libomptarget.%s" % shlib_ext,
                                           "lib/libomptarget-nvptx.a",
                                           "lib/libomptarget.rtl.cuda.%s" % shlib_ext,

--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -479,6 +479,17 @@ class EB_Clang(CMakeMake):
         if LooseVersion(self.version) >= LooseVersion('3.8'):
             custom_paths['files'].extend(["lib/libomp.%s" % shlib_ext, "lib/clang/%s/include/omp.h" % self.version])
 
+        if 'NVPTX' in self.cfg['build_targets']:
+            arch = get_cpu_architecture()
+            if arch == POWER:
+                # The 'libomptarget.rtl' on POWER systems is identified using
+                # the following arch
+                arch = 'ppc64'
+            custom_paths['files'].extend(["lib/libomptarget.%s" % shlib_ext,
+                                          "lib/libomptarget-nvptx.a",
+                                          "lib/libomptarget.rtl.cuda.%s" % shlib_ext,
+                                          "lib/libomptarget.rtl.%s.%s" % (arch, shlib_ext)])
+
         custom_commands = ['clang --help', 'clang++ --help', 'llvm-config --cxxflags']
         super(EB_Clang, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
 


### PR DESCRIPTION
When building Clang with the `gcccuda` toolchain (or just `CUDA` loaded) the offloading library might not be built due to a required dependency on `elfutils`, related to easybuilders/easybuild-easyconfigs#13006. This PR adds a check to see if the appropriate CUDA `libomptarget` library has been built.