### PR TITLE
fix FFTW.MPI on lib64 distros (such as SUSE) to prevents not found paths

### DIFF
--- a/easybuild/easyblocks/f/fftwmpi.py
+++ b/easybuild/easyblocks/f/fftwmpi.py
@@ -63,9 +63,11 @@ class EB_FFTW_period_MPI(EB_FFTW):
         """Custom post install step for FFTW.MPI"""
 
         # remove everything except include files that are already in non-MPI FFTW dependency.
-        remove(glob.glob(os.path.join(self.installdir, 'lib', 'libfftw.*')) +
-               glob.glob(os.path.join(self.installdir, 'lib', 'libfftw[lf].*')) +
-               [os.path.join(self.installdir, p) for p in ['bin', 'lib/pkgconfig', 'lib/cmake', 'share']])
+        remove(glob.glob(os.path.join(self.installdir, 'lib*', 'libfftw.*')) +
+               glob.glob(os.path.join(self.installdir, 'lib*', 'libfftw[lf].*')) +
+               glob.glob(os.path.join(self.installdir, 'lib*/pkgconfig')) +
+               glob.glob(os.path.join(self.installdir, 'lib*/cmake')) +
+               [os.path.join(self.installdir, p) for p in ['bin', 'share']])
         super(EB_FFTW_period_MPI, self).post_install_step()
 
     def sanity_check_step(self):


### PR DESCRIPTION
deals with this error installing 2022a

```
== FAILED: Installation ended unsuccessfully (build directory: /opt/easybuild/build/FFTWMPI/3.3.10/gompi-2022a): build failed (first 300 chars): Specified path to remove is not an existing file or directory: /
opt/easybuild/software/FFTW.MPI/3.3.10-gompi-2022a/lib/pkgconfig (took 7 mins 2 secs)
```