### PR TITLE
use start dir of extension to install R packages

### DIFF
--- a/easybuild/easyblocks/generic/rpackage.py
+++ b/easybuild/easyblocks/generic/rpackage.py
@@ -134,15 +134,10 @@ class RPackage(ExtensionEasyBlock):
         else:
             prefix = ''
 
-        if self.start_dir:
-            loc = os.path.join(self.ext_dir or os.path.sep, self.start_dir)
-        else:
-            loc = self.ext_dir or self.ext_src
-
         cmd = ' '.join([
             self.cfg['preinstallopts'],
             "R CMD INSTALL",
-            loc,
+            self.start_dir,
             confargs,
             confvars,
             prefix,


### PR DESCRIPTION
Depends on:
* [x] https://github.com/easybuilders/easybuild-framework/pull/4196

PR https://github.com/easybuilders/easybuild-framework/pull/4196 will move this modification of the start dir in R extensions to framework. Once it is merged, `self.start_dir` will already be an absolute path pointing to the extension start directory.