### PR TITLE
don't hard override post_install_step in Clang easyblock, but extend it by calling out to parent easyblock first

### DIFF
--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -486,7 +486,9 @@ class EB_Clang(CMakeMake):
 
     def post_install_step(self):
         """Install python bindings."""
-        # do it in post_install_step so that it is not done more than once in multi_deps context
+        super(EB_Clang, self).post_install_step()
+
+        # copy Python bindings here in post-install step so that it is not done more than once in multi_deps context
         if self.cfg['python_bindings']:
             python_bindings_source_dir = os.path.join(self.llvm_src_dir, "tools", "clang", "bindings", "python")
             python_bindins_target_dir = os.path.join(self.installdir, 'lib', 'python')


### PR DESCRIPTION
`post_install_step` was redefined in #2721 by @mboisson to support installing Clang with Python bindings, but the default implementation of `post_install_step` in `EasyBlock` does a bunch of (potentially) useful things that we should keep doing...

See also https://github.com/easybuilders/easybuild-framework/blob/4c3b0522f6d2df50078a563f0161ba18b767851f/easybuild/framework/easyblock.py#L2861