### PR TITLE
enhance EasyBuildMeta easyblock: auto-enable installing with pip + fix setup.py of easyconfigs package so installation with setuptools >= 61.0 works

### DIFF
--- a/easybuild/easyblocks/e/easybuildmeta.py
+++ b/easybuild/easyblocks/e/easybuildmeta.py
@@ -35,7 +35,7 @@ from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage, det_pip_version
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import apply_regex_substitutions, change_dir, read_file, which
+from easybuild.tools.filetools import apply_regex_substitutions, change_dir, read_file
 from easybuild.tools.modules import get_software_root_env_var_name
 from easybuild.tools.py2vs3 import OrderedDict
 from easybuild.tools.utilities import flatten
@@ -71,14 +71,13 @@ class EB_EasyBuildMeta(PythonPackage):
         # - pip is available, and recent enough (>= 21.0);
         # - use_pip is not specified;
         pyver = sys.version.split(' ')[0]
-        pip = which('pip')
-        self.log.info("Python version: %s - pip: %s", pyver, pip)
-        if sys.version_info >= (3, 6) and pip and self.cfg['use_pip'] is None:
+        self.log.info("Python version: %s", pyver)
+        if sys.version_info >= (3, 6) and self.cfg['use_pip'] is None:
             # try to determine pip version, ignore any failures that occur while doing so;
             # problems may occur due changes in environment ($PYTHONPATH, etc.)
             pip_version = None
             try:
-                pip_version = det_pip_version()
+                pip_version = det_pip_version(python_cmd=sys.executable)
                 self.log.info("Found Python v%s + pip: %s", pyver, pip_version)
             except Exception as err:
                 self.log.warning("Failed to determine pip version: %s", err)

--- a/easybuild/easyblocks/e/easybuildmeta.py
+++ b/easybuild/easyblocks/e/easybuildmeta.py
@@ -33,9 +33,9 @@ import re
 import sys
 from distutils.version import LooseVersion
 
-from easybuild.easyblocks.generic.pythonpackage import PythonPackage
+from easybuild.easyblocks.generic.pythonpackage import PythonPackage, det_pip_version
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import read_file
+from easybuild.tools.filetools import read_file, which
 from easybuild.tools.modules import get_software_root_env_var_name
 from easybuild.tools.py2vs3 import OrderedDict
 from easybuild.tools.utilities import flatten
@@ -65,6 +65,28 @@ class EB_EasyBuildMeta(PythonPackage):
             self.easybuild_pkgs.extend(['vsc-base', 'vsc-install'])
             # consider setuptools first, in case it is listed as a sources
             self.easybuild_pkgs.insert(0, 'setuptools')
+
+        # opt-in to using pip for recent version of EasyBuild, if:
+        # - EasyBuild is being installed for Python >= 3.6;
+        # - pip is available, and recent enough (>= 21.0);
+        # - use_pip is not specified;
+        pyver = sys.version.split(' ')[0]
+        pip = which('pip')
+        self.log.info("Python version: %s - pip: %s", pyver, pip)
+        if sys.version_info >= (3, 6) and pip and self.cfg['use_pip'] is None:
+            # try to determine pip version, ignore any failures that occur while doing so;
+            # problems may occur due changes in environment ($PYTHONPATH, etc.)
+            pip_version = None
+            try:
+                pip_version = det_pip_version()
+                self.log.info("Found Python v%s + pip: %s", pyver, pip_version)
+            except Exception as err:
+                self.log.warning("Failed to determine pip version: %s", err)
+
+            if pip_version and LooseVersion(pip_version) >= LooseVersion('21.0'):
+                self.log.info("Auto-enabling use of pip to install EasyBuild!")
+                self.cfg['use_pip'] = True
+                self.determine_install_command()
 
     # Override this function since we want to respect the user choice for the python installation to use
     # (which can be influenced by EB_PYTHON and EB_INSTALLPYTHON)

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -318,6 +318,12 @@ class PythonPackage(ExtensionEasyBlock):
 
         # determine install command
         self.use_setup_py = False
+        self.determine_install_command()
+
+    def determine_install_command(self):
+        """
+        Determine install command to use.
+        """
         if self.cfg.get('use_pip', False) or self.cfg.get('use_pip_editable', False):
             self.install_cmd = PIP_INSTALL_CMD
 
@@ -361,7 +367,7 @@ class PythonPackage(ExtensionEasyBlock):
                 else:
                     raise EasyBuildError("Installing zipped eggs requires using easy_install or pip")
 
-        self.log.debug("Using '%s' as install command", self.install_cmd)
+        self.log.info("Using '%s' as install command", self.install_cmd)
 
     def set_pylibdirs(self):
         """Set Python lib directory-related class variables."""


### PR DESCRIPTION
cfr. https://github.com/easybuilders/easybuild-easyconfigs/pull/15206

probably fixes https://github.com/easybuilders/easybuild/issues/817

definitely fixes problems reported in https://github.com/EESSI/software-layer/issues/191