### PR TITLE
Adapt header file check on R for versions >= 4.2.0 (S.h)

### DIFF
--- a/easybuild/easyblocks/r/r.py
+++ b/easybuild/easyblocks/r/r.py
@@ -126,10 +126,12 @@ class EB_R(ConfigureMake):
 
         libfiles = [os.path.join('include', x) for x in ['Rconfig.h', 'Rdefines.h', 'Rembedded.h',
                                                          'R.h', 'Rinterface.h', 'Rinternals.h',
-                                                         'Rmath.h', 'Rversion.h', 'S.h']]
+                                                         'Rmath.h', 'Rversion.h']]
         modfiles = ['internet.%s' % shlib_ext, 'lapack.%s' % shlib_ext]
         if LooseVersion(self.version) < LooseVersion('3.2'):
             modfiles.append('vfonts.%s' % shlib_ext)
+        if LooseVersion(self.version) < LooseVersion('4.2'):
+            libfiles += [os.path.join('include', 'S.h')]
         libfiles += [os.path.join('modules', x) for x in modfiles]
         libfiles += ['lib/libR.%s' % shlib_ext]
 


### PR DESCRIPTION
Starting R 4.2.0 the header file `S.h` has been removed  from the sources[C-Level facilities changes](https://cran.r-project.org/bin/windows/base/NEWS.R-devel.html). 

This PR just adds the `S.h` header check for older versions but removes it for `4.2` onwards.