### PR TITLE
update sanity check in ESMF easyblock to take into account new binary names from version 8.1.0 onwards

### DIFF
--- a/easybuild/easyblocks/e/esmf.py
+++ b/easybuild/easyblocks/e/esmf.py
@@ -117,7 +117,13 @@ class EB_ESMF(ConfigureMake):
     def sanity_check_step(self):
         """Custom sanity check for ESMF."""
 
-        binaries = ['ESMF_Info', 'ESMF_InfoC', 'ESMF_RegridWeightGen', 'ESMF_WebServController']
+        if LooseVersion(self.version) < LooseVersion('8.1.0'):
+            binaries = ['ESMF_Info', 'ESMF_InfoC', 'ESMF_Regrid', 'ESMF_RegridWeightGen',
+                        'ESMF_Scrip2Unstruct', 'ESMF_WebServController']
+        else:
+            binaries = ['ESMF_PrintInfo', 'ESMF_PrintInfoC', 'ESMF_Regrid', 'ESMF_RegridWeightGen',
+                        'ESMF_Scrip2Unstruct', 'ESMF_WebServController']
+
         libs = ['libesmf.a', 'libesmf.%s' % get_shared_lib_ext()]
         custom_paths = {
             'files': [os.path.join('bin', x) for x in binaries] + [os.path.join('lib', x) for x in libs],


### PR DESCRIPTION
ESMF command line utility names changed with v8.1 - this PR updates the sanity check to reflect the changes:

* `ESMF_Info` => `ESMF_PrintInfo`
* `ESMF_InfoC` => `ESMF_PrintInfoC`

Also, there were some command line utilities missing from the previously implemented sanity check, so this adds those:

* `ESMF_Regrid`
* `ESMF_Scrip2Unstruct`

Closes #2481 