### PR TITLE
fix error log in PythonPackage for old pip versions

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -917,8 +917,9 @@ class PythonPackage(ExtensionEasyBlock):
                     if pip_check_errors:
                         raise EasyBuildError('\n'.join(pip_check_errors))
                 else:
-                    raise EasyBuildError("pip >= 9.0.0 is required for running '%s', found %s", (pip_check_command,
-                                                                                                 pip_version))
+                    raise EasyBuildError(
+                        "pip >= 9.0.0 is required for running '%s', found %s", pip_check_command, pip_version
+                    )
             else:
                 raise EasyBuildError("Failed to determine pip version!")
 


### PR DESCRIPTION
There is a syntax error in this error message.