### PR TITLE
force use of bash for Anaconda install script

### DIFF
--- a/easybuild/easyblocks/a/anaconda.py
+++ b/easybuild/easyblocks/a/anaconda.py
@@ -48,7 +48,8 @@ class EB_Anaconda(Binary):
 
         adjust_permissions(os.path.join(self.builddir, install_script), stat.S_IRUSR | stat.S_IXUSR)
 
-        cmd = "%s ./%s -p %s -b -f" % (self.cfg['preinstallopts'], install_script, self.installdir)
+        # Anacondas own install instructions specify "bash [script]" despite using different shebangs
+        cmd = "%s bash ./%s -p %s -b -f" % (self.cfg['preinstallopts'], install_script, self.installdir)
         self.log.info("Installing %s using command '%s'..." % (self.name, cmd))
         run_cmd(cmd, log_all=True, simple=True)
 


### PR DESCRIPTION
This was broken on Ubuntu and other OS's that doesn't alias /bin/sh to /bin/bash

edit (by @boegel): fixes this issue (reproduced on Ubuntu 20.04):
```
done
installation finished.
./Anaconda3-2021.11-Linux-x86_64.sh: 516: Syntax error: "(" unexpected (expecting ")")
```