### PR TITLE
update Rosetta easyblock to take into account that $LD_LIBRARY_PATH, $CPATH, $PATH may not be defined

### DIFF
--- a/easybuild/easyblocks/r/rosetta.py
+++ b/easybuild/easyblocks/r/rosetta.py
@@ -121,9 +121,12 @@ class EB_Rosetta(EasyBlock):
         self.log.debug("List of extra environment variables to pass down: %s" % str(env_vars))
 
         # create user.settings file
-        paths = os.getenv('PATH').split(':')
-        ld_library_paths = os.getenv('LD_LIBRARY_PATH').split(':')
-        cpaths = os.getenv('CPATH').split(':')
+        paths = os.getenv('PATH')
+        paths = paths.split(':') if paths else []
+        ld_library_paths = os.getenv('LD_LIBRARY_PATH')
+        ld_library_paths = ld_library_paths.split(':') if ld_library_paths else []
+        cpaths = os.getenv('CPATH')
+        cpaths = cpaths.split(':') if cpaths else []
         flags = [str(f).strip('-') for f in self.toolchain.variables['CXXFLAGS'].copy()]
 
         txt = '\n'.join([


### PR DESCRIPTION
 LD_LIBRARY_PATH, CPATH and PATH are not guaranteed to be defined, calling .split on None results in an error.