### PR TITLE
obtain build_targets value via self.cfg.get in ConfigureMake easyblock

### DIFF
--- a/easybuild/easyblocks/generic/configuremake.py
+++ b/easybuild/easyblocks/generic/configuremake.py
@@ -322,7 +322,7 @@ class ConfigureMake(EasyBlock):
         if self.cfg['parallel']:
             paracmd = "-j %s" % self.cfg['parallel']
 
-        targets = self.cfg['build_targets'] or DEFAULT_BUILD_TARGET
+        targets = self.cfg.get('build_targets') or DEFAULT_BUILD_TARGET
         # ensure strings are converted to list
         targets = [targets] if isinstance(targets, str) else targets
 


### PR DESCRIPTION
Fix for crash for easyblock that derive from `ConfigureMake`, but don't pick up the custom easyconfig parameters for `ConfigureMake` (like `PerlModule`, for example):

```
Use of unknown easyconfig parameter 'build_targets' when getting parameter valu
```