### PR TITLE
Don't allow an easyblock that overrides `run_all_steps()` to be used in a bundle

### DIFF
--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -114,7 +114,7 @@ class Bundle(EasyBlock):
             comp_cfg['version'] = comp_version
 
             # determine easyblock to use for this component
-            # - if an easyblock is specified explicitely, that will be used
+            # - if an easyblock is specified explicitly, that will be used
             # - if not, a software-specific easyblock will be considered by get_easyblock_class
             # - if no easyblock was found, default_easyblock is considered
             comp_easyblock = comp_specs.get('easyblock')
@@ -134,6 +134,10 @@ class Bundle(EasyBlock):
 
             if easyblock == 'Bundle':
                 raise EasyBuildError("The Bundle easyblock can not be used to install components in a bundle")
+
+            if easyblock_class.run_all_steps.__code__ is not EasyBlock.run_all_steps.__code__:
+                raise EasyBuildError("Easyblock %s overrides the run_all_steps() method and can not be used to install "
+                                     "a component in a bundle", easyblock)
 
             comp_cfg.easyblock = easyblock_class
 


### PR DESCRIPTION
Can be tested with an extended dry run (`-x`) and the example easyconfig
```
easyblock = 'Bundle'

name = 'GROMACS'
version = '2020.2'

homepage = 'http://www.gromacs.org'

description = 'GROMACS default_easyblock test'

toolchain = {'name': 'intel', 'version': '2020a'}
toolchainopts = {'openmp': True, 'usempi': True}

dependencies = [
    ('CUDA', '11.4.1', '', True)
]

source_urls = ['ftp://ftp.gromacs.org/pub/gromacs/']

default_easyblock = 'CMakeMake'

default_component_specs = {
    'sources':   [SOURCELOWER_TAR_GZ],
    'checksums': [ '7465e4cd616359d84489d919ec9e4b1aaf51f0a4296e693c249e83411b7bd2f3'],
    'separate_build_dir': False,
    'preconfigopts' : '( [ -f CMakeCache.txt ] && /bin/rm CMakeCache.txt ) ; ' +
                      '( [ -f Makefile ] && make clean ) ; ' ,
    'buildopts' : 'all check -j ',
    'start_dir':   '%(namelower)s-%(version)s',
}

components = [
    ('GROMACS', version, {
        'easyblock': 'CMakeMake',
        'configopts': "-DGMX_MPI=OFF -DGMX_THREAD_MPI=ON  -DGMX_DOUBLE=OFF ",
    }),
    ('GROMACS', version, {
        # 'easyblock': 'CMakeMake',
        'configopts': "-DGMX_MPI=ON  -DGMX_THREAD_MPI=OFF -DGMX_DOUBLE=OFF ",
    }),
]

modextravars = {
    'GROMACS_DIR': "%(installdir)s",
    'GMXBIN':      "%(installdir)s/bin",
    'GMXLDLIB':    "%(installdir)s/lib64",
    'GMXMAN':      "%(installdir)s/share/man",
    'GMXDATA':     "%(installdir)s/share/data",
}

moduleclass = 'bio'
```