### PR TITLE
fix easyblock 'numexpr' for Intel MKL 2021 new directory structure

### DIFF
--- a/easybuild/easyblocks/n/numexpr.py
+++ b/easybuild/easyblocks/n/numexpr.py
@@ -56,12 +56,12 @@ class EB_numexpr(PythonPackage):
         """Custom configuration procedure for numexpr."""
         super(EB_numexpr, self).configure_step()
 
-        self.imkl_root = os.getenv('MKLROOT')
-
         # if Intel MKL is available, set up site.cfg such that the right VML library is used;
         # this makes a *big* difference in terms of performance;
         # see also https://github.com/pydata/numexpr/blob/master/site.cfg.example
-        if self.imkl_root:
+        if get_software_root('imkl'):
+
+            self.imkl_root = os.getenv('MKLROOT')
 
             # figure out which VML library to link to
             cpu_features = get_cpu_features()

--- a/easybuild/easyblocks/n/numexpr.py
+++ b/easybuild/easyblocks/n/numexpr.py
@@ -56,7 +56,7 @@ class EB_numexpr(PythonPackage):
         """Custom configuration procedure for numexpr."""
         super(EB_numexpr, self).configure_step()
 
-        self.imkl_root = get_software_root('imkl')
+        self.imkl_root = os.getenv('MKLROOT')
 
         # if Intel MKL is available, set up site.cfg such that the right VML library is used;
         # this makes a *big* difference in terms of performance;
@@ -78,13 +78,12 @@ class EB_numexpr(PythonPackage):
             mkl_libs = ['mkl_intel_lp64', 'mkl_intel_thread', 'mkl_core', 'mkl_def', mkl_vml_lib, 'mkl_rt', 'iomp5']
 
             mkl_lib_dirs = [
-                os.path.join(self.imkl_root, 'mkl', 'lib', 'intel64'),
                 os.path.join(self.imkl_root, 'lib', 'intel64'),
             ]
 
             site_cfg_txt = '\n'.join([
                 "[mkl]",
-                "include_dirs = %s" % os.path.join(self.imkl_root, 'mkl', 'include'),
+                "include_dirs = %s" % os.path.join(self.imkl_root, 'include'),
                 "library_dirs = %s" % ':'.join(mkl_lib_dirs),
                 "mkl_libs = %s" % ', '.join(mkl_libs),
             ])


### PR DESCRIPTION
The directory structure for Intel's MKL installation has changed with 2021.2.0 from  
`<stage>/software/imkl/2020.2.254/mkl/lib`  
to  
`<stage>/software/imkl/2021.2.0/mkl/2021.2.0/lib`
This is not respected by the current numexpr.py easyblockm but it can easily be fixed by using `MKLROOT`.
