### PR TITLE
fix checking of CUDA/ROCR-Runtime dependencies for Clang to determine default build targets

### DIFF
--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -177,18 +177,19 @@ class EB_Clang(CMakeMake):
         build_targets = self.cfg['build_targets']
         # define build_targets if not set
         if build_targets is None:
+            deps = [dep['name'].lower() for dep in self.cfg.dependencies()]
             arch = get_cpu_architecture()
             try:
                 default_targets = DEFAULT_TARGETS_MAP[arch][:]
                 # If CUDA is included as a dep, add NVPTX as a target
-                if get_software_root("CUDA"):
-                    default_targets += ["NVPTX"]
+                if 'cuda' in deps:
+                    default_targets += ['NVPTX']
                 # For AMDGPU support we need ROCR-Runtime and
                 # ROCT-Thunk-Interface, however, since ROCT is a dependency of
                 # ROCR we only check for the ROCR-Runtime here
                 # https://openmp.llvm.org/SupportAndFAQ.html#q-how-to-build-an-openmp-amdgpu-offload-capable-compiler
-                if get_software_root("ROCR-Runtime"):
-                    default_targets += ["AMDGPU"]
+                if 'rocr-runtime' in deps:
+                    default_targets += ['AMDGPU']
                 self.cfg['build_targets'] = build_targets = default_targets
                 self.log.debug("Using %s as default build targets for CPU/GPU architecture %s.", default_targets, arch)
             except KeyError:

--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -182,7 +182,9 @@ class EB_Clang(CMakeMake):
             try:
                 default_targets = DEFAULT_TARGETS_MAP[arch][:]
                 # If CUDA is included as a dep, add NVPTX as a target
-                if 'cuda' in deps:
+                # There are (old) toolchains with CUDA as part of the toolchain
+                cuda_toolchain = hasattr(self.toolchain, 'COMPILER_CUDA_FAMILY')
+                if 'cuda' in deps or cuda_toolchain:
                     default_targets += ['NVPTX']
                 # For AMDGPU support we need ROCR-Runtime and
                 # ROCT-Thunk-Interface, however, since ROCT is a dependency of


### PR DESCRIPTION
fixes #2871

Works as expected, now getting this in the log, as intended:

```
== 2023-01-30 14:55:17,205 clang.py:194 DEBUG Using ['X86', 'NVPTX'] as default build targets for CPU/GPU architecture x86_64.
```