### PR TITLE
Set OpenMPI configuration for orca sanity check

### DIFF
--- a/easybuild/easyblocks/o/orca.py
+++ b/easybuild/easyblocks/o/orca.py
@@ -156,13 +156,16 @@ H   0.7920   0.0000  -0.4973
         test_output_energy = '-75.95934031'
         test_output_regex = 'FINAL SINGLE POINT ENERGY[ \t]*%s' % test_output_energy
 
+        # Instruct openmpi to treat hardware threads as slot
+        test_ompi_env = 'OMPI_MCA_hwloc_base_use_hwthreads_as_cpus=1'
+
         # ORCA has to be executed using its full path to run in parallel
         if os.path.isdir(os.path.join(self.installdir, 'bin')):
             orca_bin = '$EBROOTORCA/bin/orca'
         else:
             orca_bin = '$(which orca)'
 
-        test_orca_cmd = "%s %s" % (orca_bin, test_input_path)
+        test_orca_cmd = "%s %s %s" % (test_ompi_env, orca_bin, test_input_path)
 
         custom_commands = [
             # Execute test in ORCA

--- a/easybuild/easyblocks/o/orca.py
+++ b/easybuild/easyblocks/o/orca.py
@@ -157,7 +157,7 @@ H   0.7920   0.0000  -0.4973
         test_output_regex = 'FINAL SINGLE POINT ENERGY[ \t]*%s' % test_output_energy
 
         # Instruct openmpi to treat hardware threads as slot
-        test_ompi_env = 'OMPI_MCA_hwloc_base_use_hwthreads_as_cpus=1'
+        test_ompi_env = 'env OMPI_MCA_hwloc_base_use_hwthreads_as_cpus=1'
 
         # ORCA has to be executed using its full path to run in parallel
         if os.path.isdir(os.path.join(self.installdir, 'bin')):


### PR DESCRIPTION
This should fix OpenMPI errors during the orca sanity check, when hyperthreading is enabled but OpenMPI is not configured to count the hyperthreads as slot.
Error message on a system with 32 cores / 64 hardware threads
```
There are not enough slots available in the system to satisfy the 64
slots that were requested by the application
```

This error did not happen when building with slurm.