### PR TITLE
also run easyblocks test suite with Python 3.8-3.10 + consistently us…

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,7 +7,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -5,12 +5,12 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python: [2.7, 3.5, 3.6, 3.7]
+        python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
         modules_tool: [Lmod-6.6.3, Lmod-7.8.22, Lmod-8.1.14, modules-tcl-1.147, modules-3.2.10, modules-4.1.4]
         module_syntax: [Lua, Tcl]
         # exclude some configuration for non-Lmod modules tool:
         # - don't test with Lua module syntax (only supported in Lmod)
-        # - don't test with Python 3.5 and 3.7 (only with 2.7 and 3.6), to limit test configurations
+        # - don't test with Python 3.5 and 3.7+ (only with 2.7 and 3.6), to limit test configurations
         exclude:
           - modules_tool: modules-tcl-1.147
             module_syntax: Lua
@@ -22,20 +22,38 @@ jobs:
             python: 3.5
           - modules_tool: modules-tcl-1.147
             python: 3.7
+          - modules_tool: modules-tcl-1.147
+            python: 3.8
+          - modules_tool: modules-tcl-1.147
+            python: 3.9
+          - modules_tool: modules-tcl-1.147
+            python: '3.10'
           - modules_tool: modules-3.2.10
             python: 3.5
           - modules_tool: modules-3.2.10
             python: 3.7
+          - modules_tool: modules-3.2.10
+            python: 3.8
+          - modules_tool: modules-3.2.10
+            python: 3.9
+          - modules_tool: modules-3.2.10
+            python: '3.10'
           - modules_tool: modules-4.1.4
             python: 3.5
           - modules_tool: modules-4.1.4
             python: 3.7
+          - modules_tool: modules-4.1.4
+            python: 3.8
+          - modules_tool: modules-4.1.4
+            python: 3.9
+          - modules_tool: modules-4.1.4
+            python: '3.10'
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
 
     - name: set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.python}}
         architecture: x64

--- a/test/easyblocks/module.py
+++ b/test/easyblocks/module.py
@@ -200,7 +200,7 @@ class ModuleOnlyTest(TestCase):
             (r'^prepend.path.*\WLIBRARY_PATH\W.*lib"?\W*$', True),
             (r'^prepend.path.*\WPATH\W.*bin"?\W*$', True),
             (r'^prepend.path.*\WPKG_CONFIG_PATH\W.*lib64/pkgconfig"?\W*$', True),
-            (r'^prepend.path.*\WPYTHONPATH\W.*lib/python[23]\.[0-9]/site-packages"?\W*$', True),
+            (r'^prepend.path.*\WPYTHONPATH\W.*lib/python[23]\.[0-9]+/site-packages"?\W*$', True),
             # lib64 doesn't contain any library files, so these are *not* included in $LD_LIBRARY_PATH or $LIBRARY_PATH
             (r'^prepend.path.*\WLD_LIBRARY_PATH\W.*lib64', False),
             (r'^prepend.path.*\WLIBRARY_PATH\W.*lib64', False),


### PR DESCRIPTION
…e actions/setup-python@v2 in CI workflows