### PR TITLE
Allow pybind11 to be installed as an extension

### DIFF
--- a/easybuild/easyblocks/p/pybind11.py
+++ b/easybuild/easyblocks/p/pybind11.py
@@ -91,13 +91,18 @@ class EB_pybind11(CMakePythonPackage):
         # don't add user site directory to sys.path (equivalent to python -s)
         env.setvar('PYTHONNOUSERSITE', '1', verbose=False)
         # Get python includes
-        fake_mod_data = self.load_fake_module(purge=True)
+        if not self.is_extension:
+            # for stand-alone Python package installations (not part of a bundle of extensions),
+            # we need to load the fake module file, otherwise the Python package being installed
+            # is not "in view", and we will overlook missing dependencies...
+            fake_mod_data = self.load_fake_module(purge=True)
         cmd = "%s -c 'import pybind11; print(pybind11.get_include())'" % self.python_cmd
         out, ec = run_cmd(cmd, simple=False)
         if ec:
             raise EasyBuildError("Failed to get pybind11 includes!")
         python_include = out.strip()
-        self.clean_up_fake_module(fake_mod_data)
+        if not self.is_extension:
+            self.clean_up_fake_module(fake_mod_data)
 
         # Check for CMake config and includes
         custom_paths = {

--- a/easybuild/easyblocks/p/pybind11.py
+++ b/easybuild/easyblocks/p/pybind11.py
@@ -92,9 +92,8 @@ class EB_pybind11(CMakePythonPackage):
         env.setvar('PYTHONNOUSERSITE', '1', verbose=False)
         # Get python includes
         if not self.is_extension:
-            # for stand-alone Python package installations (not part of a bundle of extensions),
-            # we need to load the fake module file, otherwise the Python package being installed
-            # is not "in view", and we will overlook missing dependencies...
+            # only load fake module for stand-alone installations (not for extensions),
+            # since for extension the necessary modules should already be loaded at this point
             fake_mod_data = self.load_fake_module(purge=True)
         cmd = "%s -c 'import pybind11; print(pybind11.get_include())'" % self.python_cmd
         out, ec = run_cmd(cmd, simple=False)


### PR DESCRIPTION
This is inspired from PythonPackage's `sanity_check_step`. Without this, the install fails in the sanity check step with 
```
  File "/cvmfs/soft.computecanada.ca/easybuild/site-packages/easybuild-easyblocks/easybuild/easyblocks/p/pybind11.py", line 94, in sanity_check_step
    fake_mod_data = self.load_fake_module(purge=True)
  File "/cvmfs/soft.computecanada.ca/easybuild/site-packages/easybuild-framework/easybuild/framework/easyblock.py", line 1641, in load_fake_module
    fake_mod_path = self.make_module_step(fake=True)
  File "/cvmfs/soft.computecanada.ca/easybuild/site-packages/easybuild-framework/easybuild/framework/easyblock.py", line 3581, in make_module_step
    mod_filepath = self.mod_filepath
AttributeError: 'EB_pybind11' object has no attribute 'mod_filepath'
``` 

For @Micket 