### PR TITLE
use custom RPATH sanity check for Go packages that doesn't actually check for an RPATH section in the binary

### DIFF
--- a/easybuild/easyblocks/generic/gopackage.py
+++ b/easybuild/easyblocks/generic/gopackage.py
@@ -28,14 +28,17 @@ EasyBuild support for Go packages, implemented as an EasyBlock
 @author: Pavel Grochal (INUITS)
 """
 import os
+import re
 from distutils.version import LooseVersion
 
 import easybuild.tools.environment as env
-from easybuild.framework.easyblock import EasyBlock
+from easybuild.framework.easyblock import DEFAULT_BIN_LIB_SUBDIRS, EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.config import build_option
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
+from easybuild.tools.systemtools import get_linked_libs_raw
 
 
 class GoPackage(EasyBlock):
@@ -149,3 +152,75 @@ class GoPackage(EasyBlock):
         custom_commands = ['%s --help' % self.name.lower()]
 
         super(GoPackage, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
+
+    def sanity_check_rpath(self, rpath_dirs=None):
+        """Sanity check binaries/libraries w.r.t. RPATH linking."""
+
+        self.log.info("Checking RPATH linkage for binaries/libraries...")
+
+        fails = []
+
+        # hard reset $LD_LIBRARY_PATH before running RPATH sanity check
+        orig_env = env.unset_env_vars(['LD_LIBRARY_PATH'])
+
+        self.log.debug("$LD_LIBRARY_PATH during RPATH sanity check: %s", os.getenv('LD_LIBRARY_PATH', '(empty)'))
+        self.log.debug("List of loaded modules: %s", self.modules_tool.list())
+
+        not_found_regex = re.compile(r'(\S+)\s*\=\>\s*not found')
+        readelf_rpath_regex = re.compile('(RPATH)', re.M)
+
+        # List of libraries that should be exempt from the RPATH sanity check;
+        # For example, libcuda.so.1 should never be RPATH-ed by design,
+        # see https://github.com/easybuilders/easybuild-framework/issues/4095
+        filter_rpath_sanity_libs = build_option('filter_rpath_sanity_libs')
+        msg = "Ignoring the following libraries if they are not found by RPATH sanity check: %s"
+        self.log.info(msg, filter_rpath_sanity_libs)
+
+        if rpath_dirs is None:
+            rpath_dirs = self.cfg['bin_lib_subdirs'] or self.bin_lib_subdirs()
+
+        if not rpath_dirs:
+            rpath_dirs = DEFAULT_BIN_LIB_SUBDIRS
+            self.log.info("Using default subdirectories for binaries/libraries to verify RPATH linking: %s",
+                          rpath_dirs)
+        else:
+            self.log.info("Using specified subdirectories for binaries/libraries to verify RPATH linking: %s",
+                          rpath_dirs)
+
+        for dirpath in [os.path.join(self.installdir, d) for d in rpath_dirs]:
+            if os.path.exists(dirpath):
+                self.log.debug("Sanity checking RPATH for files in %s", dirpath)
+
+                for path in [os.path.join(dirpath, x) for x in os.listdir(dirpath)]:
+                    self.log.debug("Sanity checking RPATH for %s", path)
+
+                    out = get_linked_libs_raw(path)
+
+                    if out is None:
+                        msg = "Failed to determine dynamically linked libraries for %s, "
+                        msg += "so skipping it in RPATH sanity check"
+                        self.log.debug(msg, path)
+                    else:
+                        # check whether all required libraries are found via 'ldd'
+                        matches = re.findall(not_found_regex, out)
+                        if len(matches) > 0:  # Some libraries are not found via 'ldd'
+                            # For each match, check if the library is in the exception list
+                            for match in matches:
+                                if match in filter_rpath_sanity_libs:
+                                    msg = "Library %s not found for %s, but ignored "
+                                    msg += "since it is on the rpath exception list: %s"
+                                    self.log.info(msg, match, path, filter_rpath_sanity_libs)
+                                else:
+                                    fail_msg = "Library %s not found for %s; " % (match, path)
+                                    fail_msg += "RPATH linking is enabled, but not implemented for Go packages."
+                                    fail_msg += "See https://github.com/easybuilders/easybuild-easyconfigs/issues/17516"
+                                    self.log.warning(fail_msg)
+                                    fails.append(fail_msg)
+                        else:
+                            self.log.debug("Output of 'ldd %s' checked, looks OK", path)
+            else:
+                self.log.debug("Not sanity checking files in non-existing directory %s", dirpath)
+
+        env.restore_env_vars(orig_env)
+
+        return fails

--- a/easybuild/easyblocks/generic/gopackage.py
+++ b/easybuild/easyblocks/generic/gopackage.py
@@ -167,7 +167,6 @@ class GoPackage(EasyBlock):
         self.log.debug("List of loaded modules: %s", self.modules_tool.list())
 
         not_found_regex = re.compile(r'(\S+)\s*\=\>\s*not found')
-        readelf_rpath_regex = re.compile('(RPATH)', re.M)
 
         # List of libraries that should be exempt from the RPATH sanity check;
         # For example, libcuda.so.1 should never be RPATH-ed by design,

--- a/easybuild/easyblocks/generic/gopackage.py
+++ b/easybuild/easyblocks/generic/gopackage.py
@@ -28,17 +28,14 @@ EasyBuild support for Go packages, implemented as an EasyBlock
 @author: Pavel Grochal (INUITS)
 """
 import os
