### PR TITLE
patch Java binaries/libraries when using alternate sysroot to ensure correct glibc & co are picked up + add custom sanity check

### DIFF
--- a/easybuild/easyblocks/j/java.py
+++ b/easybuild/easyblocks/j/java.py
@@ -28,16 +28,18 @@ EasyBlock for installing Java, implemented as an easyblock
 @author: Jens Timmerman (Ghent University)
 @author: Kenneth Hoste (Ghent University)
 """
-
+import glob
 import os
 import stat
 
 from distutils.version import LooseVersion
 from easybuild.easyblocks.generic.packedbinary import PackedBinary
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import adjust_permissions, change_dir, copy_dir, copy_file, remove_dir
+from easybuild.tools.config import build_option
+from easybuild.tools.filetools import adjust_permissions, change_dir, copy_dir, copy_file, remove_dir, which
 from easybuild.tools.run import run_cmd
-from easybuild.tools.systemtools import AARCH64, POWER, X86_64, get_cpu_architecture
+from easybuild.tools.systemtools import AARCH64, POWER, X86_64, get_cpu_architecture, get_shared_lib_ext
+from easybuild.tools.utilities import nub
 
 
 class EB_Java(PackedBinary):
@@ -75,15 +77,125 @@ class EB_Java(PackedBinary):
             PackedBinary.extract_step(self)
 
     def install_step(self):
+        """Custom install step: just copy unpacked installation files."""
         if LooseVersion(self.version) < LooseVersion('1.7'):
             remove_dir(self.installdir)
             copy_dir(os.path.join(self.builddir, 'jdk%s' % self.version), self.installdir)
         else:
             PackedBinary.install_step(self)
 
+    def post_install_step(self):
+        """
+        Custom post-installation step:
+        - ensure correct glibc is used when installing into custom sysroot and using RPATH
+        """
+        super(EB_Java, self).post_install_step()
+
+        # patch binaries and libraries when using alternate sysroot in combination with RPATH
+        sysroot = build_option('sysroot')
+        if sysroot and self.toolchain.use_rpath:
+            if not which('patchelf'):
+                error_msg = "patchelf not found via $PATH, required to patch RPATH section in binaries/libraries"
+                raise EasyBuildError(error_msg)
+
+            try:
+                # list of paths in sysroot to consider for adding to RPATH section
+                sysroot_lib_paths = glob.glob(os.path.join(sysroot, 'lib*'))
+                sysroot_lib_paths += glob.glob(os.path.join(sysroot, 'usr', 'lib*'))
+                sysroot_lib_paths += glob.glob(os.path.join(sysroot, 'usr', 'lib*', 'gcc', '*', '*'))
+                if sysroot_lib_paths:
+                    self.log.info("List of library paths in %s to add to RPATH section: %s", sysroot, sysroot_lib_paths)
+
+                # find path to ELF interpreter
+                elf_interp = None
+                res = glob.glob(os.path.join(sysroot, 'lib*', r'ld-linux-*.so.*'))
+                self.log.debug("Paths for ELF interpreter: %s", res)
+                if res:
+                    # if there are multiple hits, make sure they resolve to the same paths,
+                    # but keep using the symbolic link, not the resolved path!
+                    uniq_real_paths = nub([os.path.realpath(x) for x in res])
+                    if len(uniq_real_paths) == 1:
+                        elf_interp = res[0]
+                        self.log.info("ELF interpreter found at %s", elf_interp)
+                    else:
+                        raise EasyBuildError("Multiple different unique ELF interpreters found: %s", uniq_real_paths)
+
+                if elf_interp is None:
+                    raise EasyBuildError("Failed to isolate ELF interpreter!")
+
+                bindir = os.path.join(self.installdir, 'bin')
+                for path in os.listdir(bindir):
+                    path = os.path.join(bindir, path)
+                    out, _ = run_cmd("file %s" % path, trace=False)
+                    if "dynamically linked" in out:
+
+                        out, _ = run_cmd("patchelf --print-interpreter %s" % path, trace=False)
+                        self.log.debug("ELF interpreter for %s: %s" % (path, out))
+
+                        run_cmd("patchelf --set-interpreter %s %s" % (elf_interp, path), trace=False)
+
+                        out, _ = run_cmd("patchelf --print-interpreter %s" % path, trace=False)
+                        self.log.debug("ELF interpreter for %s: %s" % (path, out))
+
+                        out, _ = run_cmd("patchelf --print-rpath %s" % path, simple=False, trace=False)
+                        curr_rpath = out.strip()
+                        self.log.debug("RPATH for %s: %s" % (path, curr_rpath))
+
+                        new_rpath = ':'.join([curr_rpath] + sysroot_lib_paths)
+                        # note: it's important to wrap the new RPATH value in single quotes,
+                        # to avoid magic values like $ORIGIN being resolved by the shell
+                        run_cmd("patchelf --set-rpath '%s' %s" % (new_rpath, path), trace=False)
+
+                        curr_rpath, _ = run_cmd("patchelf --print-rpath %s" % path, simple=False, trace=False)
+                        self.log.debug("RPATH for %s (prior to shrinking): %s" % (path, curr_rpath))
+
+                        run_cmd("patchelf --shrink-rpath %s" % path, trace=False)
+
+                        curr_rpath, _ = run_cmd("patchelf --print-rpath %s" % path, simple=False, trace=False)
+                        self.log.debug("RPATH for %s (after shrinking): %s" % (path, curr_rpath))
+
+                libdir = os.path.join(self.installdir, 'lib')
+                shlib_ext = '.' + get_shared_lib_ext()
+                for path, _, filenames in os.walk(libdir):
+                    shlibs = [os.path.join(path, x) for x in filenames if x.endswith(shlib_ext)]
+                    for shlib in shlibs:
+                        out, _ = run_cmd("patchelf --print-rpath %s" % shlib, simple=False, trace=False)
+                        curr_rpath = out.strip()
+                        self.log.debug("RPATH for %s: %s" % (shlib, curr_rpath))
+
+                        new_rpath = ':'.join([curr_rpath] + sysroot_lib_paths)
+                        # note: it's important to wrap the new RPATH value in single quotes,
+                        # to avoid magic values like $ORIGIN being resolved by the shell
+                        run_cmd("patchelf --set-rpath '%s' %s" % (new_rpath, shlib), trace=False)
+
+                        curr_rpath, _ = run_cmd("patchelf --print-rpath %s" % shlib, simple=False, trace=False)
+                        self.log.debug("RPATH for %s (prior to shrinking): %s" % (path, curr_rpath))
+
+                        run_cmd("patchelf --shrink-rpath %s" % shlib, trace=False)
+
+                        curr_rpath, _ = run_cmd("patchelf --print-rpath %s" % shlib, simple=False, trace=False)
+                        self.log.debug("RPATH for %s (after shrinking): %s" % (path, curr_rpath))
+
+            except OSError as err:
+                raise EasyBuildError("Failed to patch RPATH section in binaries/libraries: %s", err)
+
+    def sanity_check_step(self):
+        """Custom sanity check for Java."""
+        custom_paths = {
+            'files': ['bin/java', 'bin/javac'],
+            'dirs': ['lib'],
+        }
+
+        custom_commands = [
+            "java -help",
+            "javac -help",
+        ]
+
+        super(EB_Java, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
+
     def make_module_extra(self):
         """
-        Set JAVA_HOME to install dir
+        Set $JAVA_HOME to installation directory
         """
         txt = PackedBinary.make_module_extra(self)
         txt += self.module_generator.set_environment('JAVA_HOME', self.installdir)


### PR DESCRIPTION
Enhancement for custom easyblock for Java to fix problems that occur when using `Java` in the context of an alternate sysroot and using RPATH (see https://github.com/EESSI/software-layer/issues/123)

Also adds basic custom sanity check for Java, including running `java -help` and `javac -help`, which work for Java 1.7.x, 1.8.x, 11.x, 13.x

This is a draft PR because this should be cleaned up a bit, by adding support in EasyBuild framework for leveraging `patchelf`, so it's a lot cleaner to patch a binary installation like this (we may also need this for other stuff, like CUDA, Intel tools, etc.)