### PR TITLE
modify logic in QScintilla easyblock to find the PyQt5 sipdir in more places

### DIFF
--- a/easybuild/easyblocks/q/qscintilla.py
+++ b/easybuild/easyblocks/q/qscintilla.py
@@ -126,7 +126,7 @@ class EB_QScintilla(ConfigureMake):
                                os.path.join('share', 'sip'),
                                os.path.join('lib', 'python%s*' % pyshortver, 'site-packages', self.pyqt_pkg_name,
                                             'bindings')
-                              ]
+                               ]
             pyqt_sipdir_options = [os.path.join(self.pyqt_root, subdir) for subdir in pyqt_sip_subidr]
             for pyqt_sipdir_option in pyqt_sipdir_options:
                 pyqt_sipdir = find_glob_pattern(pyqt_sipdir_option, False)

--- a/easybuild/easyblocks/q/qscintilla.py
+++ b/easybuild/easyblocks/q/qscintilla.py
@@ -120,14 +120,14 @@ class EB_QScintilla(ConfigureMake):
             sip_incdir = find_glob_pattern(os.path.join(self.pyqt_root, 'include', 'python%s*' % pyshortver), False)
             # depending on PyQt5 versions and how it was installed, the sip directory could be in various places
             # test them and figure out the first one that matches
-            pyqt_sip_subidr = [os.path.join('share', 'python%s*' % pyshortver, 'site-packages', 'sip',
+            pyqt_sip_subdir = [os.path.join('share', 'python%s*' % pyshortver, 'site-packages', 'sip',
                                             self.pyqt_pkg_name),
                                os.path.join('share', 'sip', self.pyqt_pkg_name),
                                os.path.join('share', 'sip'),
                                os.path.join('lib', 'python%s*' % pyshortver, 'site-packages', self.pyqt_pkg_name,
                                             'bindings')
                                ]
-            pyqt_sipdir_options = [os.path.join(self.pyqt_root, subdir) for subdir in pyqt_sip_subidr]
+            pyqt_sipdir_options = [os.path.join(self.pyqt_root, subdir) for subdir in pyqt_sip_subdir]
             for pyqt_sipdir_option in pyqt_sipdir_options:
                 pyqt_sipdir = find_glob_pattern(pyqt_sipdir_option, False)
                 if pyqt_sipdir:

--- a/easybuild/easyblocks/q/qscintilla.py
+++ b/easybuild/easyblocks/q/qscintilla.py
@@ -118,16 +118,23 @@ class EB_QScintilla(ConfigureMake):
             pyshortver = '.'.join(get_software_version('Python').split('.')[:2])
 
             sip_incdir = find_glob_pattern(os.path.join(self.pyqt_root, 'include', 'python%s*' % pyshortver), False)
-            # in case PyQt5's sip was installed in directories that are specific to each version of python
-            # as could happen with multi_deps
-            pyqt_sipdir = find_glob_pattern(os.path.join(self.pyqt_root, 'share', 'python%s*' % pyshortver,
-                                                         'site-packages', 'sip', self.pyqt_pkg_name), False)
-            # fall back to a single sipdir
+            # depending on PyQt5 versions and how it was installed, the sip directory could be in various places
+            # test them and figure out the first one that matches
+            pyqt_sip_subidr = [os.path.join('share', 'python%s*' % pyshortver, 'site-packages', 'sip',
+                                            self.pyqt_pkg_name),
+                               os.path.join('share', 'sip', self.pyqt_pkg_name),
+                               os.path.join('share', 'sip'),
+                               os.path.join('lib', 'python%s*' % pyshortver, 'site-packages', self.pyqt_pkg_name,
+                                            'bindings')
+                              ]
+            pyqt_sipdir_options = [os.path.join(self.pyqt_root, subdir) for subdir in pyqt_sip_subidr]
+            for pyqt_sipdir_option in pyqt_sipdir_options:
+                pyqt_sipdir = find_glob_pattern(pyqt_sipdir_option, False)
+                if pyqt_sipdir:
+                    break
+
             if not pyqt_sipdir:
-                if LooseVersion(get_software_version(self.pyqt_pkg_name)) >= LooseVersion('5.15'):
-                    pyqt_sipdir = os.path.join(self.pyqt_root, 'share', 'sip')
-                else:
-                    pyqt_sipdir = os.path.join(self.pyqt_root, 'share', 'sip', self.pyqt_pkg_name)
+                raise EasyBuildError("Failed to find PyQt5 sip directory")
 
             cfgopts = [
                 '--destdir %s' % os.path.join(self.installdir, pylibdir),


### PR DESCRIPTION
When installing PyQt5 5.15.5 as an extension of Qt5 5.15.8, two things happen
1) The current `qscintilla.py` at line https://github.com/easybuilders/easybuild-easyblocks/blob/develop/easybuild/easyblocks/q/qscintilla.py#L127 tests `get_software_version('PyQt5')`, which returns None, since `PyQt5` is it is part of `Qt5`, not `PyQt5` module (see support for this at https://github.com/easybuilders/easybuild-easyblocks/blob/develop/easybuild/easyblocks/q/qscintilla.py#L60)

2) Our SIP files are not in the locations that are tested, i.e. previously, we had: 
```
$ find /cvmfs/soft.computecanada.ca/easybuild/software/2020/avx2/Core/qt/5.12.8/ -name 'qgraphicssceneevent.sip'
/cvmfs/soft.computecanada.ca/easybuild/software/2020/avx2/Core/qt/5.12.8/share/python3.6/site-packages/sip/PyQt5/QtWidgets/qgraphicssceneevent.sip
/cvmfs/soft.computecanada.ca/easybuild/software/2020/avx2/Core/qt/5.12.8/share/python3.7/site-packages/sip/PyQt5/QtWidgets/qgraphicssceneevent.sip
/cvmfs/soft.computecanada.ca/easybuild/software/2020/avx2/Core/qt/5.12.8/share/python3.8/site-packages/sip/PyQt5/QtWidgets/qgraphicssceneevent.sip
/cvmfs/soft.computecanada.ca/easybuild/software/2020/avx2/Core/qt/5.12.8/share/python3.9/site-packages/sip/PyQt5/QtWidgets/qgraphicssceneevent.sip
/cvmfs/soft.computecanada.ca/easybuild/software/2020/avx2/Core/qt/5.12.8/share/python2.7/site-packages/sip/PyQt5/QtWidgets/qgraphicssceneevent.sip
``` 

now we have: 
```
$ find /cvmfs/soft.computecanada.ca/easybuild/software/2020/avx2/Core/qt/5.15.8/ -name 'qgraphicssceneevent.sip'
/cvmfs/soft.computecanada.ca/easybuild/software/2020/avx2/Core/qt/5.15.8/lib/python3.8/site-packages/PyQt5/bindings/QtWidgets/qgraphicssceneevent.sip
/cvmfs/soft.computecanada.ca/easybuild/software/2020/avx2/Core/qt/5.15.8/lib/python3.9/site-packages/PyQt5/bindings/QtWidgets/qgraphicssceneevent.sip
/cvmfs/soft.computecanada.ca/easybuild/software/2020/avx2/Core/qt/5.15.8/lib/python3.10/site-packages/PyQt5/bindings/QtWidgets/qgraphicssceneevent.sip
``` 

This PR avoids using `get_software_version('PyQt5')` altogether, and instead tests various possible location of PyQt5 sip dir, and picks the first one that matches. 