### PR TITLE
update CP2K easyblock to use -D__MKL

### DIFF
--- a/easybuild/easyblocks/c/cp2k.py
+++ b/easybuild/easyblocks/c/cp2k.py
@@ -598,7 +598,10 @@ class EB_CP2K(EasyBlock):
         else:
             # only use Intel FFTW wrappers if FFTW is not loaded
             options['CFLAGS'] += ' -I$(INTEL_INCF)'
-            options['DFLAGS'] += ' -D__FFTMKL'
+            if LooseVersion(self.version) > LooseVersion('2.3'):
+                options['DFLAGS'] += ' -D__MKL'
+            else:
+                options['DFLAGS'] += ' -D__FFTMKL'
             options['INTEL_INCF'] = '$(INTEL_INC)/fftw'
             options['LIBS'] = '%s %s' % (os.getenv('LIBFFT', ''), options['LIBS'])
 


### PR DESCRIPTION
The last version of CP2K which used the flag -D__FFTMKL is 2.3.  The later versions use -D__MKL .  This change is necessary to have psmp version (MPI/OpenMP) work properly, as without it the executable will build but a check for thread safety fails at runtime when running with more than 1 thread.

In INSTALL.md instructions of latest version of 8.2 of CP2K it is stated: "if compiling with MKL you must
define `-D__MKL` to ensure the code is thread-safe."

A change like this has been suggested in issue "suggested enhancements to CP2K easyblock #1086"