### PR TITLE
Prefer `python -m pip` over `pip` for Python packages

### DIFF
--- a/easybuild/easyblocks/d/dm_reverb.py
+++ b/easybuild/easyblocks/d/dm_reverb.py
@@ -121,6 +121,7 @@ class EB_dm_minus_reverb(PythonPackage):
             'installopts': self.cfg['installopts'],
             'loc': whl_path,
             'prefix': self.installdir,
+            'python': self.python_cmd,
         }
 
         return super(EB_dm_minus_reverb, self).install_step(*args, **kwargs)

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -60,7 +60,7 @@ from easybuild.tools.hooks import CONFIGURE_STEP, BUILD_STEP, TEST_STEP, INSTALL
 # not 'easy_install' deliberately, to avoid that pkg installations listed in easy-install.pth get preference
 # '.' is required at the end when using easy_install/pip in unpacked source dir
 EASY_INSTALL_TARGET = "easy_install"
-PIP_INSTALL_CMD = "pip install --prefix=%(prefix)s %(installopts)s %(loc)s"
+PIP_INSTALL_CMD = "%(python)s -m pip install --prefix=%(prefix)s %(installopts)s %(loc)s"
 SETUP_PY_INSTALL_CMD = "%(python)s setup.py %(install_target)s --prefix=%(prefix)s %(installopts)s"
 UNKNOWN = 'UNKNOWN'
 
@@ -204,14 +204,14 @@ def get_pylibdirs(python_cmd):
     return all_pylibdirs
 
 
-def det_pip_version():
-    """Determine version of currently active 'pip' command."""
+def det_pip_version(python_cmd='python'):
+    """Determine version of currently active 'pip' module."""
 
     pip_version = None
     log = fancylogger.getLogger('det_pip_version', fname=False)
     log.info("Determining pip version...")
 
-    out, _ = run_cmd("pip --version", verbose=False, simple=False, trace=False)
+    out, _ = run_cmd("%s -m pip --version" % python_cmd, verbose=False, simple=False, trace=False)
 
     pip_version_regex = re.compile('^pip ([0-9.]+)')
     res = pip_version_regex.search(out)
@@ -247,8 +247,8 @@ class PythonPackage(ExtensionEasyBlock):
                                    "the pip version check. Enabled by default when pip_ignore_installed=True", CUSTOM],
             'req_py_majver': [None, "Required major Python version (only relevant when using system Python)", CUSTOM],
             'req_py_minver': [None, "Required minor Python version (only relevant when using system Python)", CUSTOM],
-            'sanity_pip_check': [False, "Run 'pip check' to ensure all required Python packages are installed "
-                                        "and check for any package with an invalid (0.0.0) version.", CUSTOM],
+            'sanity_pip_check': [False, "Run 'python -m pip check' to ensure all required Python packages are "
+                                        "installed and check for any package with an invalid (0.0.0) version.", CUSTOM],
             'runtest': [True, "Run unit tests.", CUSTOM],  # overrides default
             'unpack_sources': [None, "Unpack sources prior to build/install. Defaults to 'True' except for whl files",
                                CUSTOM],
@@ -261,8 +261,8 @@ class PythonPackage(ExtensionEasyBlock):
             # see https://packaging.python.org/tutorials/installing-packages/#installing-setuptools-extras
             'use_pip_extras': [None, "String with comma-separated list of 'extras' to install via pip", CUSTOM],
             'use_pip_for_deps': [False, "Install dependencies using '%s'" % PIP_INSTALL_CMD, CUSTOM],
-            'use_pip_requirement': [False, "Install using 'pip install --requirement'. The sources is expected " +
-                                           "to be the requirements file.", CUSTOM],
+            'use_pip_requirement': [False, "Install using 'python -m pip install --requirement'. The sources is " +
+                                           "expected to be the requirements file.", CUSTOM],
             'zipped_egg': [False, "Install as a zipped eggs", CUSTOM],
         })
         # Use PYPI_SOURCE as the default for source_urls.
@@ -468,7 +468,7 @@ class PythonPackage(ExtensionEasyBlock):
         using_pip = self.install_cmd.startswith(PIP_INSTALL_CMD)
         if using_pip:
 
-            pip_version = det_pip_version()
+            pip_version = det_pip_version(python_cmd=self.python_cmd)
             if pip_version:
                 # pip 8.x or newer required, because of --prefix option being used
                 if LooseVersion(pip_version) >= LooseVersion('8.0'):
@@ -834,8 +834,11 @@ class PythonPackage(ExtensionEasyBlock):
                 kwargs.update({'exts_filter': exts_filter})
 
         if self.cfg.get('sanity_pip_check', False):
-            pip_version = det_pip_version()
+            pip_version = det_pip_version(python_cmd=python_cmd)
+
             if pip_version:
+                pip_check_command = "%s -m pip check" % python_cmd
+
                 if LooseVersion(pip_version) >= LooseVersion('9.0.0'):
 
                     if not self.is_extension:
@@ -846,11 +849,11 @@ class PythonPackage(ExtensionEasyBlock):
 
                     pip_check_errors = []
 
-                    pip_check_msg, ec = run_cmd("pip check", log_ok=False)
+                    pip_check_msg, ec = run_cmd(pip_check_command, log_ok=False)
                     if ec:
-                        pip_check_errors.append('`pip check` failed:\n%s' % pip_check_msg)
+                        pip_check_errors.append('`%s` failed:\n%s' % (pip_check_command, pip_check_msg))
                     else:
-                        self.log.info('`pip check` completed successfully')
+                        self.log.info('`%s` completed successfully' % pip_check_command)
 
                     # Also check for a common issue where the package version shows up as 0.0.0 often caused
                     # by using setup.py as the installation method for a package which is released as a generic wheel
@@ -869,8 +872,8 @@ class PythonPackage(ExtensionEasyBlock):
                                 version = next(pkg['version'] for pkg in pkgs if pkg['name'] == unversioned_package)
                             except StopIteration:
                                 msg = ('Package %s in unversioned_packages was not found in the installed packages. '
-                                       'Check that the name from `pip list` is used which may be different than the '
-                                       'module name.' % unversioned_package)
+                                       'Check that the name from `python -m pip list` is used which may be different '
+                                       'than the module name.' % unversioned_package)
                             else:
                                 msg = ('Package %s in unversioned_packages has a version of %s which is valid. '
                                        'Please remove it from unversioned_packages.' % (unversioned_package, version))
@@ -894,7 +897,8 @@ class PythonPackage(ExtensionEasyBlock):
                     if pip_check_errors:
                         raise EasyBuildError('\n'.join(pip_check_errors))
                 else:
-                    raise EasyBuildError("pip >= 9.0.0 is required for running 'pip check', found %s", pip_version)
+                    raise EasyBuildError("pip >= 9.0.0 is required for running '%s', found %s", (pip_check_command,
+                                                                                                 pip_version))
             else:
                 raise EasyBuildError("Failed to determine pip version!")
 

--- a/easybuild/easyblocks/t/tensorrt.py
+++ b/easybuild/easyblocks/t/tensorrt.py
@@ -108,6 +108,7 @@ class EB_TensorRT(PythonPackage, Binary):
                     'installopts': self.cfg['installopts'],
                     'loc': whl_paths[0],
                     'prefix': self.installdir,
+                    'python': self.python_cmd,
                 }
 
                 # Use --no-deps to prevent pip from downloading & installing


### PR DESCRIPTION
This is motivated by changes required in #2805 where (due to environment variables like `EB_PYTHON`) the "correct" `pip` command may not even be in the users path.