### PR TITLE
use det_cmake_version function to determine CMake version in CMakeMake generic easyblock

### DIFF
--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -60,7 +60,7 @@ def det_cmake_version():
     cmake_version = get_software_version('CMake')
     if cmake_version is None:
         # also take into account release candidate versions
-        regex = re.compile(r"^cmake version (?P<version>[0-9]\.[0-9a-zA-Z.-]+)$", re.M)
+        regex = re.compile(r"^[cC][mM]ake version (?P<version>[0-9]\.[0-9a-zA-Z.-]+)$", re.M)
 
         cmd = "cmake --version"
         (out, _) = run_cmd(cmd, simple=False, log_ok=False, log_all=False, trace=False)

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -34,12 +34,13 @@ EasyBuild support for software that is configured with CMake, implemented as an 
 @author: Maxime Boissonneault (Compute Canada - Universite Laval)
 """
 import glob
+import re
 import os
 from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import CUSTOM
-from easybuild.tools.build_log import print_warning
+from easybuild.tools.build_log import EasyBuildError, print_warning
 from easybuild.tools.config import build_option
 from easybuild.tools.filetools import change_dir, create_unused_dir, mkdir, which
 from easybuild.tools.environment import setvar
@@ -50,6 +51,26 @@ from easybuild.tools.utilities import nub
 
 
 DEFAULT_CONFIGURE_CMD = 'cmake'
+
+
+def det_cmake_version():
+    """
+    Determine active CMake version.
+    """
+    cmake_version = get_software_version('CMake')
+    if cmake_version is None:
+        # also take into account release candidate versions
+        regex = re.compile(r"^cmake version (?P<version>[0-9]\.[0-9a-zA-Z.-]+)$", re.M)
+
+        cmd = "cmake --version"
+        (out, _) = run_cmd(cmd, simple=False, log_ok=False, log_all=False, trace=False)
+        res = regex.search(out)
+        if res:
+            cmake_version = res.group('version')
+        else:
+            raise EasyBuildError("Failed to determine CMake version from output of '%s': %s", cmd, out)
+
+    return cmake_version
 
 
 def setup_cmake_env(tc):
@@ -217,8 +238,10 @@ class CMakeMake(ConfigureMake):
             if fc:
                 setvar('FC', fc)
 
+        cmake_version = det_cmake_version()
+
         # Flags are read from environment variables already since at least CMake 2.8.0
-        if LooseVersion(get_software_version('CMake')) < LooseVersion('2.8.0') or cache_exists:
+        if LooseVersion(cmake_version) < LooseVersion('2.8.0') or cache_exists:
             env_to_options.update({
                 'CFLAGS': 'CMAKE_C_FLAGS',
                 'CXXFLAGS': 'CMAKE_CXX_FLAGS',

--- a/test/easyblocks/easyblock_specific.py
+++ b/test/easyblocks/easyblock_specific.py
@@ -235,21 +235,28 @@ class EasyBlockSpecificTest(TestCase):
 
         del os.environ['EBVERSIONCMAKE']
 
-        # output of 'cmake --version' as produced by CMake 2.x
+        # output of 'cmake --version' as produced by CMake 2.x < 2.4.0
         write_file(cmake_cmd, textwrap.dedent("""
         #!/bin/bash
-        echo "cmake version 4.5.6"
+        echo "CMake version 2.3.0"
         """))
-        self.assertEqual(det_cmake_version(), '4.5.6')
+        self.assertEqual(det_cmake_version(), '2.3.0')
+
+        # output of 'cmake --version' as produced by CMake 2.x >= 2.4.0
+        write_file(cmake_cmd, textwrap.dedent("""
+        #!/bin/bash
+        echo "cmake version 2.4.1"
+        """))
+        self.assertEqual(det_cmake_version(), '2.4.1')
 
         # output of 'cmake --version' as produced by CMake 3.x
         write_file(cmake_cmd, textwrap.dedent("""
         #!/bin/bash
-        echo "cmake version 7.8.9"
+        echo "cmake version 3.15.3"
         echo ""
         echo "CMake suite maintained and supported by Kitware (kitware.com/cmake)."
         """))
-        self.assertEqual(det_cmake_version(), '7.8.9')
+        self.assertEqual(det_cmake_version(), '3.15.3')
 
         # also consider release candidate versions
         write_file(cmake_cmd, textwrap.dedent("""

