### PR TITLE
Fail out if the MATLAB install key is not set

### DIFF
--- a/easybuild/easyblocks/m/matlab.py
+++ b/easybuild/easyblocks/m/matlab.py
@@ -159,7 +159,10 @@ class EB_MATLAB(PackedBinary):
 
         keys = self.cfg['key']
         if keys is None:
-            keys = os.getenv('EB_MATLAB_KEY', '00000-00000-00000-00000-00000-00000-00000-00000-00000-00000')
+            try:
+                keys = os.environ['EB_MATLAB_KEY']
+            except KeyError:
+                raise EasyBuildError("The MATLAB install key is not set.")
         if isinstance(keys, string_type):
             keys = keys.split(',')
 


### PR DESCRIPTION
It makes more sense to me to fail out if the MATLAB install key is not set, rather than install nothing.