### PR TITLE
update OpenMPI easyblock to fix sanity check for Clang-based compilers

### DIFF
--- a/easybuild/easyblocks/o/openmpi.py
+++ b/easybuild/easyblocks/o/openmpi.py
@@ -199,6 +199,10 @@ class EB_OpenMPI(ConfigureMake):
         # for PGI, correct pattern is "pgfortran" with mpif90
         if expected['mpif90'] == 'pgf90':
             expected['mpif90'] = 'pgfortran'
+        # for Clang the pattern is always clang
+        for key in ['mpicxx', 'mpifort', 'mpif90']:
+            if expected[key] in ['clang++', 'flang']:
+                expected[key] = 'clang'
 
         custom_commands = ["%s --version | grep '%s'" % (key, expected[key]) for key in sorted(expected.keys())]
 


### PR DESCRIPTION
Clang compilers always have the same output when using `--version`. There is no different information when using C++ or Fortran compilers.

e.g.

```
$ clang++ --version
clang version 11.0.1
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /software/all/Clang/11.0.1-GCCcore-10.2.0/bin
```