### PR TITLE
update scipy easyblock for scipy >= 1.9 to correctly configure BLAS/LAPACK library to use via Meson (WIP)

### DIFF
--- a/easybuild/easyblocks/s/scipy.py
+++ b/easybuild/easyblocks/s/scipy.py
@@ -32,9 +32,12 @@ EasyBuild support for building and installing scipy, implemented as an easyblock
 @author: Jens Timmerman (Ghent University)
 """
 from distutils.version import LooseVersion
+import os
 
 from easybuild.easyblocks.generic.fortranpythonpackage import FortranPythonPackage
 from easybuild.easyblocks.generic.pythonpackage import det_pylibdir
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.filetools import remove_dir
 import easybuild.tools.toolchain as toolchain
 
 
@@ -57,6 +60,48 @@ class EB_scipy(FortranPythonPackage):
             # which requires unsetting $LDFLAGS
             if self.toolchain.comp_family() in [toolchain.GCC, toolchain.CLANGGCC]:  # @UndefinedVariable
                 self.cfg.update('preinstallopts', "unset LDFLAGS && ")
+
+        # configure BLAS/LAPACK library to use with Meson for scipy >= 1.9.0
+        if LooseVersion(self.version) >= LooseVersion('1.9.0'):
+            lapack_lib = self.toolchain.lapack_family()
+            if lapack_lib == toolchain.FLEXIBLAS:
+                blas_lapack = 'flexiblas'
+            elif lapack_lib == toolchain.INTELMKL:
+                blas_lapack = 'mkl'
+            elif lapack_lib == toolchain.OPENBLAS:
+                blas_lapack = 'openblas'
+            else:
+                raise EasyBuildError("Unknown BLAS/LAPACK library used: %s", lapack_lib)
+
+            meson_cmd = ' '.join([
+                'meson',
+                'setup',
+                'build',
+                '-Dblas=' + blas_lapack,
+                '-Dlapack=' + blas_lapack,
+            ])
+            self.cfg.update('preinstallopts', meson_cmd + ' && ')
+
+    def build_step(self):
+        """
+        Custom build step for scipy: don't run "python setup.py build" for scipy >= 1.9.0
+        """
+        if LooseVersion(self.version) < LooseVersion('1.9.0'):
+            super(EB_scipy, self).build_step()
+
+    def install_step(self):
+        """
+        Custom install step for scipy: clean up existing 'build' directory for scipy >= 1.9.0
+        """
+        if LooseVersion(self.version) >= LooseVersion('1.9.0'):
+            # we need to clean up the build directory if it exists already,
+            # to avoid that Meson detects that the build has been configured already
+            # (when installing scipy for running the tests)
+            build_dir = 'build'
+            if os.path.exists(build_dir):
+                remove_dir(build_dir)
+
+        super(EB_scipy, self).install_step()
 
     def sanity_check_step(self, *args, **kwargs):
         """Custom sanity check for scipy."""


### PR DESCRIPTION
draft PR, since it's not working as intended yet

The `meson setup build` command is correct when building on top of `foss/2022b`:

```
The Meson build system
Version: 0.64.0
Source dir: /tmp/easybuild_build/SciPybundle/2022.11/gfbf-2022.10/scipy/scipy-1.9.3
Build dir: /tmp/easybuild_build/SciPybundle/2022.11/gfbf-2022.10/scipy/scipy-1.9.3/build
Build type: native build
Project name: SciPy
Project version: 1.9.3
C compiler for the host machine: gcc (gcc 12.2.0 "gcc (GCC) 12.2.0")
C linker for the host machine: gcc ld.bfd 2.39
...
Run-time dependency flexiblas found: YES 3.2.1
Dependency flexiblas found: YES 3.2.1 (cached)
```

but the the `pip install` command also calls `meson setup` with different arguments, resulting in a direct link with OpenBLAS:

```
Using pip 22.3.1 from /software/Python/3.10.8-GCCcore-12.2.0/lib/python3.10/site-packages/pip (python 3.10)
Processing /tmp/vsc40023/easybuild_build/SciPybundle/2022.11/gfbf-2022.10/scipy/scipy-1.9.3
  Preparing metadata (pyproject.toml): started
  Running command Preparing metadata (pyproject.toml)
  + meson setup --prefix=/software/Python/3.10.8-GCCcore-12.2.0 /tmp/easybuild_build/SciPybundle/2022.11/gfbf-2022.10/scipy/scipy-1.9.3 /tmp/easybuild_build/SciPybundle/2022.11/gfbf-2022.10/scipy/scipy-1.9.3/.mesonpy-znuvtok_/build --native-file=/tmp/easybuild_build/SciPybundle/2022.11/gfbf-2022.10/scipy/scipy-1.9.3/.mesonpy-native-file.ini -Ddebug=false -Doptimization=2
  The Meson build system
  Version: 0.64.0
  Source dir: /tmp/easybuild_build/SciPybundle/2022.11/gfbf-2022.10/scipy/scipy-1.9.3
  Build dir: /tmp/easybuild_build/SciPybundle/2022.11/gfbf-2022.10/scipy/scipy-1.9.3/.mesonpy-znuvtok_/build
  Build type: native build
  Project name: SciPy
  Project version: 1.9.3
  C compiler for the host machine: gcc (gcc 12.2.0 "gcc (GCC) 12.2.0")
  C linker for the host machine: gcc ld.bfd 2.39
  ...
  Run-time dependency openblas found: YES 0.3.21
  Dependency openblas found: YES 0.3.21 (cached)
```

So rather than running `meson setup build` before `pip install` (as suggested by the [scipy docs](https://scipy.github.io/devdocs/dev/contributor/meson.html)), we probably need to switch to using `meson install`?