### PR TITLE
skip motorBike tutorial case in OpenFOAM sanity check if available cores < 6

### DIFF
--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -526,7 +526,7 @@ class EB_OpenFOAM(EasyBlock):
                 else:
                     # Ensure we log the fact the check was skipped somewhere
                     custom_commands.append(
-                        "echo 'motorBike tutorial case was skipped due to insufficient CPU cores available (%d < 6).'" 
+                        "echo 'motorBike tutorial case was skipped due to insufficient CPU cores available (%d < 6).'"
                         % os.cpu_count()
                     )
 

--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -492,7 +492,8 @@ class EB_OpenFOAM(EasyBlock):
             # check to fail.  Only attempt to run it if there are 6 (or more) cores available.
             if os.cpu_count() >= 6:
                 openfoamdir_path = os.path.join(self.installdir, self.openfoamdir)
-                motorbike_path = os.path.join(openfoamdir_path, 'tutorials', 'incompressible', 'simpleFoam', 'motorBike')
+                motorbike_path = os.path.join(openfoamdir_path, 'tutorials', 'incompressible', 'simpleFoam',
+                                              'motorBike')
                 if os.path.exists(motorbike_path):
                     test_dir = tempfile.mkdtemp()
 
@@ -524,7 +525,10 @@ class EB_OpenFOAM(EasyBlock):
                     custom_commands.append(' && '.join(cmds))
                 else:
                     # Ensure we log the fact the check was skipped somewhere
-                    custom_commands.append("echo 'motorBike tutorial case was skipped due to insufficient CPU cores available (%d < 6).'" % os.cpu_count())
+                    custom_commands.append(
+                        "echo 'motorBike tutorial case was skipped due to insufficient CPU cores available (%d < 6).'" 
+                        % os.cpu_count()
+                    )
 
         super(EB_OpenFOAM, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
 


### PR DESCRIPTION
The tutorial is hardcoded to use exactly 6 cores, so the sanity check will always fail if there are fewer cores than this available locally (even if there is no problem with the build).  Problem occurs with both foss and intel toolchains (I've not tested any others).

This change only attempts to run that case as a test if there are 6 or more cores locally.

Closes easybuilders/easybuild-easyconfigs#14291