-import re
 from distutils.version import LooseVersion
 
 import easybuild.tools.environment as env
-from easybuild.framework.easyblock import DEFAULT_BIN_LIB_SUBDIRS, EasyBlock
+from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.config import build_option
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
-from easybuild.tools.systemtools import get_linked_libs_raw
 
 
 class GoPackage(EasyBlock):
@@ -134,9 +131,6 @@ class GoPackage(EasyBlock):
             self.cfg['preinstallopts'],
             'go',
             'install',
-            # print commands as they are executed,
-            # including downloading and installing of package deps as listed in the go.mod file
-            '-x',
             self.cfg['installopts'],
         ])
         run_cmd(cmd, log_all=True, log_ok=True, simple=True)
@@ -154,72 +148,4 @@ class GoPackage(EasyBlock):
         super(GoPackage, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
 
     def sanity_check_rpath(self, rpath_dirs=None):
-        """Sanity check binaries/libraries w.r.t. RPATH linking."""
-
-        self.log.info("Checking RPATH linkage for binaries/libraries...")
-
-        fails = []
-
-        # hard reset $LD_LIBRARY_PATH before running RPATH sanity check
-        orig_env = env.unset_env_vars(['LD_LIBRARY_PATH'])
-
-        self.log.debug("$LD_LIBRARY_PATH during RPATH sanity check: %s", os.getenv('LD_LIBRARY_PATH', '(empty)'))
-        self.log.debug("List of loaded modules: %s", self.modules_tool.list())
-
-        not_found_regex = re.compile(r'(\S+)\s*\=\>\s*not found')
-
-        # List of libraries that should be exempt from the RPATH sanity check;
-        # For example, libcuda.so.1 should never be RPATH-ed by design,
-        # see https://github.com/easybuilders/easybuild-framework/issues/4095
-        filter_rpath_sanity_libs = build_option('filter_rpath_sanity_libs')
-        msg = "Ignoring the following libraries if they are not found by RPATH sanity check: %s"
-        self.log.info(msg, filter_rpath_sanity_libs)
-
-        if rpath_dirs is None:
-            rpath_dirs = self.cfg['bin_lib_subdirs'] or self.bin_lib_subdirs()
-
-        if not rpath_dirs:
-            rpath_dirs = DEFAULT_BIN_LIB_SUBDIRS
-            self.log.info("Using default subdirectories for binaries/libraries to verify RPATH linking: %s",
-                          rpath_dirs)
-        else:
-            self.log.info("Using specified subdirectories for binaries/libraries to verify RPATH linking: %s",
-                          rpath_dirs)
-
-        for dirpath in [os.path.join(self.installdir, d) for d in rpath_dirs]:
-            if os.path.exists(dirpath):
-                self.log.debug("Sanity checking RPATH for files in %s", dirpath)
-
-                for path in [os.path.join(dirpath, x) for x in os.listdir(dirpath)]:
-                    self.log.debug("Sanity checking RPATH for %s", path)
-
-                    out = get_linked_libs_raw(path)
-
-                    if out is None:
-                        msg = "Failed to determine dynamically linked libraries for %s, "
-                        msg += "so skipping it in RPATH sanity check"
-                        self.log.debug(msg, path)
-                    else:
-                        # check whether all required libraries are found via 'ldd'
-                        matches = re.findall(not_found_regex, out)
-                        if len(matches) > 0:  # Some libraries are not found via 'ldd'
-                            # For each match, check if the library is in the exception list
-                            for match in matches:
-                                if match in filter_rpath_sanity_libs:
-                                    msg = "Library %s not found for %s, but ignored "
-                                    msg += "since it is on the rpath exception list: %s"
-                                    self.log.info(msg, match, path, filter_rpath_sanity_libs)
-                                else:
-                                    fail_msg = "Library %s not found for %s; " % (match, path)
-                                    fail_msg += "RPATH linking is enabled, but not implemented for Go packages."
-                                    fail_msg += "See https://github.com/easybuilders/easybuild-easyconfigs/issues/17516"
-                                    self.log.warning(fail_msg)
-                                    fails.append(fail_msg)
-                        else:
-                            self.log.debug("Output of 'ldd %s' checked, looks OK", path)
-            else:
-                self.log.debug("Not sanity checking files in non-existing directory %s", dirpath)
-
-        env.restore_env_vars(orig_env)
-
-        return fails
+        super(GoPackage, self).sanity_check_rpath(rpath_dirs=rpath_dirs, check_readelf_rpath=False)

--- a/easybuild/easyblocks/generic/gopackage.py
+++ b/easybuild/easyblocks/generic/gopackage.py
@@ -131,6 +131,9 @@ class GoPackage(EasyBlock):
             self.cfg['preinstallopts'],
             'go',
             'install',
+            # print commands as they are executed,
+            # including downloading and installing of package deps as listed in the go.mod file
+            '-x',
             self.cfg['installopts'],
         ])
         run_cmd(cmd, log_all=True, log_ok=True, simple=True)


### PR DESCRIPTION
With RPATH support enabled, the RPATH sanity check of the `GoPackage` easyblock always fails. See https://github.com/easybuilders/easybuild-easyconfigs/issues/17516.

This implements @casparvl's suggestion (https://github.com/easybuilders/easybuild-easyconfigs/issues/17516#issuecomment-1473843382) and doesn't run the `readelf` command on these binaries. In the rare case that a binary does actually depend on some external library, an error should be printed that explains that the current RPATH wrappers don't work for Go, and a link to the issue is printed as well.