### PR TITLE
 Cancel GithubAction runs for outdated commits 

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,5 +1,10 @@
 name: Static Analysis
 on: [push, pull_request]
+
+concurrency:
+  group: ${{format('{0}:{1}:{2}', github.repository, github.ref, github.workflow)}}
+  cancel-in-progress: true
+
 jobs:
   python-linting:
     runs-on: ubuntu-20.04

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,5 +1,10 @@
 name: easyblocks unit tests
 on: [push, pull_request]
+
+concurrency:
+  group: ${{format('{0}:{1}:{2}', github.repository, github.ref, github.workflow)}}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Save (free) CPU hours by canceling running actions on the same branch, e.g. after a re-push on a PR