### PR TITLE
Support arbitrary version strings in OpenSSL wrapper and add minimum_openssl_version option

### DIFF
--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -43,9 +43,18 @@ from easybuild.tools.systemtools import DARWIN, LINUX, get_os_type, get_shared_l
 
 class EB_OpenSSL_wrapper(Bundle):
     """
-    Locate the installation files of OpenSSL in the host system
-    If available, wrap the system OpenSSL by symlinking all installation files
-    Fall back to the bundled component otherwise
+    Find path to installation files of OpenSSL in the host system. Checks in
+    order: library files defined in 'openssl_libs', engines libraries, header
+    files and executables. Any missing component will trigger an installation
+    from source of the fallback component.
+    Libraries are located by soname using the major and minor subversions of
+    the wrapper version. The full version of the wrapper or the option
+    'minimum_openssl_version' determine the minimum required version of OpenSSL
+    in the system. The wrapper checks for version strings in the library files
+    and the opensslv.h header.
+    If OpenSSL in host systems fulfills the version requirements, wrap it by
+    symlinking all installation files. Otherwise fall back to the bundled
+    component.
     """
 
     @staticmethod

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -128,7 +128,7 @@ class EB_OpenSSL_wrapper(Bundle):
             system_libssl = find_library_path(libssl)
             if system_libssl:
                 # check version string of system library
-                libssl_strings = read_file(system_libssl, mode="rb")
+                libssl_strings = read_file(system_libssl, mode="rb").decode('utf-8', 'replace')
                 try:
                     libssl_version = openssl_version_regex.search(libssl_strings).group(1)
                 except AttributeError:

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -78,19 +78,12 @@ class EB_OpenSSL_wrapper(Bundle):
         elif not isinstance(min_openssl_version, string_type):
             min_openssl_version = str(min_openssl_version)
 
-        try:
-            subversions = min_openssl_version.split('.')
-            req_majmin_version = '%s.%s' % (subversions[0], subversions[1])
-        except (AttributeError, IndexError):
-            err_msg = "Required minimum OpenSSL version does not have any subversion: %s"
-            raise EasyBuildError(err_msg, min_openssl_version)
-
-        # Forbid minimum_openssl_version with major minor versions beyond wrapper version
-        if req_majmin_version == self.majmin_version:
+        # Minimum OpenSSL version can only increase depth of wrapper version
+        if min_openssl_version.startswith(self.version):
             self.log.debug("Requiring minimum OpenSSL version: %s", min_openssl_version)
         else:
             err_msg = "Requested minimum OpenSSL version '%s' does not fit in wrapper easyconfig version '%s'"
-            raise EasyBuildError(err_msg, min_openssl_version, self.majmin_version)
+            raise EasyBuildError(err_msg, min_openssl_version, self.version)
 
         # Regex pattern to find version strings in OpenSSL libraries and headers
         openssl_version_regex = re.compile(r'OpenSSL\s+([0-9]+\.[0-9]+(\.[0-9]+.)*)', re.M)

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -154,24 +154,25 @@ class EB_OpenSSL_wrapper(Bundle):
             self.log.info(info_msg, openssl_libs[0], libssl_version, self.system_ssl['lib'])
         else:
             self.log.info("OpenSSL library '%s' not found, falling back to OpenSSL in EasyBuild", openssl_libs[0])
+            return
 
         # Directory with engine libraries
-        if self.system_ssl['lib']:
-            lib_dir = os.path.dirname(self.system_ssl['lib'])
-            lib_engines_dir = [
-                os.path.join(lib_dir, 'openssl', self.target_ssl_engine),
-                os.path.join(lib_dir, self.target_ssl_engine),
-            ]
+        lib_dir = os.path.dirname(self.system_ssl['lib'])
+        lib_engines_dir = [
+            os.path.join(lib_dir, 'openssl', self.target_ssl_engine),
+            os.path.join(lib_dir, self.target_ssl_engine),
+        ]
 
-            for engines_path in lib_engines_dir:
-                if os.path.isdir(engines_path):
-                    self.system_ssl['engines'] = engines_path
-                    self.log.debug("Found OpenSSL engines in: %s", self.system_ssl['engines'])
-                    break
+        for engines_path in lib_engines_dir:
+            if os.path.isdir(engines_path):
+                self.system_ssl['engines'] = engines_path
+                self.log.debug("Found OpenSSL engines in: %s", self.system_ssl['engines'])
+                break
 
-            if not self.system_ssl['engines']:
-                self.system_ssl['lib'] = None
-                self.log.info("OpenSSL engines not found in host system, falling back to OpenSSL in EasyBuild")
+        if not self.system_ssl['engines']:
+            self.system_ssl['lib'] = None
+            self.log.info("OpenSSL engines not found in host system, falling back to OpenSSL in EasyBuild")
+            return
 
         # Check system include paths for OpenSSL headers
         cmd = "LC_ALL=C gcc -E -Wp,-v -xc /dev/null"
@@ -218,6 +219,7 @@ class EB_OpenSSL_wrapper(Bundle):
 
         if not self.system_ssl['include']:
             self.log.info("OpenSSL headers not found in host system, falling back to OpenSSL in EasyBuild")
+            return
 
         # Check system OpenSSL binary
         if majmin_version == '1.1':

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -131,7 +131,7 @@ class EB_OpenSSL_wrapper(Bundle):
 
         # early return when we're not wrapping the system OpenSSL installation
         if not self.cfg.get('wrap_system_openssl'):
