### PR TITLE
Fix CPU-only runtime for dpcpp-generated executables in custom easyblock for intel-compilers

### DIFF
--- a/easybuild/easyblocks/i/intel_compilers.py
+++ b/easybuild/easyblocks/i/intel_compilers.py
@@ -124,8 +124,11 @@ class EB_intel_minus_compilers(IntelBase):
             os.path.join('compiler', 'lib', 'intel64_lin'),
         ]
         libdirs = [os.path.join(self.compilers_subdir, x) for x in libdirs]
-        # resolve 'latest' symlink for tbb
-        tbb_version = os.readlink(os.path.join(self.installdir, self.tbb_subdir))
+        # resolve 'latest' symlink for tbb (if module guess is run with install in place)
+        if os.path.islink(os.path.join(self.installdir, self.tbb_subdir)):
+            tbb_version = os.readlink(os.path.join(self.installdir, self.tbb_subdir))
+        else:
+            tbb_version = 'latest'
         tbb_subdir = os.path.join('tbb', tbb_version)
         tbb_libsubdir = os.path.join(tbb_subdir, 'lib', 'intel64')
         libdirs.append(os.path.join(tbb_libsubdir,

--- a/easybuild/easyblocks/i/intel_compilers.py
+++ b/easybuild/easyblocks/i/intel_compilers.py
@@ -50,6 +50,7 @@ class EB_intel_minus_compilers(IntelBase):
             raise EasyBuildError("Invalid version %s, should be >= 2021.x" % self.version)
 
         self.compilers_subdir = os.path.join('compiler', self.version, 'linux')
+        self.tbb_subdir = os.path.join('tbb', self.version)
 
     def prepare_step(self, *args, **kwargs):
         """
@@ -120,6 +121,7 @@ class EB_intel_minus_compilers(IntelBase):
             os.path.join('compiler', 'lib', 'intel64_lin'),
         ]
         libdirs = [os.path.join(self.compilers_subdir, x) for x in libdirs]
+        libdirs.append(os.path.join(self.tbb_subdir, 'lib', 'intel64', 'gcc4.8'))
         guesses = {
             'PATH': [
                 os.path.join(self.compilers_subdir, 'bin'),
@@ -130,5 +132,9 @@ class EB_intel_minus_compilers(IntelBase):
             'OCL_ICD_FILENAMES': [
                 os.path.join(self.compilers_subdir, 'lib', 'x64', 'libintelocl.so'),
             ],
+            'CPATH': [
+                os.path.join(self.tbb_subdir, 'include'),
+            ],
+            'TBBROOT': [self.tbb_subdir],
         }
         return guesses

--- a/easybuild/easyblocks/i/intel_compilers.py
+++ b/easybuild/easyblocks/i/intel_compilers.py
@@ -127,5 +127,8 @@ class EB_intel_minus_compilers(IntelBase):
             ],
             'LD_LIBRARY_PATH': libdirs,
             'LIBRARY_PATH': libdirs,
+            'OCL_ICD_FILENAMES': [
+                os.path.join(self.compilers_subdir, 'lib', 'x64', 'libintelocl.so'),
+            ],
         }
         return guesses


### PR DESCRIPTION
First of all the OpenCL runtime needs to be aware of the CPU-only shared object via `OCL_ICD_FILENAMES -> libintelocl.so`
The module also needs to set TBB-related variables (the same ones as the old iccifort modules), since the above object links to TBB.

This can be tested using e.g. saxpy from
https://github.com/jeffhammond/dpcpp-tutorial

I haven't tested dpcpp on FPGAs, nor on Intel GPUs (though I can try the one on my laptop, an Intel Corporation UHD Graphics 620 chip).

NVidia GPUs are not supported.