### PR TITLE
Make the test output from PythonPackage less verbose

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -684,8 +684,8 @@ class PythonPackage(ExtensionEasyBlock):
                 ])
 
                 if return_output_ec:
-                    (out, ec) = run_cmd(cmd, log_all=False, log_ok=False, simple=False)
-                    # need to log seperately, since log_all and log_ok need to be false to retreive out and ec
+                    (out, ec) = run_cmd(cmd, log_all=False, log_ok=False, simple=False, regexp=False)
+                    # need to log seperately, since log_all and log_ok need to be false to retrieve out and ec
                     self.log.info("cmd '%s' exited with exit code %s and output:\n%s", cmd, ec, out)
                 else:
                     run_cmd(cmd, log_all=True, simple=True)


### PR DESCRIPTION
When the EasyBlock wants to handle the test output itself it doesn't make sense to search it for potential errors using the generic RegExp.

This applies e.g. to PyTorch and TensorFlow which search for test failures themselves.

So set `regexp=False` to avoid making the log much harder to read due to duplicated and, more annoyingly, partial test (fail) output.