### PR TITLE
fix motorBike test in sanity check for OpenFOAM 9

### DIFF
--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -491,12 +491,18 @@ class EB_OpenFOAM(EasyBlock):
             motorbike_path = os.path.join(openfoamdir_path, 'tutorials', 'incompressible', 'simpleFoam', 'motorBike')
             if os.path.exists(motorbike_path):
                 test_dir = tempfile.mkdtemp()
+
+                if self.looseversion >= LooseVersion('9'):
+                    geom_target_dir = 'geometry'
+                else:
+                    geom_target_dir = 'triSurface'
+
                 cmds = [
                     "cp -a %s %s" % (motorbike_path, test_dir),
                     "cd %s" % os.path.join(test_dir, os.path.basename(motorbike_path)),
                     "source $FOAM_BASH",
                     ". $WM_PROJECT_DIR/bin/tools/RunFunctions",
-                    "cp $FOAM_TUTORIALS/resources/geometry/motorBike.obj.gz constant/triSurface/",
+                    "cp $FOAM_TUTORIALS/resources/geometry/motorBike.obj.gz constant/%s/" % geom_target_dir,
                     "runApplication surfaceFeatures",
                     "runApplication blockMesh",
                     "runApplication decomposePar -copyZero",


### PR DESCRIPTION
`constant/triSurface` is no longer there in the `motorBike` tutorial case that's included with OpenFOAM 9, and the `Allrun` script included with it copies `motorBike.obj.gz` to `constant/geometry`

To test: `--module-only` is your friend, no need to rebuild OpenFOAM from scratch.