### PR TITLE
remove vulnerable binaries from sanity check of HDF5, no longer installed by default with HDF5 1.10.8

### DIFF
--- a/easybuild/easyblocks/h/hdf5.py
+++ b/easybuild/easyblocks/h/hdf5.py
@@ -125,9 +125,10 @@ class EB_HDF5(ConfigureMake):
         else:
             extra_binaries = ["h5cc", "h5fc"]
 
-        h5binaries = ["2gif", "c++", "copy", "debug", "diff", "dump", "import", "jam", "ls", "mkgrp", "perf_serial",
+        h5binaries = ["c++", "copy", "debug", "diff", "dump", "import", "jam", "ls", "mkgrp", "perf_serial",
                       "redeploy", "repack", "repart", "stat", "unjam"]
-        binaries = ["h5%s" % x for x in h5binaries] + ["gif2h5"] + extra_binaries
+        binaries = ["h5%s" % x for x in h5binaries] + extra_binaries
+
         shlib_ext = get_shared_lib_ext()
         libs = ["libhdf5%s.%s" % (lib, shlib_ext) for lib in ['', '_cpp', '_fortran', '_hl_cpp', '_hl', 'hl_fortran']]
         custom_paths = {


### PR DESCRIPTION
The gif tools in HDF5 are no longer built by default due to multiple CVEs.
See https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.8/src/hdf5-1.10.8-RELEASE.txt

Since the build of the affected tools can still be enabled by the user with `--enable-hltools`, I propose to not check either their presence or absence in the sanity checks.

* Failed test with current easyblock in https://github.com/easybuilders/easybuild-easyconfigs/pull/14894#issuecomment-1027396917
* Successful test with this PR in https://github.com/easybuilders/easybuild-easyconfigs/pull/14894#issuecomment-1027457330
