### PR TITLE
Change in cudnnarch string templates used to compose source tarball names from cuDNN 8.3.3 onwards

### DIFF
--- a/easybuild/easyblocks/c/cudnn.py
+++ b/easybuild/easyblocks/c/cudnn.py
@@ -44,9 +44,10 @@ class EB_cuDNN(Tarball):
         # Need to call super's init first, so we can use self.version
         super(EB_cuDNN, self).__init__(*args, **kwargs)
 
-        # Generated cudnnarch template value for this system
+        # Generate cudnnarch template value for this system
+        cudnnarch = False    
         myarch = get_cpu_architecture()
-        # Strings needed for tarballs downloaded from https://developer.download.nvidia.com/compute/redist/cudnn/
+
         if LooseVersion(self.version) < LooseVersion('8.3.3'):
             if myarch == AARCH64:
                 cudnnarch = 'aarch64sbsa'
@@ -54,10 +55,6 @@ class EB_cuDNN(Tarball):
                 cudnnarch = 'ppc64le'
             elif myarch == X86_64:
                 cudnnarch = 'x64'
-            else:
-                raise EasyBuildError("Architecture %s is not supported for cuDNN on EasyBuild", myarch)
-        # Strings needed for manually downloaded tarballs, as sources are no longer present at
-        # https://developer.download.nvidia.com/compute/redist/cudnn/ from 8.3.3 onwards
         else:
             if myarch == AARCH64:
                 cudnnarch = 'sbsa'
@@ -65,9 +62,9 @@ class EB_cuDNN(Tarball):
                 cudnnarch = 'ppc64le'
             elif myarch == X86_64:
                 cudnnarch = 'x86_64'
-            else:
-                raise EasyBuildError("Architecture %s is not supported for cuDNN on EasyBuild", myarch)
 
+        if not cudnnarch:
+            raise EasyBuildError("The cuDNN easyblock does not currently support architecture %s", myarch)
         self.cfg['keepsymlinks'] = True
         self.cfg.template_values['cudnnarch'] = cudnnarch
         self.cfg.generate_template_values()

--- a/easybuild/easyblocks/c/cudnn.py
+++ b/easybuild/easyblocks/c/cudnn.py
@@ -45,7 +45,7 @@ class EB_cuDNN(Tarball):
         super(EB_cuDNN, self).__init__(*args, **kwargs)
 
         # Generate cudnnarch template value for this system
-        cudnnarch = False    
+        cudnnarch = False
         myarch = get_cpu_architecture()
 
         if LooseVersion(self.version) < LooseVersion('8.3.3'):


### PR DESCRIPTION
Sources are not available from https://developer.download.nvidia.com…/compute/redist/cudnn/ for cudnn 8.3.3 onwards. This might be temporary, but at least blocks adoption of newer cuDNN versions in EasyBuild. This commit implements support for generating source template names for the manually downloaded sources from https://developer.nvidia.com/rdp/cudnn-download for those versions. We could revert this change if the sources are ever still put on .../redist/cudnn/ again in the future.