### PR TITLE
remove -openmp build option for MRtrix v3.x

### DIFF
--- a/easybuild/easyblocks/m/mrtrix.py
+++ b/easybuild/easyblocks/m/mrtrix.py
@@ -65,9 +65,6 @@ class EB_MRtrix(EasyBlock):
             env.setvar('QMAKE_CXX', os.getenv('CXX'))
             cmd = "python configure -verbose"
 
-            if LooseVersion(self.version) >= LooseVersion('3.0'):
-                cmd += " -openmp"
-
             run_cmd(cmd, log_all=True, simple=True, log_ok=True)
 
     def build_step(self):


### PR DESCRIPTION
Removed the openmp build flag as MRtrix itself does not contain any OpenMP code. Using the flag led to issues with unresolved omp symbols however.

See https://community.mrtrix.org/t/error-population-template-undefined-symbol-omp-get-max-threads/6128/7 for a description of the issue. 

I assume the issue is caused by a missing -fopenmp flag on some linker steps in the MRtrix build process. And since no direct OpenMP calls are made in the code it is upon the compiler to decide to actually link OpenMP, or not. 
But since MRtrix does not support OpenMP directly it may be better to not use the flag at all.