### PR TITLE
fix check configure option in FlexiBLAS easyblock

### DIFF
--- a/easybuild/easyblocks/f/flexiblas.py
+++ b/easybuild/easyblocks/f/flexiblas.py
@@ -138,7 +138,7 @@ class EB_FlexiBLAS(CMakeMake):
         # to allow easyconfig to override specifies settings
         for key, value in sorted(configopts.items()):
             opt = '-D%s=' % key
-            if key not in self.cfg['configopts']:
+            if opt not in self.cfg['configopts']:
                 self.cfg.update('configopts', opt + "'%s'" % value)
 
         # specify compiler commands with absolute paths, to ensure that RPATH wrapper scripts are used


### PR DESCRIPTION
Only checking for `key` might match where it should not. Use the full `"-Dkey="` as the search string.

@boegel Looks like you intended to do that but forgot to use the already defined `opt` in #2369