### PR TITLE
Always add add distinct_host_configuration=false to TensorFlow compilation

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -786,11 +786,9 @@ class EB_TensorFlow(PythonPackage):
         # Ignore user environment for Python
         self.target_opts.append('--action_env=PYTHONNOUSERSITE=1')
 
-        # use same configuration for both host and target programs, which can speed up the build
-        # only done when optarch is enabled, since this implicitely assumes that host and target platform are the same
-        # see https://docs.bazel.build/versions/master/guide.html#configurations
-        if self.toolchain.options.get('optarch'):
-            self.target_opts.append('--distinct_host_configuration=false')
+        # Use the same configuration (i.e. environment) for compiling and using host tools
+        # This means that our action_envs are always passed
+        self.target_opts.append('--distinct_host_configuration=false')
 
         # TF 2 (final) sets this in configure
         if LooseVersion(self.version) < LooseVersion('2.0'):


### PR DESCRIPTION
This fixes a failure when using optarch=False due to missing CPATH and friends while compiling e.g. protobuf files.


More info:
We pass env vars such as CPATH explicitely because Bazel clears the whole env. If you use `distinct_host_configuration=true`  then bazel will have 2 envs: One for host compilation one for target compilation. We only pass stuff to the target env. Hence the host env is empty and the compiler can't find protobuf due to CPATH not being set

So optarch for TF is broken and likely always has been due to that flag. We can either remove the check which means optarch can now be used, although only for lower archs than the build node, or "fix" it by passing the env vars also to the Bazel host env.
But I think we don't support building for higher archs anyway, as e.g. all tests would fail to execute. Hence IMO we can remove the if and be done