-            self.log.info("Not wrapping system OpenSSL installation!")
+            self.log.info("Not wrapping system OpenSSL installation by user request")
             return
 
         # Check the system libraries of OpenSSL
@@ -304,9 +304,14 @@ class EB_OpenSSL_wrapper(Bundle):
             mkdir(bin_dir)
             symlink(self.system_ssl['bin'], os.path.join(bin_dir, self.name.lower()))
 
+        elif self.cfg.get('wrap_system_openssl'):
+            # install OpenSSL component due to lack of OpenSSL in host system
+            print_warning("Not all OpenSSL components found in host system, falling back to OpenSSL in EasyBuild!")
+            super(EB_OpenSSL_wrapper, self).install_step()
         else:
-            # install OpenSSL component
-            print_warning("Not all OpenSSL components found, falling back to OpenSSL in EasyBuild!")
+            # install OpenSSL component by user request
+            warn_msg = "Installing OpenSSL from source in EasyBuild by user request ('wrap_system_openssl=%s')"
+            print_warning(warn_msg, self.cfg.get('wrap_system_openssl'))
             super(EB_OpenSSL_wrapper, self).install_step()
 
     def sanity_check_step(self):

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -178,9 +178,8 @@ class EB_OpenSSL_wrapper(Bundle):
                     break
 
             if self.system_ssl['lib']:
-                # change target libraries to the ones found in the system
-                self.target_ssl_libs = system_versioned_libs[idx]
-                self.log.info("Target system OpenSSL libraries: %s", self.target_ssl_libs)
+                # keep the libraries found as possible targets for this installation
+                target_system_ssl_libs = system_versioned_libs[idx]
                 break
 
         if self.system_ssl['lib']:
@@ -267,6 +266,11 @@ class EB_OpenSSL_wrapper(Bundle):
             self.log.info("System OpenSSL binary found: %s", self.system_ssl['bin'])
         else:
             self.log.info("System OpenSSL binary not found!")
+            return
+
+        # system OpenSSL is fine, change target libraries to the ones found in it
+        self.target_ssl_libs = target_system_ssl_libs
+        self.log.info("Target system OpenSSL libraries: %s", self.target_ssl_libs)
 
     def fetch_step(self, *args, **kwargs):
         """Fetch sources if OpenSSL component is needed"""


### PR DESCRIPTION
As discussed in Slack, software needing OpenSSL v1.1.1(_eg_ Qt5) will not work with v1.1.0. Therefore we have to make our wrapper aware of the full version of OpenSSL.

Since the soname of `libssl` is limited to a major minor version, the system will only provide a single `libssl.so.1.1` in any case. So the existing code to find the library file still applies. All that is needed is an extra check on the version string contained in the shared object.

Changelog:
* the version of the wrapper easyconfig can have any depth and it determines the minimum version of OpenSSL required in the system
* regex the full version string from OpenSSL library files in the system
* check that the version of the system library fulfils the version of the wrapper
* apply the same regex used for the libraries to the `opensslv.h` header
* check that the version in the header matches the version of the OpenSSL library
* stop the search process in the system as soon as any component is missing

update in https://github.com/easybuilders/easybuild-easyblocks/pull/2475/commits/6d5124e919efb9de7397b823c87c329af8cb32d8
* search the version string in both `libssl` and `libcrypto` as some distros ship `libssl` without any version string

update in https://github.com/easybuilders/easybuild-easyblocks/pull/2475/commits/044ef733482c8a1de3748275c7e2c9a2273e7329, https://github.com/easybuilders/easybuild-easyblocks/pull/2475/commits/70d0186bf5b11bedc57d7ece5f9911cebbebbab4, https://github.com/easybuilders/easybuild-easyblocks/pull/2475/commits/565694963223d9792762d72ccf9b821fc049ea4c
* add extra option `minimum_openssl_version` to explicitly set the minimum version of OpenSSL required in the system
* `minimum_openssl_version` can only increase the depth of the wrapper easyconfig version

**Existing easyconfigs with just `major.minor` versions continue to work.**

Example of the results obtained with different combinations of OpenSSL versions:
| Wrapper Easyconfig Version | minimum_openssl_version | System OpenSSL Version | Result |
| --------------- | --------------- | --------------- | --------------- |
| 1.0 | none | 1.0.2k | wrapped |
| 1.0 | 1.0.2u | 1.0.2k | built in EB |
| 1.0 | 1.1 | 1.0.2k | error |
| 1.0.2 | none | 1.0.2k | wrapped |
| 1.0.2u | none | 1.0.2k | built in EB |
| 1.1 | none | 1.0.2k | built in EB |
| 1.1 | none | 1.1.0k | wrapped |
| 1.1 | none | 1.1.1g | wrapped |
| 1.1 | 1.1.1 | 1.1.0k | built in EB |
| 1.1 | 1.1.1 | 1.1.1g | wrapped |
| 1.1 | 1.1.1k | 1.1.1g | built in EB |
| 1.1 | 1.0 | 1.1.1g | error |
| 1.1 | 1.2 | 1.1.1g | error |
| 1.1.1 | none | 1.1.0k | built in EB |
| 1.1.1 | none | 1.1.1g | wrapped |
| 1.1.1k | none | 1.1.1g | built in EB |

