### PR TITLE
remove newline from package description (required to avoid installati…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     version=str(VERSION),
     author="EasyBuild community",
     author_email="easybuild@lists.ugent.be",
-    description="""Python modules which implement support for installing particular
+    description="""Python modules which implement support for installing particular \
  (groups of) software packages with EasyBuild.""",
     license="GPLv2",
     keywords="software build building installation installing compilation HPC scientific",


### PR DESCRIPTION
…on error with setuptools>=59.0.0)

Fix for error that is raised by `setuptools` 59.0.0 or newer (see https://github.com/pypa/setuptools/pull/2870)

```
$ pip3 install easybuild-easyblocks==4.4.2
...   
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-256ka0gi/easybuild-easyblocks/setup.py'"'"'; __file__='"'"'/tmp/pip-install-256ka0gi/easybuild-easyblocks/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-256ka0gi/easybuild-easyblocks/pip-egg-info
         cwd: /tmp/pip-install-256ka0gi/easybuild-easyblocks/
    Complete output (25 lines):
    Installing version 4.4.1 (required versions: API >= 4)
    running egg_info
    creating /tmp/pip-install-256ka0gi/easybuild-easyblocks/pip-egg-info/easybuild_easyblocks.egg-info
    writing /tmp/pip-install-256ka0gi/easybuild-easyblocks/pip-egg-info/easybuild_easyblocks.egg-info/PKG-INFO
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-256ka0gi/easybuild-easyblocks/setup.py", line 56, in <module>
        setup(
      File "/usr/lib/python3.8/distutils/core.py", line 148, in setup
        dist.run_commands()
      File "/usr/lib/python3.8/distutils/dist.py", line 966, in run_commands
        self.run_command(cmd)
      File "/usr/lib/python3.8/distutils/dist.py", line 985, in run_command
        cmd_obj.run()
      File "/usr/local/lib/python3.8/dist-packages/setuptools/command/egg_info.py", line 292, in run
        writer(self, ep.name, os.path.join(self.egg_info, ep.name))
      File "/usr/local/lib/python3.8/dist-packages/setuptools/command/egg_info.py", line 656, in write_pkg_info
        metadata.write_pkg_info(cmd.egg_info)
      File "/usr/lib/python3.8/distutils/dist.py", line 1117, in write_pkg_info
        self.write_pkg_file(pkg_info)
      File "/usr/local/lib/python3.8/dist-packages/setuptools/dist.py", line 167, in write_pkg_file
        write_field('Summary', single_line(self.get_description()))
      File "/usr/local/lib/python3.8/dist-packages/setuptools/dist.py", line 151, in single_line
        raise ValueError('Newlines are not allowed')
    ValueError: Newlines are not allowed
```

(reported by @sassy-crick)