### PR TITLE
add support to NAMD easyblock to opt out of building with CUDA support even if CUDA is included as dependency

### DIFF
--- a/easybuild/easyblocks/n/namd.py
+++ b/easybuild/easyblocks/n/namd.py
@@ -45,7 +45,7 @@ class EB_NAMD(MakeCp):
             'charm_arch': [None, "Charm++ target architecture", MANDATORY],
             'charm_extra_cxxflags': ['', "Extra C++ compiler options to use for building Charm++", CUSTOM],
             'charm_opts': ['--with-production', "Charm++ build options", CUSTOM],
-            'cuda': [True, "Enable CUDA build if CUDA is among the dependencies", CUSTOM],
+            'cuda': [None, "Enable CUDA build if CUDA is among the dependencies", CUSTOM],
             'namd_basearch': [None, "NAMD base target architecture (compiler family is appended)", CUSTOM],
             'namd_cfg_opts': ['', "NAMD configure options", CUSTOM],
             'runtest': [True, "Run NAMD test case after building", CUSTOM],
@@ -153,10 +153,12 @@ class EB_NAMD(MakeCp):
 
         # NAMD dependencies: CUDA, TCL, FFTW
         cuda = get_software_root('CUDA')
-        if cuda and self.cfg['cuda']:
+        if cuda and (self.cfg['cuda'] is None or self.cfg['cuda']):
             self.cfg.update('namd_cfg_opts', "--with-cuda --cuda-prefix %s" % cuda)
+        elif not self.cfg['cuda']:
+            self.log.warning("CUDA is disabled")
         elif not cuda and self.cfg['cuda']:
-            self.log.warning("CUDA is not a dependency, but support for CUDA is enabled (default). Silently ignoring.")
+            raise EasyBuildError("CUDA is not a dependency, but support for CUDA is enabled.")
 
         tcl = get_software_root('Tcl')
         if tcl:

--- a/easybuild/easyblocks/n/namd.py
+++ b/easybuild/easyblocks/n/namd.py
@@ -45,6 +45,7 @@ class EB_NAMD(MakeCp):
             'charm_arch': [None, "Charm++ target architecture", MANDATORY],
             'charm_extra_cxxflags': ['', "Extra C++ compiler options to use for building Charm++", CUSTOM],
             'charm_opts': ['--with-production', "Charm++ build options", CUSTOM],
+            'cuda': [True, "Enable CUDA build if CUDA is among the dependencies", CUSTOM],
             'namd_basearch': [None, "NAMD base target architecture (compiler family is appended)", CUSTOM],
             'namd_cfg_opts': ['', "NAMD configure options", CUSTOM],
             'runtest': [True, "Run NAMD test case after building", CUSTOM],
@@ -152,8 +153,10 @@ class EB_NAMD(MakeCp):
 
         # NAMD dependencies: CUDA, TCL, FFTW
         cuda = get_software_root('CUDA')
-        if cuda:
+        if cuda and self.cfg['cuda']:
             self.cfg.update('namd_cfg_opts', "--with-cuda --cuda-prefix %s" % cuda)
+        elif not cuda and self.cfg['cuda']:
+            self.log.warning("CUDA is not a dependency, but support for CUDA is enabled (default). Silently ignoring.")
 
         tcl = get_software_root('Tcl')
         if tcl:


### PR DESCRIPTION
Useful when CUDA is part of the dependencies (like when included by MPI
or any other dependency), but we don't want to build Charm++ with CUDA
support