### PR TITLE
update libQGLViewer easyblock to take into account changes in the shared library names depending on Qt versions they are compiled with

### DIFF
--- a/easybuild/easyblocks/l/libqglviewer.py
+++ b/easybuild/easyblocks/l/libqglviewer.py
@@ -67,7 +67,8 @@ class EB_libQGLViewer(ConfigureMake):
                     addition = '-' + addition
             custom_paths = {
                 'files': [('lib/libQGLViewer'+addition+'.prl', 'lib64/libQGLViewer'+addition+'.prl'),
-                          ('lib/libQGLViewer'+addition+'.%s' % shlib_ext, 'lib64/libQGLViewer'+addition+'.%s' % shlib_ext)],
+                          ('lib/libQGLViewer'+addition+'.%s' % shlib_ext, 'lib64/libQGLViewer'+addition+'.%s' \
+                                  % shlib_ext)],
                 'dirs': ['include/QGLViewer'],
             }
 

--- a/easybuild/easyblocks/l/libqglviewer.py
+++ b/easybuild/easyblocks/l/libqglviewer.py
@@ -31,6 +31,7 @@ EasyBuild support for building and installing libQGLViewer, implemented as an ea
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
+from easybuild.tools.modules import get_software_root
 from distutils.version import LooseVersion
 
 
@@ -61,10 +62,13 @@ class EB_libQGLViewer(ConfigureMake):
             }
         else:
             addition = ''
-            for dep in self.cfg.dependencies():
-                if (dep['name'][0] == 'Q' and dep['name'][1] == 't'):
-                    addition = dep['name'].lower()
+            for dep in ['Qt5', 'Qt6']:
+                if get_software_root(dep):
+                    addition = dep.lower()
                     addition = '-' + addition
