### PR TITLE
Ambertools support

### DIFF
--- a/easybuild/easyblocks/a/amber.py
+++ b/easybuild/easyblocks/a/amber.py
@@ -164,12 +164,18 @@ class EB_Amber(CMakeMake):
             external_libs_list.append('netcdf')
         if get_software_root('netCDF-Fortran'):
             external_libs_list.append('netcdf-fortran')
+            netcdf_fortran_root = get_software_root('netCDF-Fortran')
+            self.cfg.update('configopts', '-DNetCDF_INCLUDES=%s/include' % netcdf_fortran_root)
         if get_software_root('zlib'):
             external_libs_list.append('zlib')
         if get_software_root('Boost'):
             external_libs_list.append('boost')
         if get_software_root('PnetCDF'):
             external_libs_list.append('pnetcdf')
+
+        # Force to use BLAS and LAPACK from environment variables
+        self.cfg.update('configopts', '-DBLAS_LIBRARIES="%s"' % os.getenv('LIBBLAS'))
+        self.cfg.update('configopts', '-DLAPACK_LIBRARIES="%s"' % os.getenv('LIBLAPACK'))
 
         # Force libs for available deps (see cmake/3rdPartyTools.cmake in Amber source for list of 3rd party libs)
         # This provides an extra layer of checking but should already be handled by TRUST_SYSTEM_LIBS=TRUE
@@ -187,9 +193,11 @@ class EB_Amber(CMakeMake):
 
         # Amber recommend running the tests from the sources, rather than putting in installation dir
         # due to size. We handle tests under the install step
-        self.cfg.update('configopts', '-DINSTALL_TESTS=FALSE')
+        if "-DINSTALL_TESTS=" not in self.cfg['configopts']:
+            self.cfg.update('configopts', '-DINSTALL_TESTS=FALSE')
 
-        self.cfg.update('configopts', '-DCOMPILER=AUTO')
+        if "-DCOMPILER=" not in self.cfg['configopts']:
+            self.cfg.update('configopts', '-DCOMPILER=AUTO')
 
         # configure using cmake
         super(EB_Amber, self).configure_step()

--- a/easybuild/easyblocks/a/amber.py
+++ b/easybuild/easyblocks/a/amber.py
@@ -323,8 +323,8 @@ class EB_Amber(CMakeMake):
 
         super(EB_Amber, self).install_step()
 
-        # Run the tests located in the build directory
-        if self.cfg['runtest']:
+        # Run the tests located in the build directory, only for Amber. Tests fail when building only AmberTools
+        if self.cfg['runtest'] and self.name == 'Amber':
             pretestcommands = 'source %s/amber.sh && cd %s/test' % (self.installdir, self.builddir)
 
             # serial tests


### PR DESCRIPTION
This PR allows a few tings
1) For my build, CMake failed to find the fortran headers for NetCDF unless I make their location explicit through NetCDF_INCLUDES
2) CMake will not automatically find FlexiBLAS. Defining the libraries 
3) Allows to overwrite the INSTALL_TESTS and COMPILER options. In particular, when compiling with GCC on our stack, if I don't set COMPILER to GNU, disable `usempi` (to get serial compilers for serial code) and enable MPI through the CMake option, it fails to build. 
4) Disable tests when building AmberTools, as not all the binaries are included. 