### PR TITLE
fix quotes in definition of default platform macro and enhance sanity check in GATE easyblock

### DIFF
--- a/easybuild/easyblocks/g/gate.py
+++ b/easybuild/easyblocks/g/gate.py
@@ -214,4 +214,5 @@ class EB_GATE(CMakeMake):
             'files': [os.path.join('bin', subdir, 'Gate')] + extra_files,
             'dirs': dirs,
         }
-        super(EB_GATE, self).sanity_check_step(custom_paths=custom_paths)
+        custom_commands = ["gjs -h | grep 'This executable is compiled with %s as default'" % self.cfg['default_platform']]
+        super(EB_GATE, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)

--- a/easybuild/easyblocks/g/gate.py
+++ b/easybuild/easyblocks/g/gate.py
@@ -214,5 +214,6 @@ class EB_GATE(CMakeMake):
             'files': [os.path.join('bin', subdir, 'Gate')] + extra_files,
             'dirs': dirs,
         }
-        custom_commands = ["gjs -h | grep 'This executable is compiled with %s as default'" % self.cfg['default_platform']]
+        custom_commands = ["gjs -h | grep 'This executable is compiled with %s as default'" \
+                           % self.cfg['default_platform']]
         super(EB_GATE, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)

--- a/easybuild/easyblocks/g/gate.py
+++ b/easybuild/easyblocks/g/gate.py
@@ -88,7 +88,7 @@ class EB_GATE(CMakeMake):
 
         # redefine $CFLAGS/$CXXFLAGS via options to build command ('make')
         cflags = os.getenv('CFLAGS')
-        cxxflags = "%s -DGC_DEFAULT_PLATFORM=\\'%s\\'" % (os.getenv('CXXFLAGS'), self.cfg['default_platform'])
+        cxxflags = "%s -DGC_DEFAULT_PLATFORM='\\\"%s\\\"'" % (os.getenv('CXXFLAGS'), self.cfg['default_platform'])
         if self.toolchain.comp_family() in [toolchain.INTELCOMP]:
             # make sure GNU macros are defined by Intel compiler
             cflags += " -gcc"

--- a/easybuild/easyblocks/g/gate.py
+++ b/easybuild/easyblocks/g/gate.py
@@ -214,6 +214,6 @@ class EB_GATE(CMakeMake):
             'files': [os.path.join('bin', subdir, 'Gate')] + extra_files,
             'dirs': dirs,
         }
-        custom_commands = ["gjs -h | grep 'This executable is compiled with %s as default'" \
+        custom_commands = ["gjs -h | grep 'This executable is compiled with %s as default'"
                            % self.cfg['default_platform']]
         super(EB_GATE, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)


### PR DESCRIPTION
The final macro definition passed to the `make` command should look like `-DGC_DEFAULT_PLATFORM='\"openPBS\"'` and not like `-DGC_DEFAULT_PLATFORM=\'openPBS\'`. So, I changed the arrangement of quotes and added double quotes.