### PR TITLE
make VEP easyblock compatible with --sanity-check-only

### DIFF
--- a/easybuild/easyblocks/v/vep.py
+++ b/easybuild/easyblocks/v/vep.py
@@ -30,6 +30,7 @@ import os
 import easybuild.tools.environment as env
 from easybuild.easyblocks.perl import get_major_perl_version
 from easybuild.framework.easyblock import EasyBlock
+from easybuild.tools.build_log import print_warning
 from easybuild.tools.filetools import apply_regex_substitutions
 from easybuild.tools.modules import get_software_version, get_software_root
 from easybuild.tools.run import run_cmd
@@ -115,11 +116,22 @@ class EB_VEP(EasyBlock):
         }
 
         if 'Bio::EnsEMBL::XS' in [ext[0] for ext in self.cfg['exts_list']]:
-            perl_majver = get_major_perl_version()
-            perl_ver = get_software_version('Perl')
-            perl_libpath = os.path.join('lib', 'perl' + perl_majver, 'site_perl', perl_ver)
-            bio_ensembl_xs_ext = os.path.join(perl_libpath, 'x86_64-linux-thread-multi', 'Bio', 'EnsEMBL', 'XS.pm')
-            custom_paths['files'].extend([bio_ensembl_xs_ext])
+            # determine Perl version used as dependency;
+            # take into account that Perl module may not be loaded, for example when --sanity-check-only is used
+            perl_ver = None
+            deps = self.cfg.dependencies()
+            for dep in deps:
+                if dep['name'] == 'Perl':
+                    perl_ver = dep['version']
+                    break
+
+            if perl_ver is None:
+                print_warning("Failed to determine version of Perl dependency!")
+            else:
+                perl_majver = perl_ver.split('.')[0]
+                perl_libpath = os.path.join('lib', 'perl' + perl_majver, 'site_perl', perl_ver)
+                bio_ensembl_xs_ext = os.path.join(perl_libpath, 'x86_64-linux-thread-multi', 'Bio', 'EnsEMBL', 'XS.pm')
+                custom_paths['files'].extend([bio_ensembl_xs_ext])
 
         custom_commands = ['vep --help']
 


### PR DESCRIPTION
Without this fix, `perl_ver` is defined as `None` in `sanity_check_step` when using `--sanity-check-only`, because the module is not loaded yet when `get_software_root('Perl')` is being called.

During an actual build the dependencies are loaded already/still via `prepare_step` at that point...

Fixes this crash when using `--sanity-check-only`:
```
$ eb VEP-105-GCC-11.2.0.eb --sanity-check-only
...

ERROR: Traceback (most recent call last):
  File "/home/example/easybuild/easybuild-framework/easybuild/main.py", line 128, in build_and_install_software
    (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env)
  File "/home/example/easybuild/easybuild-framework/easybuild/framework/easyblock.py", line 4058, in build_and_install_one
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/home/example/easybuild/easybuild-framework/easybuild/framework/easyblock.py", line 3941, in run_all_steps
    self.run_step(step_name, step_methods)
  File "/home/example/easybuild/easybuild-framework/easybuild/framework/easyblock.py", line 3776, in run_step
    step_method(self)()
  File "/home/example/easybuild/easybuild-easyblocks/easybuild/easyblocks/v/vep.py", line 120, in sanity_check_step
    perl_libpath = os.path.join('lib', 'perl' + perl_majver, 'site_perl', perl_ver)
  File "/usr/lib64/python3.6/posixpath.py", line 94, in join
    genericpath._check_arg_types('join', a, *p)
  File "/usr/lib64/python3.6/genericpath.py", line 149, in _check_arg_types
    (funcname, s.__class__.__name__)) from None
TypeError: join() argument must be str or bytes, not 'NoneType'
```