### PR TITLE
enhance Gurobi easyblock to also update $MATLABPATH

### DIFF
--- a/easybuild/easyblocks/g/gurobi.py
+++ b/easybuild/easyblocks/g/gurobi.py
@@ -79,7 +79,7 @@ class EB_Gurobi(Tarball):
         """Custom sanity check for Gurobi."""
         custom_paths = {
             'files': ['bin/%s' % f for f in ['grbprobe', 'grbtune', 'gurobi_cl', 'gurobi.sh']],
-            'dirs': [],
+            'dirs': ['matlab'],
         }
 
         custom_commands = [
@@ -100,5 +100,7 @@ class EB_Gurobi(Tarball):
 
         if get_software_root('Python'):
             txt += self.module_generator.prepend_paths('PYTHONPATH', det_pylibdir())
+
+        txt += self.module_generator.prepend_paths('MATLABPATH', 'matlab')
 
         return txt


### PR DESCRIPTION
It's quite popular used in MATLAB as well. 
No need to have MATLAB as a main dependency though, since it's just optional, but it's still convenient to set the MATLABPATH for when it's used there.