--- a/test/easyblocks/easyblock_specific.py
+++ b/test/easyblocks/easyblock_specific.py
@@ -29,19 +29,24 @@ Unit tests for specific easyblocks.
 """
 import copy
 import os
+import stat
 import sys
 import tempfile
-from unittest import TestCase, TestLoader, TextTestRunner
+import textwrap
+from unittest import TestLoader, TextTestRunner
 from test.easyblocks.module import cleanup
 
 import easybuild.tools.options as eboptions
+from easybuild.base.testing import TestCase
+from easybuild.easyblocks.generic.cmakemake import det_cmake_version
 from easybuild.easyblocks.generic.toolchain import Toolchain
-from easybuild.framework.easyblock import get_easyblock_instance
+from easybuild.framework.easyblock import EasyBlock, get_easyblock_instance
 from easybuild.framework.easyconfig.easyconfig import process_easyconfig
 from easybuild.tools import config
-from easybuild.tools.config import get_module_syntax
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.config import GENERAL_CLASS, get_module_syntax
 from easybuild.tools.environment import modify_env
-from easybuild.tools.filetools import remove_dir, write_file
+from easybuild.tools.filetools import adjust_permissions, remove_dir, write_file
 from easybuild.tools.modules import modules_tool
 from easybuild.tools.options import set_tmpdir
 from easybuild.tools.py2vs3 import StringIO
@@ -49,6 +54,18 @@ from easybuild.tools.py2vs3 import StringIO
 
 class EasyBlockSpecificTest(TestCase):
     """ Baseclass for easyblock testcases """
+
+    # initialize configuration (required for e.g. default modules_tool setting)
+    eb_go = eboptions.parse_options()
+    config.init(eb_go.options, eb_go.get_options_by_section('config'))
+    build_options = {
+        'suffix_modules_path': GENERAL_CLASS,
+        'valid_module_classes': config.module_classes(),
+        'valid_stops': [x[0] for x in EasyBlock.get_steps()],
+    }
+    config.init_build_options(build_options=build_options)
+    set_tmpdir()
+    del eb_go
 
     def setUp(self):
         """Test setup."""
@@ -199,6 +216,47 @@ class EasyBlockSpecificTest(TestCase):
             if any(key.startswith(x) for x in ['EBROOT', 'EBVERSION']):
                 extra_eb_env_vars.append(key)
         self.assertEqual(extra_eb_env_vars, [])
+
+    def test_det_cmake_version(self):
+        """Tests for det_cmake_version function provided along with CMakeMake generic easyblock."""
+
+        # set up fake 'cmake' command
+        cmake_cmd = os.path.join(self.tmpdir, 'cmake')
+        write_file(cmake_cmd, '#!/bin/bash\nexit 1')
+        adjust_permissions(cmake_cmd, stat.S_IXUSR)
+
+        os.environ['PATH'] = '%s:%s' % (self.tmpdir, os.getenv('PATH'))
+
+        self.assertErrorRegex(EasyBuildError, "Failed to determine CMake version", det_cmake_version)
+
+        # if $EBVERSIONCMAKE is defined (by loaded CMake module), that's picked up
+        os.environ['EBVERSIONCMAKE'] = '1.2.3'
+        self.assertEqual(det_cmake_version(), '1.2.3')
+
+        del os.environ['EBVERSIONCMAKE']
+
+        # output of 'cmake --version' as produced by CMake 2.x
+        write_file(cmake_cmd, textwrap.dedent("""
+        #!/bin/bash
+        echo "cmake version 4.5.6"
+        """))
+        self.assertEqual(det_cmake_version(), '4.5.6')
+
+        # output of 'cmake --version' as produced by CMake 3.x
+        write_file(cmake_cmd, textwrap.dedent("""
+        #!/bin/bash
+        echo "cmake version 7.8.9"
+        echo ""
+        echo "CMake suite maintained and supported by Kitware (kitware.com/cmake)."
+        """))
+        self.assertEqual(det_cmake_version(), '7.8.9')
+
+        # also consider release candidate versions
+        write_file(cmake_cmd, textwrap.dedent("""
+        #!/bin/bash
+        echo "cmake version 1.2.3-rc4"
+        """))
+        self.assertEqual(det_cmake_version(), '1.2.3-rc4')
 
 
 def suite():


### PR DESCRIPTION
Follow-up for #2514 by @Flamefire, which takes into account that:

* CMake may not be loaded as a (build) dependency, which results in a hard crash without these changes because `None` is fed to `LooseVersion` (cfr. https://github.com/easybuilders/easybuild-easyblocks/pull/2514#discussion_r937960734)
* CMake may be filtered out as a dependency, because `cmake` in OS is preferred instead

`det_cmake_version` produces a clean error message if the CMake version could not be determined (for example if the `cmake` command is not found)