### PR TITLE
make sure that CMakeMakeCp uses correct build dir

### DIFF
--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -92,6 +92,7 @@ class CMakeMake(ConfigureMake):
         """Constructor for CMakeMake easyblock"""
         super(CMakeMake, self).__init__(*args, **kwargs)
         self._lib_ext = None
+        self.separate_build_dir = None
 
     @property
     def lib_ext(self):
@@ -122,7 +123,8 @@ class CMakeMake(ConfigureMake):
         setup_cmake_env(self.toolchain)
 
         if builddir is None and self.cfg.get('separate_build_dir', True):
-            builddir = create_unused_dir(self.builddir, 'easybuild_obj')
+            self.separate_build_dir = create_unused_dir(self.builddir, 'easybuild_obj')
+            builddir = self.separate_build_dir
 
         if builddir:
             mkdir(builddir, parents=True)

--- a/easybuild/easyblocks/generic/cmakemakecp.py
+++ b/easybuild/easyblocks/generic/cmakemakecp.py
@@ -50,5 +50,9 @@ class CMakeMakeCp(CMakeMake, MakeCp):
     def install_step(self):
         """Install by copying specified files and directories."""
         if self.cfg.get('separate_build_dir', False):
-            self.cfg['start_dir'] = os.path.join(self.builddir, 'easybuild_obj')
+            if self.separate_build_dir:
+                self.cfg['start_dir'] = self.separate_build_dir
+            else:
+                self.cfg['start_dir'] = os.path.join(self.builddir, 'easybuild_obj')
+
         return MakeCp.install_step(self)


### PR DESCRIPTION
When the `CMakeMakeCp` easyblock is used to install a bundle component while other components also use the `CMakeMake` easyblock (or one that derives from it), blindly using the `easybuild_obj` build directory is wrong, since that was already created for another component.

The `CMakeMake` easyblock is aware of this, and ensure creating a unique build directory via `create_unused_dir`, but this was not taken into account in the `CMakeMakeCp` easyblock which hardcoded `'easybuild_obj'`...