### PR TITLE
Update Siesta EasyBlock to use serial FFTW

### DIFF
--- a/easybuild/easyblocks/s/siesta.py
+++ b/easybuild/easyblocks/s/siesta.py
@@ -87,7 +87,8 @@ class EB_Siesta(ConfigureMake):
         lapack = os.environ['LIBLAPACK' + env_var_suff]
         blas = os.environ['LIBBLAS' + env_var_suff]
         if get_software_root('imkl') or get_software_root('FFTW'):
-            fftw = os.environ['LIBFFT' + env_var_suff]
+            # the only module that uses FFTW is STM and it explicitly wants a non-MPI version
+            fftw = os.environ['LIBFFT_MT']
         else:
             fftw = None
 


### PR DESCRIPTION
The only module of Siesta that uses FFTW is STM, and 
`./Util/STM/ol-stm/Src/Makefile` 
explicitly mentions: 
```
  19 #
  20 #  If your main Siesta build used an mpi compiler, you might need to
  21 #  define an FC_SERIAL symbol in your top arch.make, to avoid linking
  22 #  in the mpi libraries even if we explicitly undefine MPI below.
  23 #
``` 

Using `LIBFFT` contains `-lfftw3_mpi`, which will fail to link when compiled by a serial compiler. 

`fftw` should be set to `LIBFFT_MT` and not `LIBFFT` 

@akesandgren @dithwick 