### PR TITLE
enhance PythonPackage easyblock to make sure all test command output makes it to the EasyBuild log, also when return_output_ec=True

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -685,6 +685,8 @@ class PythonPackage(ExtensionEasyBlock):
 
                 if return_output_ec:
                     (out, ec) = run_cmd(cmd, log_all=False, log_ok=False, simple=False)
+                    # need to log seperately, since log_all and log_ok need to be false to retreive out and ec
+                    self.log.info('cmd "%s" exited with exit code %s and output:\n%s' % (cmd, ec, out))
                 else:
                     run_cmd(cmd, log_all=True, simple=True)
 

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -686,7 +686,7 @@ class PythonPackage(ExtensionEasyBlock):
                 if return_output_ec:
                     (out, ec) = run_cmd(cmd, log_all=False, log_ok=False, simple=False)
                     # need to log seperately, since log_all and log_ok need to be false to retreive out and ec
-                    self.log.info('cmd "%s" exited with exit code %s and output:\n%s' % (cmd, ec, out))
+                    self.log.info("cmd '%s' exited with exit code %s and output:\n%s", cmd, ec, out)
                 else:
                     run_cmd(cmd, log_all=True, simple=True)
 


### PR DESCRIPTION
Currently, the output is not written to the EasyBuild log. The output of the test command is parsed for errors _and that part_ is stored, e.g.

```
== 2022-08-02 11:35:56,516 run.py:233 INFO running cmd: export PYTHONPATH=/scratch-shared/casparl/eb-dilodzki/tmp2w14ksbj/lib/python3.10/site-packages:$PYTHONPATH &&  cd test && PYTHONUNBUFFERED=1 /sw/arch/RHEL8/EB_production/2022/software/Python/3.10.4-GCCcore-11.3.0/bin/python run_test.py --continue-through-error  --verbose -x distributed/elastic/utils/distributed_test distributed/elastic/multiprocessing/api_test distributed/test_distributed_spawn test_optim test_model_dump distributed/fsdp/test_fsdp_memory distributed/fsdp/test_fsdp_overlap
== 2022-08-02 15:55:46,938 run.py:676 INFO parse_log_for_error msg: Command used: export PYTHONPATH=/scratch-shared/casparl/eb-dilodzki/tmp2w14ksbj/lib/python3.10/site-packages:$PYTHONPATH &&  cd test && PYTHONUNBUFFERED=1 /sw/arch/RHEL8/EB_production/2022/software/Python/3.10.4-GCCcore-11.3.0/bin/python run_test.py --continue-through-error  --verbose -x distributed/elastic/utils/distributed_test distributed/elastic/multiprocessing/api_test distributed/test_distributed_spawn test_optim test_model_dump distributed/fsdp/test_fsdp_memory distributed/fsdp/test_fsdp_overlap
== 2022-08-02 15:55:46,983 run.py:678 INFO parse_log_for_error (some may be harmless) regExp (?<![(,-]|\w)(?:error|segmentation fault|failed)(?![(,-]|\.?\w) found:
[W tensorpipe_agent.cpp:726] RPC agent for worker3 encountered error when reading incoming request from worker0: eof (this error originated at tensorpipe/transport/shm/connection_impl.cc:259)
[W tensorpipe_agent.cpp:726] RPC agent for worker1 encountered error when reading incoming request from worker0: eof (this error originated at tensorpipe/transport/shm/connection_impl.cc:259)
[W tensorpipe_agent.cpp:726] RPC agent for worker2 encountered error when reading incoming request from worker0: eof (this error originated at tensorpipe/transport/shm/connection_impl.cc:259)
[W tensorpipe_agent.cpp:726] RPC agent for worker3 encountered error when reading incoming request from worker0: eof (this error originated at tensorpipe/transport/shm/connection_impl.cc:259)
[W tensorpipe_agent.cpp:726] RPC agent for worker2 encountered error when reading incoming request from worker0: eof (this error originated at tensorpipe/transport/shm/connection_impl.cc:259)
ERROR: expected to be in states [<TrainingState_.IDLE: 1>] but current state is TrainingState_.SUMMON_FULL_PARAMS
FSDP throws appropriate error when we wrap multi-device module. ... INFO:torch.testing._internal.common_distributed:Started process 0 with pid 775257
ERROR: expected to be in states [<TrainingState_.IDLE: 1>] but current state is TrainingState_.BACKWARD_PRE
ERROR: expected to be in states [<TrainingState_.IDLE: 1>] but current state is TrainingState_.FORWARD
Test that an error is raised if we attempt to wrap when submodules are ... INFO:torch.testing._internal.common_distributed:Started process 0 with pid 786905
Test that an error is raised if we attempt to wrap when submodules are ... INFO:torch.testing._internal.common_distributed:Started process 0 with pid 786950
Test that an error is raised if we attempt to wrap when submodules are ... INFO:torch.testing._internal.common_distributed:Started process 0 with pid 787005
Test that an error is raised if we attempt to wrap when submodules are ... INFO:torch.testing._internal.common_distributed:Started process 0 with pid 787052
```

but that's not always very useful if you're missing the context. In particular for PyTorch we'd want to have access to the full output in the EasyBuild log, but I imagine the same is true for any other Pythonpackage.