### PR TITLE
correctly check whether --with-ucx is used as OpenMPI configure option (taking into account --with-ucx=no)

### DIFF
--- a/easybuild/easyblocks/o/openmpi.py
+++ b/easybuild/easyblocks/o/openmpi.py
@@ -113,7 +113,9 @@ class EB_OpenMPI(ConfigureMake):
             # for OpenMPI v4.x, the openib BTL should be disabled when UCX is used;
             # this is required to avoid "error initializing an OpenFabrics device" warnings,
             # see also https://www.open-mpi.org/faq/?category=all#ofa-device-error
-            if LooseVersion(self.version) >= LooseVersion('4.0.0') and '--with-ucx' in self.cfg['configopts']:
+            is_ucx_enabled = ('--with-ucx' in self.cfg['configopts'] and
+                              '--with-ucx=no' not in self.cfg['configopts'])
+            if LooseVersion(self.version) >= LooseVersion('4.0.0') and is_ucx_enabled:
                 verbs = False
             else:
                 # auto-detect based on available OS packages


### PR DESCRIPTION
We want to disable verbs only when UCX is disabled. So also consider `--with-ucx=no` as disabled (done in last #2500)