### PR TITLE
enable system SSL certificates in OpenSSL installations

### DIFF
--- a/easybuild/easyblocks/o/openssl.py
+++ b/easybuild/easyblocks/o/openssl.py
@@ -153,4 +153,8 @@ class EB_OpenSSL(ConfigureMake):
 
         custom_paths['dirs'].append(os.path.join(lib_dir, engines_dir))
 
+        # add SSL certificates
+        if self.ssl_certs_dir:
+            custom_paths['dirs'].append('ssl/certs')
+
         super(EB_OpenSSL, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/o/openssl.py
+++ b/easybuild/easyblocks/o/openssl.py
@@ -37,7 +37,7 @@ from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import CUSTOM
-from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.build_log import EasyBuildError, print_warning
 from easybuild.tools.filetools import remove_dir, symlink
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
@@ -125,9 +125,11 @@ class EB_OpenSSL(ConfigureMake):
         openssl_certs_dir = os.path.join(self.installdir, 'ssl', 'certs')
 
         if self.ssl_certs_dir:
-            # symlink the provided certificates by the user
             remove_dir(openssl_certs_dir)
             symlink(self.ssl_certs_dir, openssl_certs_dir)
+        else:
+            print_warning("OpenSSL successfully installed without system SSL certificates. "
+                          "Some packages might experience limited functionality.")
 
     def sanity_check_step(self):
         """Custom sanity check"""

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -222,7 +222,7 @@ class EB_OpenSSL_wrapper(Bundle):
         self.log.debug("Found the following include directories in host system: %s", ', '.join(sys_include_dirs))
 
         # headers are located in 'include/openssl' by default
-        ssl_include_subdirs = [self.name.lower()]
+        ssl_include_subdirs = ['openssl']
         if self.majmin_version == '1.1':
             # but version 1.1 can be installed in 'include/openssl11/openssl' as well, for example in CentOS 7
             # prefer 'include/openssl' as long as the version of headers matches
@@ -267,7 +267,7 @@ class EB_OpenSSL_wrapper(Bundle):
             self.system_ssl['bin'] = which('openssl11')
 
         if not self.system_ssl['bin']:
-            self.system_ssl['bin'] = which(self.name.lower())
+            self.system_ssl['bin'] = which('openssl')
 
         if self.system_ssl['bin']:
             self.log.info("System OpenSSL binary found: %s", self.system_ssl['bin'])

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -256,8 +256,10 @@ class EB_OpenSSL_wrapper(Bundle):
                 self.log.info("System OpenSSL header file %s not found", opensslv_path)
 
         if not self.system_ssl['include']:
-            self.log.info("OpenSSL headers not found in host system, falling back to OpenSSL in EasyBuild")
-            return
+            err_msg = ("OpenSSL v%s headers not found in host system, but libraries for v%s are present. "
+                       "Install the development package of OpenSSL for your system or force building OpenSSL from "
+                       "source in EasyBuild by setting 'wrap_system_openssl = False' in the OpenSSL easyconfig.")
+            raise EasyBuildError(err_msg, self.version, self.system_ssl['version'])
 
         # Check system OpenSSL binary
         if self.majmin_version == '1.1':


### PR DESCRIPTION
fixes #2674, fixes https://github.com/easybuilders/easybuild-easyconfigs/issues/14901

Changelog:
* make OpenSSL wrapper to error out instead of building OpenSSL from source if the only missing pieces in the system are the header files. On error, inform the user to either install the development package of openssl in the system or force the installation from source in EasyBuild with `wrap_system_openssl`
* symlink system certificates (if present) in the installation directory of OpenSSL whenever it is build from source
* add `ssl_certificates` option to `openssl` easyblock to define the path to system certificates
* update sanity checks in openssl easyblock: remove hardcoded library extensions, remove checks for `lib` and `lib64` (now EB installs both), add checks on `ssl/certs` whenever certificates are symlinked

The link to the system certificates is determined in the following order:
* use `ssl_certificates` path if defined
* fall back to `OPENSSLDIR` from system openssl
* fall back to generic path in `GENERIC_SSL_CERTS_DIR`
* fall back to installation without certificates and print warning informing the user