### PR TITLE
fix JULIA_DEPOT_PATH in installation of multiple JuliaPackage extensions

### DIFF
--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -96,11 +96,12 @@ class JuliaPackage(ExtensionEasyBlock):
         """Install Julia package with Pkg"""
 
         # prepend installation directory to Julia DEPOT_PATH
+        # extensions in a bundle can share their DEPOT_PATH
         # see https://docs.julialang.org/en/v1/manual/environment-variables/#JULIA_DEPOT_PATH
-        depot_path = os.getenv('JULIA_DEPOT_PATH')
-        if depot_path is not None:
-            depot_path = ':'.join([self.installdir, depot_path])
-        env.setvar('JULIA_DEPOT_PATH', depot_path)
+        depot_path = os.getenv('JULIA_DEPOT_PATH', '')
+        if self.installdir not in depot_path:
+            depot_path = ':'.join([depot for depot in (self.installdir, depot_path) if depot])
+            env.setvar('JULIA_DEPOT_PATH', depot_path)
 
         # command sequence for Julia.Pkg
         julia_pkg_cmd = ['using Pkg']


### PR DESCRIPTION
Installation of Julia packages is broken in two specific cases:
* whenever `JULIA_DEPOT_PATH` is unset, as `env.setvar` tries to access a `depot_path` that is `None`
* bundles of extensions prepend multiple times `installdir` to `JULIA_DEPOT_PATH`