### PR TITLE
let Bundle easyblock pick up custom easyblock for components based on name if no easyblock is specified explicitly

### DIFF
--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -94,13 +94,14 @@ class Bundle(EasyBlock):
             comp_cfg['version'] = comp_version
 
             easyblock = comp_specs.get('easyblock') or self.cfg['default_easyblock']
-            if easyblock is None:
-                raise EasyBuildError("No easyblock specified for component %s v%s", comp_cfg['name'],
-                                     comp_cfg['version'])
-            elif easyblock == 'Bundle':
+            if easyblock == 'Bundle':
                 raise EasyBuildError("The Bundle easyblock can not be used to install components in a bundle")
 
-            comp_cfg.easyblock = get_easyblock_class(easyblock, name=comp_cfg['name'])
+            easyblock = get_easyblock_class(easyblock, name=comp_name)
+            if easyblock is None:
+                raise EasyBuildError("No easyblock found for component %s v%s", comp_name, comp_version)
+
+            comp_cfg.easyblock = easyblock
 
             # make sure that extra easyconfig parameters are known, so they can be set
             extra_opts = comp_cfg.easyblock.extra_options()


### PR DESCRIPTION
Without this change, you always get `No easyblock specified for component` if `default_easyblock` is not set and no explicit `easyblock` is specified for a component, even though there might be a custom easyblock already for that specified component.

We're already calling out to `get_easyblock_class` which will look for a custom easyblock if the `easyblock` value is `None`, but we're giving up too early currently...