### PR TITLE
add Ampere to known GPU architectures for Kokkos in LAMMPS easyblock

### DIFF
--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -86,6 +86,8 @@ KOKKOS_GPU_ARCH_TABLE = {
     '7.0': 'Volta70',  # NVIDIA Volta generation CC 7.0
     '7.2': 'Volta72',  # NVIDIA Volta generation CC 7.2
     '7.5': 'Turing75',  # NVIDIA Turing generation CC 7.5
+    '8.0': 'AMPERE80',  # NVIDIA Ampere generation CC 8.0
+    '8.6': 'AMPERE86',  # NVIDIA Ampere generation CC 8.6
 }
 
 PKG_PREFIX = 'PKG_'
@@ -298,9 +300,6 @@ class EB_LAMMPS(CMakeMake):
             pyshortver = '.'.join(get_software_version('Python').split('.')[:2])
             pythonpath = os.path.join('lib', 'python%s' % pyshortver, 'site-packages')
             txt += self.module_generator.prepend_paths('PYTHONPATH', [pythonpath])
-
-        txt += self.module_generator.prepend_paths('PYTHONPATH', ["lib64"])
-        txt += self.module_generator.prepend_paths('LD_LIBRARY_PATH', ["lib64"])
 
         return txt
 


### PR DESCRIPTION
Adds CC 8.0 and 8.6

Also removes the redundant entry for lib64 (added by default, now it was duplicated) and PYTHONPATH to lib64 as that doesn't contain any python packages as far as I can tell. Querying @Darkless012 and @ocaisa for confirmation
