### PR TITLE
add option to control MKL-DNN in jaxlib easyblock

### DIFF
--- a/easybuild/easyblocks/j/jaxlib.py
+++ b/easybuild/easyblocks/j/jaxlib.py
@@ -34,6 +34,7 @@ import tempfile
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage
+from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option
 from easybuild.tools.filetools import apply_regex_substitutions, which
@@ -53,6 +54,11 @@ class EB_jaxlib(PythonPackage):
         # Run custom build script and install the generated whl file
         extra_vars['buildcmd'][0] = '%(python)s build/build.py'
         extra_vars['install_src'][0] = 'dist/*.whl'
+
+        # Custom parameters
+        extra_vars.update({
+            'use_mkl_dnn': [True, "Enable support for Intel MKL-DNN", CUSTOM],
+        })
 
         return extra_vars
 
@@ -123,6 +129,11 @@ class EB_jaxlib(PythonPackage):
             config_env_vars['GCC_HOST_COMPILER_PATH'] = which(os.getenv('CC'))
         else:
             options.append('--noenable_cuda')
+
+        if self.cfg['use_mkl_dnn']:
+            options.append('--enable_mkl_dnn')
+        else:
+            options.append('--noenable_mkl_dnn')
 
         # Prepend to buildopts so users can overwrite this
         self.cfg['buildopts'] = ' '.join(

--- a/easybuild/easyblocks/j/jaxlib.py
+++ b/easybuild/easyblocks/j/jaxlib.py
@@ -27,6 +27,7 @@ EasyBlock for installing jaxlib, implemented as an easyblock
 
 @author: Denis Kristak (INUITS)
 @author: Alexander Grund (TU Dresden)
+@author: Alex Domingo (Vrije Universiteit Brussel)
 """
 
 import os
@@ -42,6 +43,7 @@ from easybuild.tools.config import build_option
 from easybuild.tools.filetools import apply_regex_substitutions, which
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
+
 
 class EB_jaxlib(PythonPackage):
     """Support for installing jaxlib. Extension of the existing PythonPackage easyblock"""

--- a/easybuild/easyblocks/j/jaxlib.py
+++ b/easybuild/easyblocks/j/jaxlib.py
@@ -32,6 +32,8 @@ EasyBlock for installing jaxlib, implemented as an easyblock
 import os
 import tempfile
 
+from distutils.version import LooseVersion
+
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage
 from easybuild.framework.easyconfig import CUSTOM
@@ -40,7 +42,6 @@ from easybuild.tools.config import build_option
 from easybuild.tools.filetools import apply_regex_substitutions, which
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
-
 
 class EB_jaxlib(PythonPackage):
     """Support for installing jaxlib. Extension of the existing PythonPackage easyblock"""
@@ -120,11 +121,12 @@ class EB_jaxlib(PythonPackage):
                 '--cudnn_version=' + cudnn_version,
             ])
 
-            nccl_root = get_software_root('NCCL')
-            if nccl_root:
-                options.append('--enable_nccl')
-            else:
-                options.append('--noenable_nccl')
+            if LooseVersion(self.version) >= LooseVersion('0.1.70'):
+                nccl_root = get_software_root('NCCL')
+                if nccl_root:
+                    options.append('--enable_nccl')
+                else:
+                    options.append('--noenable_nccl')
 
             config_env_vars['GCC_HOST_COMPILER_PATH'] = which(os.getenv('CC'))
         else:

--- a/easybuild/easyblocks/j/jaxlib.py
+++ b/easybuild/easyblocks/j/jaxlib.py
@@ -35,8 +35,10 @@ import tempfile
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.config import build_option
 from easybuild.tools.filetools import apply_regex_substitutions, which
 from easybuild.tools.modules import get_software_root, get_software_version
+from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
 
 
 class EB_jaxlib(PythonPackage):
@@ -69,13 +71,18 @@ class EB_jaxlib(PythonPackage):
 
         # Collect options for the build script
         # Used only by the build script
-        options = [
-            '--target_cpu_features=default',  # Using copt for optimizations
-        ]
+
+        # C++ flags are set through copt below
+        if build_option('optarch') == OPTARCH_GENERIC:
+            options = ['--target_cpu_features=default']
+        else:
+            options = ['--target_cpu_features=native']
+
         # Passed directly to bazel
         bazel_startup_options = [
             '--output_user_root=%s' % tempfile.mkdtemp(suffix='-bazel', dir=self.builddir),
         ]
+
         # Passed to the build command of bazel
         bazel_options = [
             '--jobs=%s' % self.cfg['parallel'],

--- a/easybuild/easyblocks/j/jaxlib.py
+++ b/easybuild/easyblocks/j/jaxlib.py
@@ -39,10 +39,8 @@ import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.config import build_option
 from easybuild.tools.filetools import apply_regex_substitutions, which
 from easybuild.tools.modules import get_software_root, get_software_version
-from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
 
 
 class EB_jaxlib(PythonPackage):
@@ -82,10 +80,7 @@ class EB_jaxlib(PythonPackage):
         # Used only by the build script
 
         # C++ flags are set through copt below
-        if build_option('optarch') == OPTARCH_GENERIC:
-            options = ['--target_cpu_features=default']
-        else:
-            options = ['--target_cpu_features=native']
+        options = ['--target_cpu_features=default']
 
         # Passed directly to bazel
         bazel_startup_options = [


### PR DESCRIPTION
A few enhancements to the jaxlib easyblock:
* ~~use native CPU features for non-generic builds in EasyBuild~~
* add extra parameter to control the use of Intel's MKL-DNN
* only set support for NCCL starting from version 0.1.170