### PR TITLE
remove system-compiled binutils dirs from $LDFLAGS in binutils easyblock

### DIFF
--- a/easybuild/easyblocks/b/binutils.py
+++ b/easybuild/easyblocks/b/binutils.py
@@ -108,6 +108,15 @@ class EB_binutils(ConfigureMake):
         else:
             libs = []
 
+        binutilsroot = get_software_root('binutils')
+        if binutilsroot:
+            # Remove LDFLAGS that start with '-L' + binutilsroot, since we don't
+            # want to link libraries from binutils compiled with the system toolchain
+            # into binutils binaries compiled with a compiler toolchain.
+            ldflags = os.getenv('LDFLAGS').split(' ')
+            ldflags = [p for p in ldflags if not p.startswith('-L' + binutilsroot)]
+            env.setvar('LDFLAGS', ' '.join(ldflags))
+
         # configure using `--with-system-zlib` if zlib is a (build) dependency
         zlibroot = get_software_root('zlib')
         if zlibroot:


### PR DESCRIPTION
Various binutils binaries were linked with both libiberty from
binutils compiled with the system toolchain and libiberty from
binutils compiled with a compiler toolchain.

The gold linker allows this but ld.bfd does not, and it's not
a good thing to do in any case. Removing -L$EBROOTBINUTILS/lib*
from LDFLAGS fixes this issue.

edit (by @boegel): just to make this PR easy to find in case people hit the problem this is causing, here's the error message you get without this change (harvested from a test report in https://github.com/easybuilders/easybuild-easyconfigs/pull/15311#issuecomment-1107448963):

```
/project/def-maintainers/boegelbot/Rocky8/zen2/software/binutils/2.38/bin/ld: ../libiberty/libiberty.a(concat.o): in function `concat_length':
concat.c:(.text+0x0): multiple definition of `concat_length'; /project/def-maintainers/boegelbot/Rocky8/zen2/software/binutils/2.38/lib64/libiberty.a(concat.o):/tmp/boegelbot/binutils/2.38/system-system/binutils-2.38/libiberty/./concat.c:91: first defined here
/project/def-maintainers/boegelbot/Rocky8/zen2/software/binutils/2.38/bin/ld: ../libiberty/libiberty.a(concat.o): in function `concat_copy':
concat.c:(.text+0xb0): multiple definition of `concat_copy'; /project/def-maintainers/boegelbot/Rocky8/zen2/software/binutils/2.38/lib64/libiberty.a(concat.o):/tmp/boegelbot/binutils/2.38/system-system/binutils-2.38/libiberty/./concat.c:106: first defined here
/project/def-maintainers/boegelbot/Rocky8/zen2/software/binutils/2.38/bin/ld: ../libiberty/libiberty.a(concat.o): in function `concat_copy2':
concat.c:(.text+0x190): multiple definition of `concat_copy2'; /project/def-maintainers/boegelbot/Rocky8/zen2/software/binutils/2.38/lib64/libiberty.a(concat.o):/tmp/boegelbot/binutils/2.38/system-system/binutils-2.38/libiberty/./concat.c:130: first defined here
/project/def-maintainers/boegelbot/Rocky8/zen2/software/binutils/2.38/bin/ld: ../libiberty/libiberty.a(concat.o): in function `concat':
concat.c:(.text+0x260): multiple definition of `concat'; /project/def-maintainers/boegelbot/Rocky8/zen2/software/binutils/2.38/lib64/libiberty.a(concat.o):/tmp/boegelbot/binutils/2.38/system-system/binutils-2.38/libiberty/./concat.c:141: first defined here
/project/def-maintainers/boegelbot/Rocky8/zen2/software/binutils/2.38/bin/ld: ../libiberty/libiberty.a(concat.o): in function `reconcat':
concat.c:(.text+0x3e0): multiple definition of `reconcat'; /project/def-maintainers/boegelbot/Rocky8/zen2/software/binutils/2.38/lib64/libiberty.a(concat.o):/tmp/boegelbot/binutils/2.38/system-system/binutils-2.38/libiberty/./concat.c:178: first defined here
/project/def-maintainers/boegelbot/Rocky8/zen2/software/binutils/2.38/bin/ld: ../libiberty/libiberty.a(xexit.o): in function `xexit':
xexit.c:(.text+0x0): multiple definition of `xexit'; /project/def-maintainers/boegelbot/Rocky8/zen2/software/binutils/2.38/lib64/libiberty.a(xexit.o):/tmp/boegelbot/binutils/2.38/system-system/binutils-2.38/libiberty/./xexit.c:48: first defined here
collect2: error: ld returned 1 exit status
make[4]: *** [Makefile:1049: readelf] Error 1
```