### PR TITLE
Let GROMACS runtime logs show EasyBuild was used

### DIFF
--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -215,7 +215,7 @@ class EB_GROMACS(CMakeMake):
             if plumed_root:
                 plumed_version = get_software_version('PLUMED')
                 if plumed_version:
-                    gromacs_version_string_suffix = '%s-%s' % (plumed-version, VERBOSE_VERSION)
+                    gromacs_version_string_suffix = '%s-%s' % (plumed_version, VERBOSE_VERSION)
                 else:
                     gromacs_version_string_suffix = 'PLUMED-%s' % VERBOSE_VERSION
             else:

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -51,7 +51,7 @@ from easybuild.tools.modules import get_software_libdir, get_software_root, get_
 from easybuild.tools.run import run_cmd
 from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
 from easybuild.tools.systemtools import X86_64, get_cpu_architecture, get_shared_lib_ext, get_cpu_features
-from easybuild.tools.version import VERBOSE_VERSION
+from easybuild.tools.version import VERBOSE_VERSION as EASYBUILD_VERSION
 
 
 class EB_GROMACS(CMakeMake):
@@ -211,11 +211,11 @@ class EB_GROMACS(CMakeMake):
 
         # Ensure that the GROMACS log files report how the code was patched
         # during the build, so that any problems are easier to diagnose.
-        if '-DGMX_VERSION_STRING_OF_FORK=' not in self.cfg['configopts']:
+        # The GMX_VERSION_STRING_OF_FORK feature is available since 2020.
+        if LooseVersion(self.version) >= LooseVersion('2020') and '-DGMX_VERSION_STRING_OF_FORK=' not in self.cfg['configopts']:
+            gromacs_version_string_suffix = 'EasyBuild-%s' % EASYBUILD_VERSION
             if plumed_root:
-                gromacs_version_string_suffix = 'PLUMED-%s-%s' % (get_software_version('PLUMED'), VERBOSE_VERSION)
-            else:
-                gromacs_version_string_suffix = VERBOSE_VERSION
+                gromacs_version_string_suffix += '-PLUMED-%s' % get_software_version('PLUMED')
             self.cfg.update('configopts', '-DGMX_VERSION_STRING_OF_FORK=%s' % gromacs_version_string_suffix)
 
         if LooseVersion(self.version) < LooseVersion('4.6'):

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -213,11 +213,7 @@ class EB_GROMACS(CMakeMake):
         # during the build, so that any problems are easier to diagnose.
         if '-DGMX_VERSION_STRING_OF_FORK=' not in self.cfg['configopts']:
             if plumed_root:
-                plumed_version = get_software_version('PLUMED')
-                if plumed_version:
-                    gromacs_version_string_suffix = '%s-%s' % (plumed_version, VERBOSE_VERSION)
-                else:
-                    gromacs_version_string_suffix = 'PLUMED-%s' % VERBOSE_VERSION
+                gromacs_version_string_suffix = 'PLUMED-%s-%s' % (get_software_version('PLUMED'), VERBOSE_VERSION)
             else:
                 gromacs_version_string_suffix = VERBOSE_VERSION
             self.cfg.update('configopts', '-DGMX_VERSION_STRING_OF_FORK=%s' % gromacs_version_string_suffix)

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -51,6 +51,7 @@ from easybuild.tools.modules import get_software_libdir, get_software_root, get_
 from easybuild.tools.run import run_cmd
 from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
 from easybuild.tools.systemtools import X86_64, get_cpu_architecture, get_shared_lib_ext, get_cpu_features
+from easybuild.tools.version import VERBOSE_VERSION
 
 
 class EB_GROMACS(CMakeMake):
@@ -207,6 +208,19 @@ class EB_GROMACS(CMakeMake):
             # PLUMED patching must be done at different stages depending on
             # version of GROMACS. Just prepare first part of cmd here
             plumed_cmd = "plumed-patch -p -e %s" % engine
+
+        # Ensure that the GROMACS log files report how the code was patched
+        # during the build, so that any problems are easier to diagnose.
+        if '-DGMX_VERSION_STRING_OF_FORK=' not in self.cfg['configopts']:
+            if plumed_root:
+                plumed_version = get_software_version('PLUMED')
+                if plumed_version:
+                    gromacs_version_string_suffix = '%s-%s' % (plumed-version, VERBOSE_VERSION)
+                else:
+                    gromacs_version_string_suffix = 'PLUMED-%s' % VERBOSE_VERSION
+            else:
+                gromacs_version_string_suffix = VERBOSE_VERSION
+            self.cfg.update('configopts', '-DGMX_VERSION_STRING_OF_FORK=%s' % gromacs_version_string_suffix)
 
         if LooseVersion(self.version) < LooseVersion('4.6'):
             self.log.info("Using configure script for configuring GROMACS build.")

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -212,7 +212,8 @@ class EB_GROMACS(CMakeMake):
         # Ensure that the GROMACS log files report how the code was patched
         # during the build, so that any problems are easier to diagnose.
         # The GMX_VERSION_STRING_OF_FORK feature is available since 2020.
-        if LooseVersion(self.version) >= LooseVersion('2020') and '-DGMX_VERSION_STRING_OF_FORK=' not in self.cfg['configopts']:
+        if (LooseVersion(self.version) >= LooseVersion('2020') and 
+            '-DGMX_VERSION_STRING_OF_FORK=' not in self.cfg['configopts']):
             gromacs_version_string_suffix = 'EasyBuild-%s' % EASYBUILD_VERSION
             if plumed_root:
                 gromacs_version_string_suffix += '-PLUMED-%s' % get_software_version('PLUMED')

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -212,8 +212,8 @@ class EB_GROMACS(CMakeMake):
         # Ensure that the GROMACS log files report how the code was patched
         # during the build, so that any problems are easier to diagnose.
         # The GMX_VERSION_STRING_OF_FORK feature is available since 2020.
-        if (LooseVersion(self.version) >= LooseVersion('2020') and 
-            '-DGMX_VERSION_STRING_OF_FORK=' not in self.cfg['configopts']):
+        if (LooseVersion(self.version) >= LooseVersion('2020') and
+                '-DGMX_VERSION_STRING_OF_FORK=' not in self.cfg['configopts']):
             gromacs_version_string_suffix = 'EasyBuild-%s' % EASYBUILD_VERSION
             if plumed_root:
                 gromacs_version_string_suffix += '-PLUMED-%s' % get_software_version('PLUMED')


### PR DESCRIPTION
Knowing that EasyBuild has patched the code and organized the build is potentially valuable information for GROMACS users and developers troubleshooting their runs.

PLUMED does further patches to GROMACS, so that is expressed directly also.