### PR TITLE
always strip output from gcc -print-multiarch

### DIFF
--- a/easybuild/easyblocks/i/intel_compilers.py
+++ b/easybuild/easyblocks/i/intel_compilers.py
@@ -138,8 +138,9 @@ class EB_intel_minus_compilers(IntelBase):
         # On Debian/Ubuntu, /usr/include/x86_64-linux-gnu, or whatever dir gcc uses, needs to be included
         # in $CPATH for Intel C compiler
         multiarch_out, ec = run_cmd("gcc -print-multiarch", simple=False)
+        multiarch_out = multiarch_out.strip()
         if ec == 0 and multiarch_out:
-            multiarch_inc_dir, ec = run_cmd("gcc -E -Wp,-v -xc /dev/null 2>&1 | grep %s$" % multiarch_out.strip())
+            multiarch_inc_dir, ec = run_cmd("gcc -E -Wp,-v -xc /dev/null 2>&1 | grep %s$" % multiarch_out)
             if ec == 0 and multiarch_inc_dir:
                 multiarch_inc_dir = multiarch_inc_dir.strip()
                 self.log.info("Adding multiarch include path %s to $CPATH in generated module file", multiarch_inc_dir)


### PR DESCRIPTION
In our system (CentOS 7.9), `gcc -print-multiarch` returns an empty string with a new line character, which gets into the multiarch conditional and generates a buggy module file (as there is no multiarch in the system).

Simple fix by ensuring that the output of `-print-multiarch` is always stripped.