### PR TITLE
restore RPATH wrappers for OpenMPI sanity check (WIP)

### DIFF
--- a/easybuild/easyblocks/o/openmpi.py
+++ b/easybuild/easyblocks/o/openmpi.py
@@ -198,4 +198,10 @@ class EB_OpenMPI(ConfigureMake):
                     params['nr_ranks'] = 1
                     custom_commands.append(mpi_cmd_tmpl % params)
 
+        # ensure RPATH wrappers are in place, otherwise compiling minimal test programs will fail
+        if build_option('rpath'):
+            if self.toolchain.options.get('rpath', True):
+                self.toolchain.prepare_rpath_wrappers(rpath_filter_dirs=self.rpath_filter_dirs,
+                                                      rpath_include_dirs=self.rpath_include_dirs)
+
         super(EB_OpenMPI, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)


### PR DESCRIPTION
WIP because I need to check whether this fixes a problem reported in Slack, after I reproduce the issue first...