### PR TITLE
build single-file shared libraries for imkl so it can be used as FlexiBLAS backend via $FLEXIBLAS_LIBRARY_PATH

### DIFF
--- a/easybuild/easyblocks/f/flexiblas.py
+++ b/easybuild/easyblocks/f/flexiblas.py
@@ -35,9 +35,15 @@ from easybuild.tools import toolchain
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option
 from easybuild.tools.environment import setvar
+from easybuild.tools.filetools import write_file
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
 
+IMKL_CONF_TEMPLATE = """[IMKL]
+library = libflexiblas_imkl_%(parallel)s_thread.so
+[IMKL_SEQ]
+library = libflexiblas_imkl_sequential.so
+"""
 
 class EB_FlexiBLAS(CMakeMake):
     """Support for building/installing FlexiBLAS."""
@@ -51,7 +57,8 @@ class EB_FlexiBLAS(CMakeMake):
             'flexiblas_default': [None, "Default BLAS lib to set at compile time. If not defined, " +
                                   "the first BLAS lib in backends or the list of dependencies is set as default",
                                   CUSTOM],
-            'backends': [None, "List of (build)dependency names to use as BLAS library backends. " +
+            'backends': [None, "List of (build)dependency names to use as BLAS library backends, or " +
+                         "'imkl', which does not need to be a (build)dependency." +
                          "If not defined, use the list of dependencies.", CUSTOM],
         })
         extra_vars['separate_build_dir'][0] = True
@@ -63,8 +70,10 @@ class EB_FlexiBLAS(CMakeMake):
 
         dep_names = [dep['name'] for dep in self.cfg.dependencies()]
         if self.cfg['backends']:
-            self.blas_libs = self.cfg['backends']
-            # make sure that all listed backends are (build)dependencies
+            self.blas_libs = self.cfg['backends'][:]
+            # make sure that all listed backends except imkl are (build)dependencies
+            if 'imkl' in self.blas_libs and 'imkl' not in dep_names:
+                self.blas_libs.remove('imkl')
             backends_nodep = [x for x in self.blas_libs if x not in dep_names]
             if backends_nodep:
                 raise EasyBuildError("One or more backends not listed as (build)dependencies: %s",
@@ -136,6 +145,18 @@ class EB_FlexiBLAS(CMakeMake):
             self.cfg['abs_path_compilers'] = True
 
         super(EB_FlexiBLAS, self).configure_step(builddir=self.obj_builddir)
+
+    def install_step(self):
+        """Install imkl configuration, found via FLEXIBLAS_LIBRARY_PATH set by imkl module."""
+
+        super(EB_FlexiBLAS, self).install_step()
+        if self.cfg['backends'] and 'imkl' in self.cfg['backends'] and 'imkl' not in self.blas_libs:
+            if self.toolchain.comp_family() == toolchain.GCC:
+                parallel = "gnu"
+            else:
+                parallel = "intel"
+            write_file(os.path.join(self.installdir, 'etc', 'flexiblasrc.d', 'imkl.conf'),
+                       IMKL_CONF_TEMPLATE % {'parallel': parallel})
 
     def test_step(self):
         """Run tests using each of the backends."""

--- a/easybuild/easyblocks/f/flexiblas.py
+++ b/easybuild/easyblocks/f/flexiblas.py
@@ -45,6 +45,7 @@ library = libflexiblas_imkl_%(parallel)s_thread.so
 library = libflexiblas_imkl_sequential.so
 """
 
+
 class EB_FlexiBLAS(CMakeMake):
     """Support for building/installing FlexiBLAS."""
 

--- a/easybuild/easyblocks/i/imkl.py
+++ b/easybuild/easyblocks/i/imkl.py
@@ -64,7 +64,7 @@ class EB_imkl(IntelBase):
         """Add easyconfig parameters custom to imkl (e.g. interfaces)."""
         extra_vars = {
             'interfaces': [True, "Indicates whether interfaces should be built", CUSTOM],
-            'flexiblas': [True, "Indicates whether FlexiBLAS-compatible libraries should be built", CUSTOM],
+            'flexiblas': [None, "Indicates whether FlexiBLAS-compatible libraries should be built (default for versions >= 2021)", CUSTOM],
         }
         return IntelBase.extra_options(extra_vars)
 
@@ -79,8 +79,12 @@ class EB_imkl(IntelBase):
 
         if LooseVersion(self.version) >= LooseVersion('2021'):
             self.mkl_basedir = os.path.join('mkl', self.version)
+            if self.cfg['flexiblas'] is None:
+                self.cfg['flexiblas'] = True
         else:
             self.mkl_basedir = 'mkl'
+            if self.cfg['flexiblas'] is None:
+                self.cfg['flexiblas'] = False
 
     def prepare_step(self, *args, **kwargs):
         """Prepare build environment."""

--- a/easybuild/easyblocks/i/imkl.py
+++ b/easybuild/easyblocks/i/imkl.py
@@ -64,7 +64,8 @@ class EB_imkl(IntelBase):
         """Add easyconfig parameters custom to imkl (e.g. interfaces)."""
         extra_vars = {
             'interfaces': [True, "Indicates whether interfaces should be built", CUSTOM],
-            'flexiblas': [None, "Indicates whether FlexiBLAS-compatible libraries should be built (default for versions >= 2021)", CUSTOM],
+            'flexiblas': [None, "Indicates whether FlexiBLAS-compatible libraries should be built, "
+                          "default from version 2021", CUSTOM],
         }
         return IntelBase.extra_options(extra_vars)
 

--- a/easybuild/easyblocks/i/imkl.py
+++ b/easybuild/easyblocks/i/imkl.py
@@ -441,7 +441,7 @@ class EB_imkl(IntelBase):
             libs += self.get_mkl_fftw_interface_libs()
 
         if self.cfg['flexiblas']:
-            libs += [os.path.join('flexiblas', 'libflexiblas_imkl_%s.so'%thread)
+            libs += [os.path.join('flexiblas', 'libflexiblas_imkl_%s.so' % thread)
                      for thread in ['gnu_thread', 'intel_thread', 'sequential']]
 
         if ver >= LooseVersion('10.3') and self.cfg['m32']:


### PR DESCRIPTION
By building FlexiBLAS compatible libraries and pointing FLEXIBLAS_LIBRARY_PATH to them on the imkl side and creating a configuration file on the FlexiBLAS side, FlexiBLAS no longer needs imkl as a (build)dependency.