### PR TITLE
Use report_test_failure in TF

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -972,12 +972,9 @@ class EB_TensorFlow(PythonPackage):
                         self.log.warning('Test %s failed with output\n%s', test_name,
                                          read_file(log_path, log_error=False))
                 if failed_tests:
-                    raise EasyBuildError(
-                        'At least %s %s tests failed:\n%s',
-                        len(failed_tests), device, ', '.join(failed_tests)
-                    )
-                else:
-                    raise EasyBuildError(fail_msg)
+                    fail_msg = 'At least %s %s tests failed:\n%s' % (
+                        len(failed_tests), device, ', '.join(failed_tests))
+                self.report_test_failure(fail_msg)
             else:
                 self.log.info('Tests on %s succeeded with output:\n%s', device, stdouterr)
 


### PR DESCRIPTION
Also make use of the new function in the TF easyblock to avoid calling a costly exception and the superflous log entry created by that.

Also avoids the issue which is generically fixed in https://github.com/easybuilders/easybuild-easyblocks/pull/2516

Requires framework bugfix https://github.com/easybuilders/easybuild-framework/pull/3782