### PR TITLE
GROMACS with CP2K QM/MM

### DIFF
--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -203,6 +203,8 @@ class EB_GROMACS(CMakeMake):
                 self.cfg.update('configopts', "-DGMX_GPU=OFF")
 
         # CP2K detection
+        # enable CP2K support if CP2K is listed as a dependency
+        # and CP2K support is either explicitly enabled (cp2k = True) or unspecified ('cp2k' not defined)
         cp2k_root = get_software_root('CP2K')
         if self.cfg['cp2k'] and not cp2k_root:
             msg = "The CP2K module needs to be loaded to build GROMACS with CP2K support."
@@ -211,13 +213,11 @@ class EB_GROMACS(CMakeMake):
             self.log.info('CP2K was found, but compilation without CP2K has been requested.')
             cp2k_root = None
 
-        # enable CP2K support if CP2K is listed as a dependency
-        # and CP2K support is either explicitly enabled (cp2k = True) or unspecified ('cp2k' not defined)
-        if cp2k_root and (self.cfg['cp2k'] or self.cfg['cp2k'] is None):
+        if cp2k_root:
             if LooseVersion(self.version) < LooseVersion('2022'):
                 msg = 'CP2K support is only available for GROMACS 2022 and newer.'
                 raise EasyBuildError(msg)
-            elif cp2k_root and LooseVersion(get_software_version('CP2K')) < LooseVersion('8.1'):
+            elif LooseVersion(get_software_version('CP2K')) < LooseVersion('8.1'):
                 msg = 'CP2K support in GROMACS requires CP2K version 8.1 or higher.'
                 raise EasyBuildError(msg)
 

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -543,6 +543,12 @@ class EB_GROMACS(CMakeMake):
                         lib_subdir = os.path.dirname(libpaths[0])[len(self.installdir) + 1:]
                         self.log.info("Found lib subdirectory that contains %s: %s", libname, lib_subdir)
                         break
+                if not self.cfg['build_shared_libs']:
+                    msg = "Found lib subdirectory: %s but it doesn't contain: %s.\n"
+                    msg += "As building shared libs was disabled, this is probably okay."
+                    lib_subdir = libdir
+                    self.log.info(msg, lib_subdir, libname)
+
         if not lib_subdir:
             raise EasyBuildError("Failed to determine lib subdirectory in %s", self.installdir)
 
@@ -641,18 +647,22 @@ class EB_GROMACS(CMakeMake):
         ])
         bin_files.extend([b + suff for b in bins + mpi_bins for suff in suffixes])
 
-        if not self.lib_subdir:
-            self.lib_subdir = self.get_lib_subdir()
-
-        # pkgconfig dir not available for earlier versions, exact version to use here is unclear
-        if LooseVersion(self.version) >= LooseVersion('4.6'):
-            dirs.append(os.path.join(self.lib_subdir, 'pkgconfig'))
-
         custom_paths = {
-            'files': [os.path.join('bin', b) for b in bin_files] +
-            [os.path.join(self.lib_subdir, lib) for lib in lib_files],
-            'dirs': dirs,
+            'files': [os.path.join('bin', b) for b in bin_files],
+            'dirs': dirs
         }
+
+        if self.cfg['build_shared_libs'] or LooseVersion(self.version) <= LooseVersion('2022'):
+            # only if any libs are actually built
+            if not self.lib_subdir:
+                self.lib_subdir = self.get_lib_subdir()
+
+            # pkgconfig dir not available for earlier versions, exact version to use here is unclear
+            if LooseVersion(self.version) >= LooseVersion('4.6'):
+                custom_paths['dirs'].append(os.path.join(self.lib_subdir, 'pkgconfig'))
+
+            custom_paths['files'] = custom_paths['files'] + [os.path.join(self.lib_subdir, lib) for lib in lib_files]
+
         super(EB_GROMACS, self).sanity_check_step(custom_paths=custom_paths)
 
     def run_all_steps(self, *args, **kwargs):


### PR DESCRIPTION
This PR implements building GROMACS with CP2K QM/MM enabled.

As such a version of GROMACS needs to be compiled statically, which doesn't generate any libraries, the sanity_check needs to be adjusted to not expect any libs in such a case.