### PR TITLE
create $XDG_CACHE_HOME for PyTorch tests

### DIFF
--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -37,7 +37,7 @@ from easybuild.easyblocks.generic.pythonpackage import PythonPackage
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError, print_warning
 from easybuild.tools.config import build_option
-from easybuild.tools.filetools import symlink, apply_regex_substitutions, mkdir
+from easybuild.tools.filetools import apply_regex_substitutions, mkdir, symlink
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.systemtools import POWER, get_cpu_architecture
 


### PR DESCRIPTION
The path must exist or PyTorch will show errors/warnings like:

> UserWarning: Specified kernel cache directory could not be created! This disables kernel caching.