### PR TITLE
Clean up installation of Tkinter

### DIFF
--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -144,11 +144,6 @@ class EB_Python(ConfigureMake):
 
         self.pyshortver = '.'.join(self.version.split('.')[:2])
 
-        self.pythonpath = None
-        if self.cfg['ebpythonprefixes']:
-            easybuild_subdir = log_path()
-            self.pythonpath = os.path.join(easybuild_subdir, 'python')
-
         ext_defaults = {
             # Use PYPI_SOURCE as the default for source_urls of extensions.
             'source_urls': [url for name, url, _ in TEMPLATE_CONSTANTS if name == 'PYPI_SOURCE'],
@@ -181,6 +176,15 @@ class EB_Python(ConfigureMake):
             if isinstance(ext, tuple) and len(ext) >= 2 and ext[0] == 'pip':
                 return ext[1]
         return None
+
+    def prepare_step(self, *args, **kwargs):
+        super(EB_Python, self).prepare_step(*args, **kwargs)
+
+        if self.cfg['ebpythonprefixes']:
+            easybuild_subdir = log_path()
+            self.pythonpath = os.path.join(easybuild_subdir, 'python')
+        else:
+            self.pythonpath = None
 
     def patch_step(self, *args, **kwargs):
         """
@@ -583,7 +587,7 @@ class EB_Python(ConfigureMake):
         """Add path to sitecustomize.py to $PYTHONPATH"""
         txt = super(EB_Python, self).make_module_extra()
 
-        if self.pythonpath:
+        if self.cfg['ebpythonprefixes']:
             txt += self.module_generator.prepend_paths('PYTHONPATH', self.pythonpath)
 
         return txt

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -144,6 +144,9 @@ class EB_Python(ConfigureMake):
 
         self.pyshortver = '.'.join(self.version.split('.')[:2])
 
+        # Used for EBPYTHONPREFIXES handler script
+        self.pythonpath = os.path.join(log_path(), 'python')
+
         ext_defaults = {
             # Use PYPI_SOURCE as the default for source_urls of extensions.
             'source_urls': [url for name, url, _ in TEMPLATE_CONSTANTS if name == 'PYPI_SOURCE'],
@@ -176,15 +179,6 @@ class EB_Python(ConfigureMake):
             if isinstance(ext, tuple) and len(ext) >= 2 and ext[0] == 'pip':
                 return ext[1]
         return None
-
-    def prepare_step(self, *args, **kwargs):
-        super(EB_Python, self).prepare_step(*args, **kwargs)
-
-        if self.cfg.get('ebpythonprefixes'):
-            easybuild_subdir = log_path()
-            self.pythonpath = os.path.join(easybuild_subdir, 'python')
-        else:
-            self.pythonpath = None
 
     def patch_step(self, *args, **kwargs):
         """

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -180,7 +180,7 @@ class EB_Python(ConfigureMake):
     def prepare_step(self, *args, **kwargs):
         super(EB_Python, self).prepare_step(*args, **kwargs)
 
-        if self.cfg['ebpythonprefixes']:
+        if self.cfg.get('ebpythonprefixes'):
             easybuild_subdir = log_path()
             self.pythonpath = os.path.join(easybuild_subdir, 'python')
         else:
@@ -459,7 +459,7 @@ class EB_Python(ConfigureMake):
             if not os.path.isfile(pip_binary_path):
                 symlink('pip' + self.pyshortver, pip_binary_path, use_abspath_source=False)
 
-        if self.cfg['ebpythonprefixes']:
+        if self.cfg.get('ebpythonprefixes'):
             write_file(os.path.join(self.installdir, self.pythonpath, 'sitecustomize.py'), SITECUSTOMIZE)
 
         # symlink lib/python*/lib-dynload to lib64/python*/lib-dynload if it doesn't exist;
@@ -535,7 +535,7 @@ class EB_Python(ConfigureMake):
         else:
             self.log.info("No errors found in output of %s: %s", cmd, out)
 
-        if self.cfg['ebpythonprefixes']:
+        if self.cfg.get('ebpythonprefixes'):
             self._sanity_check_ebpythonprefixes()
 
         pyver = 'python' + self.pyshortver
@@ -587,7 +587,7 @@ class EB_Python(ConfigureMake):
         """Add path to sitecustomize.py to $PYTHONPATH"""
         txt = super(EB_Python, self).make_module_extra()
 
-        if self.cfg['ebpythonprefixes']:
+        if self.cfg.get('ebpythonprefixes'):
             txt += self.module_generator.prepend_paths('PYTHONPATH', self.pythonpath)
 
         return txt

--- a/easybuild/easyblocks/t/tkinter.py
+++ b/easybuild/easyblocks/t/tkinter.py
@@ -53,6 +53,7 @@ class EB_Tkinter(EB_Python):
 
     def __init__(self, *args, **kwargs):
         """Initialize Tkinter-specific variables."""
+        self.cfg['ebpythonprefixes'] = False
         super(EB_Tkinter, self).__init__(*args, **kwargs)
         self.tkinter_so_basename = ''
 

--- a/easybuild/easyblocks/t/tkinter.py
+++ b/easybuild/easyblocks/t/tkinter.py
@@ -51,11 +51,14 @@ class EB_Tkinter(EB_Python):
     but only install the Tkinter bits.
     """
 
-    def __init__(self, *args, **kwargs):
-        """Initialize Tkinter-specific variables."""
-        self.cfg['ebpythonprefixes'] = False
-        super(EB_Tkinter, self).__init__(*args, **kwargs)
-        self.tkinter_so_basename = ''
+    @staticmethod
+    def extra_options():
+        """Disable EBPYTHONPREFIXES."""
+        extra_vars = EB_Python.extra_options()
+        # Not used for Tkinter
+        extra_vars['ebpythonprefixes'][0] = False
+
+        return extra_vars
 
     def configure_step(self):
         """Check for Tk before configuring"""
@@ -76,30 +79,28 @@ class EB_Tkinter(EB_Python):
 
         tmpdir = tempfile.mkdtemp(dir=self.builddir)
 
-        if not self.tkinter_so_basename:
-            self.tkinter_so_basename = self.get_tkinter_so_basename()
+        tkinter_so_basename = self.get_tkinter_so_basename(False)
         if LooseVersion(self.version) >= LooseVersion('3'):
-            tkparts = ["tkinter", os.path.join("lib-dynload", self.tkinter_so_basename)]
+            tkparts = ["tkinter", os.path.join("lib-dynload", tkinter_so_basename)]
         else:
-            tkparts = ["lib-tk", os.path.join("lib-dynload", self.tkinter_so_basename)]
+            tkparts = ["lib-tk", os.path.join("lib-dynload", tkinter_so_basename)]
 
-        pylibdir = os.path.join(self.installdir, os.path.dirname(det_pylibdir()))
-        copy([os.path.join(pylibdir, x) for x in tkparts], tmpdir)
+        pylibdir = os.path.join(self.installdir, det_pylibdir())
+        copy([os.path.join(os.path.dirname(pylibdir), x) for x in tkparts], tmpdir)
 
         remove_dir(self.installdir)
 
         move_file(os.path.join(tmpdir, tkparts[0]), os.path.join(pylibdir, tkparts[0]))
-        tkinter_so = os.path.basename(tkparts[1])
-        move_file(os.path.join(tmpdir, tkinter_so), os.path.join(pylibdir, tkinter_so))
+        move_file(os.path.join(tmpdir, tkinter_so_basename), os.path.join(pylibdir, tkinter_so_basename))
 
-    def get_tkinter_so_basename(self):
-        pylibdir = os.path.join(self.installdir, os.path.dirname(det_pylibdir()))
+    def get_tkinter_so_basename(self, in_final_dir):
+        pylibdir = os.path.join(self.installdir, det_pylibdir())
         shlib_ext = get_shared_lib_ext()
-        if build_option('module_only'):
+        if in_final_dir:
             # The build has already taken place so the file will have been moved into the final pylibdir
             tkinter_so = os.path.join(pylibdir, '_tkinter*.' + shlib_ext)
         else:
-            tkinter_so = os.path.join(pylibdir, 'lib-dynload', '_tkinter*.' + shlib_ext)
+            tkinter_so = os.path.join(os.path.dirname(pylibdir), 'lib-dynload', '_tkinter*.' + shlib_ext)
         tkinter_so_hits = glob.glob(tkinter_so)
         if len(tkinter_so_hits) != 1:
             raise EasyBuildError("Expected to find exactly one _tkinter*.so: %s", tkinter_so_hits)
@@ -115,11 +116,10 @@ class EB_Tkinter(EB_Python):
             tkinter = 'Tkinter'
         custom_commands = ["python -c 'import %s'" % tkinter]
 
-        if not self.tkinter_so_basename:
-            self.tkinter_so_basename = self.get_tkinter_so_basename()
+        tkinter_so_basename = self.get_tkinter_so_basename(True)
 
         custom_paths = {
-            'files': [os.path.join(os.path.dirname(det_pylibdir()), self.tkinter_so_basename)],
+            'files': [os.path.join(det_pylibdir(), tkinter_so_basename)],
             'dirs': ['lib']
         }
         super(EB_Python, self).sanity_check_step(custom_commands=custom_commands, custom_paths=custom_paths)
@@ -127,7 +127,6 @@ class EB_Tkinter(EB_Python):
     def make_module_extra(self):
         """Set PYTHONPATH"""
         txt = super(EB_Tkinter, self).make_module_extra()
-        pylibdir = os.path.dirname(det_pylibdir())
-        txt += self.module_generator.prepend_paths('PYTHONPATH', pylibdir)
+        txt += self.module_generator.prepend_paths('PYTHONPATH', det_pylibdir())
 
         return txt

--- a/easybuild/easyblocks/t/tkinter.py
+++ b/easybuild/easyblocks/t/tkinter.py
@@ -39,7 +39,6 @@ import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.pythonpackage import det_pylibdir
 from easybuild.easyblocks.python import EB_Python
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.config import build_option
 from easybuild.tools.filetools import copy, move_file, remove_dir
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.systemtools import get_shared_lib_ext


### PR DESCRIPTION
Tkinter adds a non-existing path `easybuild/python` to PYTHONPATH, which is a bug.

In the process I'v also done some cleanup:
- Custom Python modules should be installed into libdir, aka `site-packages` especially to work with EBPYTHONPREFIXES and hence virtualenvs. Moved.
- Do the setting of PYTHONPATH in EB_Python only if ebpythonprefixes is still active. the other var that was checked is set in the ctor so subclasses had no chance to change that. Fix the latter by doing it in prepare_step
- Refactor `get_tkinter_so_basename` to explicitely ask for getting from our installdir or from python