### PR TITLE
allow disabling pybind11 tests

### DIFF
--- a/easybuild/easyblocks/p/pybind11.py
+++ b/easybuild/easyblocks/p/pybind11.py
@@ -70,7 +70,7 @@ class EB_pybind11(CMakePythonPackage):
 
     def test_step(self):
         """Run pybind11 tests"""
-        # always run tests unless explicitly disabled
+        # run tests unless explicitly disabled
         if self.cfg['runtest'] is not False:
             self.cfg['runtest'] = 'check'
         super(EB_pybind11, self).test_step()

--- a/easybuild/easyblocks/p/pybind11.py
+++ b/easybuild/easyblocks/p/pybind11.py
@@ -70,8 +70,9 @@ class EB_pybind11(CMakePythonPackage):
 
     def test_step(self):
         """Run pybind11 tests"""
-        # always run tests
-        self.cfg['runtest'] = 'check'
+        # always run tests unless explicitly disabled
+        if self.cfg['runtest'] is not False:
+            self.cfg['runtest'] = 'check'
         super(EB_pybind11, self).test_step()
 
     def install_step(self):


### PR DESCRIPTION
While rebuilding a bunch of modules for python/3.11, pybind11 fails. This allows me to disable the tests. 

The tests fail with 
```
20562 ================================================================================================================================================================================= FAILURES                                                                                                                                                                                  =================================================================================================================================================================================
20563 _____________________________________________________________________________________________________________________________________________________________________________ test_properties                                                                                                                                                                               ______________________________________________________________________________________________________________________________________________________________________________
20564
20565     def test_properties():
20566         instance = m.TestProperties()
20567
20568         assert instance.def_readonly == 1
20569         with pytest.raises(AttributeError):
20570             instance.def_readonly = 2
20571
20572         instance.def_readwrite = 2
20573         assert instance.def_readwrite == 2
20574
20575         assert instance.def_property_readonly == 2
20576         with pytest.raises(AttributeError):
20577             instance.def_property_readonly = 3
20578
20579         instance.def_property = 3
20580         assert instance.def_property == 3
20581
20582         with pytest.raises(AttributeError) as excinfo:
20583             dummy = instance.def_property_writeonly  # unused var
20584 >       assert "unreadable attribute" in str(excinfo.value)
20585 E       assert 'unreadable attribute' in "property of 'TestProperties' object has no getter"
20586 E        +  where "property of 'TestProperties' object has no getter" = str(AttributeError("property of 'TestProperties' object has no getter"))
20587 E        +    where AttributeError("property of 'TestProperties' object has no getter") = <ExceptionInfo AttributeError("property of 'TestProperties' object has no getter") tblen=1>.value
20588
20589 ../../pybind11/pybind11-2.9.2/tests/test_methods_and_attributes.py:106: AssertionError
20590 __________________________________________________________________________________________________________________________________________________________________________ test_static_properties                                                                                                                                                                           __________________________________________________________________________________________________________________________________________________________________________
20591
20592     def test_static_properties():
20593         assert m.TestProperties.def_readonly_static == 1
20594         with pytest.raises(AttributeError) as excinfo:
20595             m.TestProperties.def_readonly_static = 2
20596 >       assert "can't set attribute" in str(excinfo.value)
20597 E       assert "can't set attribute" in "property of 'pybind11_type' object has no setter"
20598 E        +  where "property of 'pybind11_type' object has no setter" = str(AttributeError("property of 'pybind11_type' object has no setter"))
20599 E        +    where AttributeError("property of 'pybind11_type' object has no setter") = <ExceptionInfo AttributeError("property of 'pybind11_type' object has no setter") tblen=1>.value
20600
20601 ../../pybind11/pybind11-2.9.2/tests/test_methods_and_attributes.py:124: AssertionError
20602 ========================================================================================================================================================================= short test summary info                                                                                                                                                                           ==========================================================================================================================================================================
``` 
