### PR TITLE
Implement CUDA support in the ELPA EasyBlock & fix CPP configure issue on newer ELPA versions

### DIFF
--- a/easybuild/easyblocks/e/elpa.py
+++ b/easybuild/easyblocks/e/elpa.py
@@ -204,15 +204,9 @@ class EB_ELPA(ConfigureMake):
             self.log.info("Enabling nvidia GPU support for compute capabilitie: %s", cuda_cc_string)
 
         # From v2022.05.001 onwards, the config complains if CPP is not set
-        env_dict = env.read_environment({'cxx': 'CXX', 'cpp': 'CPP'})
-        if 'cxx' in env_dict:
-            if 'cpp' in env_dict and env_dict['cxx'] != env_dict['cpp']:
-                self.log.warning("Overwriting value of CPP (%s) with the value for CXX (%s)",
-                                 env_dict['cpp'], env_dict['cxx'])
-            env.setvar('CPP', env_dict['cxx'])
-        else:
-            raise EasyBuildError('ELPA requires CPP to be set. EasyBuild tried setting it based on the value of CXX, '
-                                 'but could not retreive a value for CXX')
+        # Need to make this neater so that it is either set by easybuild-framework, OR query the toolchain for something like COMPILER_CPP
+        # Discussing that right now on EB Slack...
+        env.setvar('CPP', 'cpp')
 
         super(EB_ELPA, self).configure_step()
 

--- a/easybuild/easyblocks/e/elpa.py
+++ b/easybuild/easyblocks/e/elpa.py
@@ -192,6 +192,12 @@ class EB_ELPA(ConfigureMake):
                 raise EasyBuildError('List of CUDA compute capabilities must be specified, either via '
                                      'cuda_compute_capabilities easyconfig parameter or via '
                                      '--cuda-compute-capabilities')
+
+            # ELPA's --with-NVIDIA-GPU-compute-capability only accepts a single architecture
+            if len(cuda_cc) > 1:
+                raise EasyBuildError('ELPA currently only supports specifying one architecture when '
+                                     'building. You specified cuda-compute-capabilities: %s', cuda_cc)
+
             cuda_cc_string = ','.join(['sm_%s' % x.replace('.', '') for x in cuda_cc])
             self.cfg.update('configopts', '--with-NVIDIA-GPU-compute-capability=%s' % cuda_cc_string)
             self.log.info("Enabling nvidia GPU support for compute capabilitie: %s", cuda_cc_string)

--- a/easybuild/easyblocks/e/elpa.py
+++ b/easybuild/easyblocks/e/elpa.py
@@ -198,17 +198,16 @@ class EB_ELPA(ConfigureMake):
                                      '--cuda-compute-capabilities')
 
             # ELPA's --with-NVIDIA-GPU-compute-capability only accepts a single architecture
