### PR TITLE
fix error when failing PIP version check during PythonPackage sanity check

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -917,8 +917,9 @@ class PythonPackage(ExtensionEasyBlock):
                     if pip_check_errors:
                         raise EasyBuildError('\n'.join(pip_check_errors))
                 else:
-                    raise EasyBuildError("pip >= 9.0.0 is required for running '%s', found %s", (pip_check_command,
-                                                                                                 pip_version))
+                    raise EasyBuildError("pip >= 9.0.0 is required for running '%s', found %s",
+                                         pip_check_command,
+                                         pip_version)
             else:
                 raise EasyBuildError("Failed to determine pip version!")
 


### PR DESCRIPTION
The arguments must be passed individually not as a tuple, else you get:
>   File "/easybuild-easyblocks/easybuild/easyblocks/generic/pythonpackage.py", line 921, in sanity_check_step
>     pip_version))
>   File "/easybuild-framework/easybuild/tools/build_log.py", line 81, in __init__
>     msg = msg % args
> TypeError: not enough arguments for format string

@boegel This should go into next release.