### PR TITLE
Use older `ncgen -H` for older netCDF

### DIFF
--- a/easybuild/easyblocks/n/netcdf.py
+++ b/easybuild/easyblocks/n/netcdf.py
@@ -143,7 +143,7 @@ class EB_netCDF(CMakeMake):
 
         custom_commands = [
             "nc-config --help",
-            "ncgen -h",
+            "ncgen -h" if LooseVersion(self.version) > LooseVersion("4.6.1") else "ncgen -H",
         ]
 
         super(EB_netCDF, self).sanity_check_step(custom_commands=custom_commands, custom_paths=custom_paths)


### PR DESCRIPTION
This seems like a simple enough fix?

Fixes #2888.