-            if len(cuda_cc) == 1:
-                cuda_cc = cuda_cc[0]
-                cuda_cc_string = cuda_cc.replace('.', '')
-                self.cfg.update('configopts', '--with-NVIDIA-GPU-compute-capability=sm_%s' % cuda_cc_string)
-                self.log.info("Enabling nvidia GPU support for compute capability: %s", cuda_cc_string)
-                # There is a dedicated kernel for sm80, but only from version 2021.11.001 onwards
-                if float(cuda_cc) >= 8.0 and LooseVersion(self.version) >= LooseVersion('2021.11.001'):
-                    self.cfg.update('configopts', '--enable-nvidia-sm80-gpu')
-            else:
-                raise EasyBuildError('ELPA currently only supports specifying one architecture when '
+            if len(cuda_cc) != 1:
+                raise EasyBuildError('ELPA currently only supports specifying one CUDA architecture when '
                                      'building. You specified cuda-compute-capabilities: %s', cuda_cc)
+            cuda_cc = cuda_cc[0]
+            cuda_cc_string = cuda_cc.replace('.', '')
+            self.cfg.update('configopts', '--with-NVIDIA-GPU-compute-capability=sm_%s' % cuda_cc_string)
+            self.log.info("Enabling nvidia GPU support for compute capability: %s", cuda_cc_string)
+            # There is a dedicated kernel for sm80, but only from version 2021.11.001 onwards
+            if float(cuda_cc) >= 8.0 and LooseVersion(self.version) >= LooseVersion('2021.11.001'):
+                self.cfg.update('configopts', '--enable-nvidia-sm80-gpu')
 
         # From v2022.05.001 onwards, the config complains if CPP is not set, resulting in non-zero exit of configure
         # C preprocessor to use for given comp_fam

--- a/easybuild/easyblocks/e/elpa.py
+++ b/easybuild/easyblocks/e/elpa.py
@@ -201,7 +201,7 @@ class EB_ELPA(ConfigureMake):
             if len(cuda_cc) == 1:
                 cuda_cc = cuda_cc[0]
                 cuda_cc_string = cuda_cc.replace('.', '')
-                self.cfg.update('configopts', '--with-NVIDIA-GPU-compute-capability=%s' % cuda_cc_string)
+                self.cfg.update('configopts', '--with-NVIDIA-GPU-compute-capability=sm_%s' % cuda_cc_string)
                 self.log.info("Enabling nvidia GPU support for compute capability: %s", cuda_cc_string)
                 # There is a dedicated kernel for sm80, but only from version 2021.11.001 onwards
                 if float(cuda_cc) >= 8.0 and LooseVersion(self.version) >= LooseVersion('2021.11.001'):

--- a/easybuild/easyblocks/e/elpa.py
+++ b/easybuild/easyblocks/e/elpa.py
@@ -209,7 +209,7 @@ class EB_ELPA(ConfigureMake):
             if '8.0' in cuda_cc and LooseVersion(self.version) >= LooseVersion('2021.11.001'):
                 self.cfg.update('configopts', '--enable-nvidia-sm80-gpu')
 
-        # From v2022.05.001 onwards, the config complains if CPP is not set
+        # From v2022.05.001 onwards, the config complains if CPP is not set, resulting in non-zero exit of configure
         # C preprocessor to use for given comp_fam
         cpp_dict = {
             TC_CONSTANT_GCC: 'cpp',

--- a/easybuild/easyblocks/e/elpa.py
+++ b/easybuild/easyblocks/e/elpa.py
@@ -40,10 +40,10 @@ from easybuild.toolchains.compiler.inteliccifort import TC_CONSTANT_INTELCOMP
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option
 from easybuild.tools.filetools import apply_regex_substitutions
+from easybuild.tools.modules import get_software_root
 from easybuild.tools.systemtools import get_cpu_features, get_shared_lib_ext
 from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
 from easybuild.tools.utilities import nub
-from easybuild.tools.modules import get_software_root
 
 ELPA_CPU_FEATURE_FLAGS = ['avx', 'avx2', 'avx512f', 'vsx', 'sse4_2']
 


### PR DESCRIPTION
This PR does two things:

1. From v2022.05.001 onwards, the config complains if CPP is not set, resulting in non-zero exit of configure. This PR sets the CPP environment variable to `cpp` for GCC and intel based toolchains. For other toolchains, it will raise an error and ask the user to expand the functionality of the EasyBlock, to point to the correct C preprocessor.
2. Implement nvidia GPU support. This involves adding a combination of configure flags: `--enable-nvidia-gpu`, `--with-cuda-path`, `--with-cuda-sdk-path`, `--with-NVIDIA-GPU-compute-capability` and `--enable-nvidia-sm80-gpu`.

Some comments regarding the last flag: newer versions of ELPA have a dedicated kernel implemented for `sm80`. It's a bit strange that `--with-NVIDIA-GPU-compute-capability='sm_80'` does not seem to properly enable those, but they don't. The config just prints an info-message saying:

```
configure: You specified --with-NVIDIA-GPU-compute-capability=sm_80, but you did not --enable-nvidia-sm80-gpu. I will thus use the standard Nvidia GPU kernels (which is of course ok, just a info...)
```
My understanding is it will build the default kernel with the correct optimization (i.e. using `-arch sm_80`), but _not_ use the dedicated code for the `sm_80` kernel. It will only do the latter if we add `--enable-nvidia-sm80-gpu`.

An EasyConfig using the new cuda support can be found in
- [ ] https://github.com/easybuilders/easybuild-easyconfigs/pull/17436