### PR TITLE
enhance PETSc easyblock to run tests in parallel

### DIFF
--- a/easybuild/easyblocks/p/petsc.py
+++ b/easybuild/easyblocks/p/petsc.py
@@ -306,7 +306,6 @@ class EB_PETSc(ConfigureMake):
         if self.cfg['test_parallel'] is None and self.cfg['parallel']:
             self.cfg['test_parallel'] = self.cfg['parallel']
 
-
         # PETSc > 3.5, make does not accept -j
         # to control parallel build, we need to specify MAKE_NP=... as argument to 'make' command
         if LooseVersion(self.version) >= LooseVersion("3.5"):


### PR DESCRIPTION
The PETSc test suite can run in parallel by passing a `-j <n>` (see https://petsc4py.readthedocs.io/en/stable/manual/tests/) but the previous EasyBlock would just run things serially.

I've tested with 64 tasks (on a 128 core node), which speeds up the test suite from about 3.5 hours to about 30 mins. On another 16-core node, with 16 tasks, it was even down to 17 minutes (probably faster filesystem)