### PR TITLE
Reduce the number of command line args for CMake configure

### DIFF
--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -188,10 +188,12 @@ class CMakeMake(ConfigureMake):
                 print_warning('Ignoring BUILD_SHARED_LIBS is set in configopts because build_shared_libs is set')
             self.cfg.update('configopts', '-DBUILD_SHARED_LIBS=%s' % ('ON' if build_shared_libs else 'OFF'))
 
+        # If the cache does not exist CMake reads the environment variables
+        cache_exists = os.path.exists('CMakeCache.txt')
         env_to_options = dict()
 
         # Setting compilers is not required unless we want absolute paths
-        if self.cfg.get('abs_path_compilers', False):
+        if self.cfg.get('abs_path_compilers', False) or cache_exists:
             env_to_options.update({
                 'CC': 'CMAKE_C_COMPILER',
                 'CXX': 'CMAKE_CXX_COMPILER',
@@ -204,7 +206,7 @@ class CMakeMake(ConfigureMake):
                 setvar('FC', fc)
 
         # Flags are read from environment variables already since at least CMake 2.8.0
-        if LooseVersion(get_software_version('CMake')) < LooseVersion('2.8.0'):
+        if LooseVersion(get_software_version('CMake')) < LooseVersion('2.8.0') or cache_exists:
             env_to_options.update({
                 'CFLAGS': 'CMAKE_C_FLAGS',
                 'CXXFLAGS': 'CMAKE_CXX_FLAGS',

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -123,10 +123,7 @@ class CMakeMake(ConfigureMake):
         # All options are of the form '-D<key>=<value>'
         new_opts = ' '.join('-D%s=%s' % (key, value) for key, value in config_opts.items()
                             if '-D%s=' % key not in cfg_configopts)
-        if new_opts:
-            if cfg_configopts:
-                new_opts += ' '
-            self.cfg['configopts'] = new_opts + ' ' + cfg_configopts
+        self.cfg['configopts'] = ' '.join([new_opts, cfg_configopts])
 
     def configure_step(self, srcdir=None, builddir=None):
         """Configure build using cmake"""

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -250,14 +250,17 @@ class CMakeMake(ConfigureMake):
                     '-DBoost_NO_SYSTEM_PATHS=ON',
                 ])
 
-        options_string = ' '.join(options)
+        # Deduplicate options (just for better readability)
+        configopts = self.cfg['configopts']
+        # All options are of the form '<key>=<value>'
+        options_string = ' '.join(o for o in options if o.split('=')[0] + '=' not in configopts)
 
         if self.cfg.get('configure_cmd') == DEFAULT_CONFIGURE_CMD:
             command = ' '.join([
                 self.cfg['preconfigopts'],
                 DEFAULT_CONFIGURE_CMD,
                 options_string,
-                self.cfg['configopts'],
+                configopts,
                 srcdir])
         else:
             command = ' '.join([


### PR DESCRIPTION
Especially to make logs more readable use the following:

- CMake uses the compiler env vars since basically forever, so only set them if we need absolute paths
- Since at least 2.8.0 the CMAKE_*_FLAGS are also taken from the environment
- If the user specifies configopts we can omit our argument for the same option

Note that CMake reads the environment only during first configure. Hence if CMakeCache.txt exists the args still need to be passed, but that should be very rare as we usually build in a clean dir