### PR TITLE
fix for FreeSurfer easyblock: define $FREESURFER needed by recon_all

### DIFF
--- a/easybuild/easyblocks/f/freesurfer.py
+++ b/easybuild/easyblocks/f/freesurfer.py
@@ -67,6 +67,7 @@ class EB_FreeSurfer(Tarball):
             'FS_OVERRIDE': '0',
             'FSF_OUTPUT_FORMAT': 'nii.gz',
             'FSFAST_HOME': os.path.join(self.installdir, 'fsfast'),
+            'FREESURFER': self.installdir,
             'FREESURFER_HOME': self.installdir,
             'FUNCTIONALS_DIR': os.path.join(self.installdir, 'sessions'),
             'MNI_DIR': os.path.join(self.installdir, 'mni'),


### PR DESCRIPTION
tool `recon_all`, part of freesurfer needs env variable FREESURFER:
```shell
3028     set cmd = ($cmd -ctab $FREESURFER/SubCorticalMassLUT.txt)
```
this variable is set in original setup by `$FREESURFER_HOME/FreeSurferEnv.sh`:
```shell
468 # set FREESURFER to match FREESURFER_HOME
469 export FREESURFER=$FREESURFER_HOME
```
this env variable was not set when using lmod software module generated with easybuild which caused errors when using `recon_all`.

This PR fixes that.