### PR TITLE
fix installation of libcp2k for recent CP2K versions

### DIFF
--- a/easybuild/easyblocks/c/cp2k.py
+++ b/easybuild/easyblocks/c/cp2k.py
@@ -670,12 +670,11 @@ class EB_CP2K(EasyBlock):
         # build and install
         # compile regularly first with the default make target
         # and only then build the library
-        run_cmd(cmd, log_all=True, simple=True, log_output=True)
+        run_cmd(cmd + ' all', log_all=True, simple=True, log_output=True)
 
         # build as a library
         if self.cfg['library']:
-            cmd += ' libcp2k'
-            run_cmd(cmd, log_all=True, simple=True, log_output=True)
+            run_cmd(cmd + 'libcp2k', log_all=True, simple=True, log_output=True)
 
 
     def test_step(self):

--- a/easybuild/easyblocks/c/cp2k.py
+++ b/easybuild/easyblocks/c/cp2k.py
@@ -676,7 +676,6 @@ class EB_CP2K(EasyBlock):
         if self.cfg['library']:
             run_cmd(cmd + 'libcp2k', log_all=True, simple=True, log_output=True)
 
-
     def test_step(self):
         """Run regression test."""
 

--- a/easybuild/easyblocks/c/cp2k.py
+++ b/easybuild/easyblocks/c/cp2k.py
@@ -668,9 +668,15 @@ class EB_CP2K(EasyBlock):
         run_cmd(cmd + " clean", log_all=True, simple=True, log_output=True)
 
         # build and install
+        # compile regularly first with the default make target
+        # and only then build the library
+        run_cmd(cmd, log_all=True, simple=True, log_output=True)
+
+        # build as a library
         if self.cfg['library']:
             cmd += ' libcp2k'
-        run_cmd(cmd + " all", log_all=True, simple=True, log_output=True)
+            run_cmd(cmd, log_all=True, simple=True, log_output=True)
+
 
     def test_step(self):
         """Run regression test."""


### PR DESCRIPTION
First building `libcp2k` seems to depend on doing a normal build first, see https://github.com/cp2k/cp2k/blob/master/INSTALL.md#3c-building-cp2k-as-a-library and https://gitlab.com/gromacs/gromacs/-/blob/2021.2-qmmm/INSTALL-dev