### PR TITLE
fix TensorFlow easyblock for new versions of Bazel & TensorFlow

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -214,7 +214,7 @@ def get_bazel_version():
     """Get the Bazel version as a LooseVersion. Error if not found"""
     version = get_software_version('Bazel')
     if version is None:
-        raise EasyBuildError('Bazel version not found. Is it a dependency?')
+        raise EasyBuildError('Failed to determine Bazel version - is it listed as a (build) dependency?')
     return LooseVersion(version)
 
 

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -758,6 +758,8 @@ class EB_TensorFlow(PythonPackage):
     def build_step(self):
         """Custom build procedure for TensorFlow."""
 
+        bazel_version = get_bazel_version()
+
         # pre-create target installation directory
         mkdir(os.path.join(self.installdir, self.pylibdir), parents=True)
 
@@ -768,8 +770,10 @@ class EB_TensorFlow(PythonPackage):
         # Options passed to the bazel command
         self.bazel_opts = [
             '--output_user_root=%s' % self.output_user_root_dir,
-            '--local_startup_timeout_secs=600',  # 5min for bazel to start
         ]
+        if bazel_version >= '4.0.0':
+            self.bazel_opts.append('--local_startup_timeout_secs=600')  # 5min for bazel to start
+
         # Environment variables and values needed for Bazel actions.
         action_env = {}
         # A value of None is interpreted as using the invoking environments value
@@ -861,8 +865,6 @@ class EB_TensorFlow(PythonPackage):
             # this makes TensorFlow use mkl-dnn (cfr. https://github.com/01org/mkl-dnn),
             # and download it if needed
             self.target_opts.append('--config=mkl')
-
-        bazel_version = get_bazel_version()
 
         # Use the same configuration (i.e. environment) for compiling and using host tools
         # This means that our action_envs are (almost) always passed

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2017-2022 Ghent University
+# Copyright 2017-2023 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
@@ -445,7 +445,7 @@ class EB_TensorFlow(PythonPackage):
         # and will hang forever building the TensorFlow package.
         # So limit to something high but still reasonable while allowing ECs to overwrite it
         if self.cfg['maxparallel'] is None:
-            self.cfg['parallel'] = min(self.cfg['parallel'], 64)
+            self.cfg['parallel'] = min(self.cfg['parallel'], 96)
 
         binutils_root = get_software_root('binutils')
         if not binutils_root:
@@ -758,6 +758,7 @@ class EB_TensorFlow(PythonPackage):
         # Options passed to the bazel command
         self.bazel_opts = [
             '--output_user_root=%s' % self.output_user_root_dir,
+            '--local_startup_timeout_secs=600',  # 5min for bazel to start
         ]
         # Environment variables and values needed for Bazel actions.
         action_env = {}


### PR DESCRIPTION
This resolves a major blocker for installing newer versions of TensorFlow (2.8+), at least the CUDA versions.

The main issue is a [change in TensorFlow](https://github.com/tensorflow/tensorflow/commit/07cbc7bb0bf899aac2bee5e21e1ba4eb40038682) which leads to Bazel not passing environment variables we set via `--action_env` to all actions because somewhere around Bazel 3.7 they changed the meaning of that option from "pass to **all** actions"  to "pass to **target** actions" and we need to use `--host_action_env` for "host actions" and "exec actions".

Furthermore they degraded the impact of `--distinct-host-configuration=false` and [officially announced](https://github.com/bazelbuild/bazel/commit/78d0fc9ff1d2f22005ddfce43384e35fbac338cb) it as a "no-op" in Bazel 6.0 which might explain [failures reported earlier](https://github.com/bazelbuild/bazel/issues/4008) regarding "exec_tools" vs "tools"

Solution is that for recent Bazel versions `--action_env` **and** `--host_action_env` is used, see https://github.com/bazelbuild/bazel/issues/17062

As a drive-by fix I change the `LooseVersion` import and made the failing tests reported unique as during testing I was hit by `"520 test failed: <500x the same test> <some others>"` and for further convenience sorted them

Test report using 2.7.1: https://github.com/easybuilders/easybuild-easyconfigs/pull/16795#issuecomment-1373561015 and later for 2.8.4 in https://github.com/easybuilders/easybuild-easyconfigs/pull/17058