+                    break
+            else:
+                raise EasyBuildError("Missing Qt5 or Qt6 dependency")
             custom_paths = {
                 'files': [('lib/libQGLViewer'+addition+'.prl', 'lib64/libQGLViewer'+addition+'.prl'),
                           ('lib/libQGLViewer'+addition+'.%s' % shlib_ext, \

--- a/easybuild/easyblocks/l/libqglviewer.py
+++ b/easybuild/easyblocks/l/libqglviewer.py
@@ -32,6 +32,7 @@ from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
 from easybuild.tools.modules import get_software_root
+from easybuild.tools.build_log import EasyBuildError
 from distutils.version import LooseVersion
 
 
@@ -71,8 +72,8 @@ class EB_libQGLViewer(ConfigureMake):
                 raise EasyBuildError("Missing Qt5 or Qt6 dependency")
             custom_paths = {
                 'files': [('lib/libQGLViewer'+addition+'.prl', 'lib64/libQGLViewer'+addition+'.prl'),
-                          ('lib/libQGLViewer'+addition+'.%s' % shlib_ext, \
-                               'lib64/libQGLViewer'+addition+'.%s' % shlib_ext)],
+                          ('lib/libQGLViewer'+addition+'.%s' % shlib_ext,
+                              'lib64/libQGLViewer'+addition+'.%s' % shlib_ext)],
                 'dirs': ['include/QGLViewer'],
             }
 

--- a/easybuild/easyblocks/l/libqglviewer.py
+++ b/easybuild/easyblocks/l/libqglviewer.py
@@ -56,25 +56,21 @@ class EB_libQGLViewer(ConfigureMake):
         From version 2.8.0 onwards qt version also gets added to the lib file names.
         """
         if LooseVersion(self.version) < LooseVersion("2.8.0"):
-            custom_paths = {
-                'files': [('lib/libQGLViewer.prl', 'lib64/libQGLViewer.prl'),
-                          ('lib/libQGLViewer.%s' % shlib_ext, 'lib64/libQGLViewer.%s' % shlib_ext)],
-                'dirs': ['include/QGLViewer'],
-            }
+            suffix = ''
         else:
-            addition = ''
+            suffix = ''
             for dep in ['Qt5', 'Qt6']:
                 if get_software_root(dep):
-                    addition = dep.lower()
-                    addition = '-' + addition
+                    suffix = dep.lower()
+                    suffix = '-' + suffix
                     break
             else:
                 raise EasyBuildError("Missing Qt5 or Qt6 dependency")
-            custom_paths = {
-                'files': [('lib/libQGLViewer'+addition+'.prl', 'lib64/libQGLViewer'+addition+'.prl'),
-                          ('lib/libQGLViewer'+addition+'.%s' % shlib_ext,
-                              'lib64/libQGLViewer'+addition+'.%s' % shlib_ext)],
-                'dirs': ['include/QGLViewer'],
-            }
+        custom_paths = {
+            'files': [('lib/libQGLViewer'+suffix+'.prl', 'lib64/libQGLViewer'+suffix+'.prl'),
+                      ('lib/libQGLViewer'+suffix+'.%s' % shlib_ext,
+                       'lib64/libQGLViewer'+suffix+'.%s' % shlib_ext)],
+            'dirs': ['include/QGLViewer'],
+        }
 
         super(EB_libQGLViewer, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/l/libqglviewer.py
+++ b/easybuild/easyblocks/l/libqglviewer.py
@@ -67,8 +67,8 @@ class EB_libQGLViewer(ConfigureMake):
                     addition = '-' + addition
             custom_paths = {
                 'files': [('lib/libQGLViewer'+addition+'.prl', 'lib64/libQGLViewer'+addition+'.prl'),
-                          ('lib/libQGLViewer'+addition+'.%s' % shlib_ext, 'lib64/libQGLViewer'+addition+'.%s' \
-                                  % shlib_ext)],
+                          ('lib/libQGLViewer'+addition+'.%s' % shlib_ext, \
+                               'lib64/libQGLViewer'+addition+'.%s' % shlib_ext)],
                 'dirs': ['include/QGLViewer'],
             }
 

--- a/easybuild/easyblocks/l/libqglviewer.py
+++ b/easybuild/easyblocks/l/libqglviewer.py
@@ -58,11 +58,9 @@ class EB_libQGLViewer(ConfigureMake):
         if LooseVersion(self.version) < LooseVersion("2.8.0"):
             suffix = ''
         else:
-            suffix = ''
             for dep in ['Qt5', 'Qt6']:
                 if get_software_root(dep):
-                    suffix = dep.lower()
-                    suffix = '-' + suffix
+                    suffix = '-' + dep.lower()
                     break
             else:
                 raise EasyBuildError("Missing Qt5 or Qt6 dependency")

--- a/easybuild/easyblocks/l/libqglviewer.py
+++ b/easybuild/easyblocks/l/libqglviewer.py
@@ -31,7 +31,6 @@ EasyBuild support for building and installing libQGLViewer, implemented as an ea
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
-from easybuild.tools.modules import get_software_root, get_software_version
 from distutils.version import LooseVersion
 
 
@@ -55,20 +54,21 @@ class EB_libQGLViewer(ConfigureMake):
         From version 2.8.0 onwards qt version also gets added to the lib file names.
         """
         if LooseVersion(self.version) < LooseVersion("2.8.0"):
-        	custom_paths = {
-            	'files': [('lib/libQGLViewer.prl', 'lib64/libQGLViewer.prl'),
-            	          ('lib/libQGLViewer.%s' % shlib_ext, 'lib64/libQGLViewer.%s' % shlib_ext)],
-            	'dirs': ['include/QGLViewer'],
-        	}
+            custom_paths = {
+                'files': [('lib/libQGLViewer.prl', 'lib64/libQGLViewer.prl'),
+                          ('lib/libQGLViewer.%s' % shlib_ext, 'lib64/libQGLViewer.%s' % shlib_ext)],
+                'dirs': ['include/QGLViewer'],
+            }
         else:
-                for dep in self.cfg.dependencies():
-                       if (dep['name'][0] == 'Q' and dep['name'][1] == 't'):
-                            addition = dep['name'].lower()
-                addition = '-' + addition
-                custom_paths = {
-            	'files': [('lib/libQGLViewer'+addition+'.prl', 'lib64/libQGLViewer'+addition+'.prl'),
-            	          ('lib/libQGLViewer'+addition+'.%s' % shlib_ext, 'lib64/libQGLViewer'+addition+'.%s' % shlib_ext)],
-            	'dirs': ['include/QGLViewer'],
-        	}
+            addition = ''
+            for dep in self.cfg.dependencies():
+                if (dep['name'][0] == 'Q' and dep['name'][1] == 't'):
+                    addition = dep['name'].lower()
+                    addition = '-' + addition
+            custom_paths = {
+                'files': [('lib/libQGLViewer'+addition+'.prl', 'lib64/libQGLViewer'+addition+'.prl'),
+                          ('lib/libQGLViewer'+addition+'.%s' % shlib_ext, 'lib64/libQGLViewer'+addition+'.%s' % shlib_ext)],
+                'dirs': ['include/QGLViewer'],
+            }
 
         super(EB_libQGLViewer, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/l/libqglviewer.py
+++ b/easybuild/easyblocks/l/libqglviewer.py
@@ -31,6 +31,8 @@ EasyBuild support for building and installing libQGLViewer, implemented as an ea
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
+from easybuild.tools.modules import get_software_root, get_software_version
+from distutils.version import LooseVersion
 
 
 class EB_libQGLViewer(ConfigureMake):
@@ -49,10 +51,24 @@ class EB_libQGLViewer(ConfigureMake):
     def sanity_check_step(self):
         """Custom sanity check for libQGLViewer."""
         shlib_ext = get_shared_lib_ext()
+        """
+        From version 2.8.0 onwards qt version also gets added to the lib file names.
+        """
+        if LooseVersion(self.version) < LooseVersion("2.8.0"):
+        	custom_paths = {
+            	'files': [('lib/libQGLViewer.prl', 'lib64/libQGLViewer.prl'),
+            	          ('lib/libQGLViewer.%s' % shlib_ext, 'lib64/libQGLViewer.%s' % shlib_ext)],
+            	'dirs': ['include/QGLViewer'],
+        	}
+        else:
+                for dep in self.cfg.dependencies():
+                       if (dep['name'][0] == 'Q' and dep['name'][1] == 't'):
+                            addition = dep['name'].lower()
+                addition = '-' + addition
+                custom_paths = {
+            	'files': [('lib/libQGLViewer'+addition+'.prl', 'lib64/libQGLViewer'+addition+'.prl'),
+            	          ('lib/libQGLViewer'+addition+'.%s' % shlib_ext, 'lib64/libQGLViewer'+addition+'.%s' % shlib_ext)],
+            	'dirs': ['include/QGLViewer'],
+        	}
 
-        custom_paths = {
-            'files': [('lib/libQGLViewer.prl', 'lib64/libQGLViewer.prl'),
-                      ('lib/libQGLViewer.%s' % shlib_ext, 'lib64/libQGLViewer.%s' % shlib_ext)],
-            'dirs': ['include/QGLViewer'],
-        }
         super(EB_libQGLViewer, self).sanity_check_step(custom_paths=custom_paths)


### PR DESCRIPTION
For the newer versions of libQGLviewer the qt versions are also included in the library names, therefore sanity check needs to be modified.