### PR TITLE
allow disabling of tests if using MPI in FFTW easyblock

### DIFF
--- a/easybuild/easyblocks/f/fftw.py
+++ b/easybuild/easyblocks/f/fftw.py
@@ -231,6 +231,10 @@ class EB_FFTW(ConfigureMake):
     def test_step(self):
         """Custom implementation of test step for FFTW."""
 
+        if self.toolchain.mpi_family() is not None and not build_option('mpi_tests'):
+            self.log.info("Skipping testing of FFTW since MPI testing is disabled")
+            return
+
         if self.toolchain.mpi_family() == toolchain.OPENMPI and not self.toolchain.comp_family() == TC_CONSTANT_FUJITSU:
 
             # allow oversubscription of number of processes over number of available cores with OpenMPI 3.0 & newer,


### PR DESCRIPTION
Addresses #1100

Q: what's the idiomatic way to add a check for the toolchain having an MPI?