### PR TITLE
derive custom easyblock from MotionCor2 from PackedBinary instead of EasyBlock

### DIFF
--- a/easybuild/easyblocks/m/motioncor2.py
+++ b/easybuild/easyblocks/m/motioncor2.py
@@ -33,13 +33,13 @@ import os
 import stat
 
 from distutils.version import LooseVersion
-from easybuild.framework.easyblock import EasyBlock
+from easybuild.easyblocks.generic.packedbinary import PackedBinary
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import adjust_permissions, copy_file, mkdir, write_file
 from easybuild.tools.modules import get_software_root
 
 
-class EB_MotionCor2(EasyBlock):
+class EB_MotionCor2(PackedBinary):
     """
     Support for installing MotionCor2
      - creates wrapper that loads the correct version of CUDA before
@@ -76,14 +76,6 @@ class EB_MotionCor2(EasyBlock):
                 else:
                     self.motioncor2_bin = 'MotionCor2_%s-Cuda%s' % (self.motioncor2_verstring, cuda_short_ver)
                 break
-
-    def configure_step(self):
-        """No configuration, this is binary software"""
-        pass
-
-    def build_step(self):
-        """No compilation, this is binary software"""
-        pass
 
     def install_step(self):
         """


### PR DESCRIPTION
Using PackedBinary for MotionCor2.
This is a follow-up to the discussion in #2541, and in particular comment https://github.com/easybuilders/easybuild-easyblocks/pull/2541#discussion_r714825070