### PR TITLE
update PyTorch easyblock to avoid RPATH linking to CUDA stubs library in libcaffe2_nvrtc.so

### DIFF
--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -234,10 +234,11 @@ class EB_PyTorch(PythonPackage):
         self.cfg.update('preinstallopts', ' '.join(unique_options) + ' ')
 
     def build_step(self):
-        if build_option('rpath'):
-            # instruct CMake not to fiddle with RPATH when --rpath is used, since it will undo stuff on install...
-            # https://github.com/LLNL/spack/blob/0f6a5cd38538e8969d11bd2167f11060b1f53b43/lib/spack/spack/build_environment.py#L416
-            env.setvar("CMAKE_SKIP_RPATH", 'ON')
+        # instruct CMake not to fiddle with RPATH when --rpath is used, since it will undo stuff on install...
+        # https://github.com/LLNL/spack/blob/0f6a5cd38538e8969d11bd2167f11060b1f53b43/lib/spack/spack/build_environment.py#L416
+        # We do this unconditionally here, since PyTorch sets problematic RPATH/RUNPATHs regardless of whether --rpath is used in EasyBuild
+        # See https://github.com/easybuilders/easybuild-easyconfigs/issues/14359
+        env.setvar("CMAKE_SKIP_RPATH", 'ON')
         super(EB_PyTorch, self).build_step()
 
     def test_step(self):

--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -234,10 +234,10 @@ class EB_PyTorch(PythonPackage):
         self.cfg.update('preinstallopts', ' '.join(unique_options) + ' ')
 
     def build_step(self):
-        # instruct CMake not to fiddle with RPATH when --rpath is used, since it will undo stuff on install...
-        # https://github.com/LLNL/spack/blob/0f6a5cd38538e8969d11bd2167f11060b1f53b43/lib/spack/spack/build_environment.py#L416
-        # We do this unconditionally here, since PyTorch sets problematic RPATH/RUNPATHs regardless of whether --rpath is used in EasyBuild
-        # See https://github.com/easybuilders/easybuild-easyconfigs/issues/14359
+        # We set CMAKE_SKIP_RPATH, since PyTorch sets problematic RPATH/RUNPATHs,
+        # regardless of whether --rpath is used in EasyBuild
+        # See https://github.com/easybuilders/easybuild-easyconfigs/issues/14359 and
+        # https://github.com/pytorch/pytorch/issues/35418
         env.setvar("CMAKE_SKIP_RPATH", 'ON')
         super(EB_PyTorch, self).build_step()
 

--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -238,7 +238,7 @@ class EB_PyTorch(PythonPackage):
         # regardless of whether --rpath is used in EasyBuild
         # See https://github.com/easybuilders/easybuild-easyconfigs/issues/14359 and
         # https://github.com/pytorch/pytorch/issues/35418
-        env.setvar("CMAKE_SKIP_RPATH", 'ON')
+        env.setvar("CMAKE_INSTALL_RPATH_USE_LINK_PATH", "FALSE")
         super(EB_PyTorch, self).build_step()
 
     def test_step(self):

--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -233,6 +233,13 @@ class EB_PyTorch(PythonPackage):
         self.cfg.update('prebuildopts', ' '.join(unique_options) + ' ')
         self.cfg.update('preinstallopts', ' '.join(unique_options) + ' ')
 
+    def build_step(self):
+        if build_option('rpath'):
+            # instruct CMake not to fiddle with RPATH when --rpath is used, since it will undo stuff on install...
+            # https://github.com/LLNL/spack/blob/0f6a5cd38538e8969d11bd2167f11060b1f53b43/lib/spack/spack/build_environment.py#L416
+            env.setvar("CMAKE_SKIP_RPATH", 'ON')
+        super(EB_PyTorch, self).build_step()
+
     def test_step(self):
         """Run unit tests"""
         # Make PyTorch tests not use the user home


### PR DESCRIPTION
Set `CMAKE_SKIP_RPATH=ON` for all PyTorch builds. This avoids the issue described at https://github.com/easybuilders/easybuild-easyconfigs/issues/14359

Note that the `cmakemake.py` EasyBlock sets `CMAKE_SKIP_RPATH=ON` _only_ when `--rpath` is used. We don't use the same condition here, but _always_ set it, since regardless of whether `--rpath` is used, the PyTorch build will get an `RPATH` set due the CMAKE configuration set here https://github.com/pytorch/pytorch/blob/36449ea93134574c2a22b87baad3de0bf8d64d42/cmake/Dependencies.cmake#L16
This will result in the `libcaffe2_nvrtc.so` picking up on the CUDA `stubs` library, rather than the _actual_ driver.