### PR TITLE
use string '0' to avoid problems when opensll version is not determined

### DIFF
--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -162,7 +162,7 @@ class EB_OpenSSL_wrapper(Bundle):
             for solib in solibs:
                 system_solib = find_library_path(solib)
                 if system_solib:
-                    openssl_version = 0
+                    openssl_version = '0'
                     # get version of system library filename
                     try:
                         openssl_version = full_version_regex.search(os.path.realpath(system_solib)).group(0)


### PR DESCRIPTION
See https://github.com/easybuilders/easybuild/issues/864

```python
>>> from distutils.version import LooseVersion
>>> a = LooseVersion(0)
>>> a.version
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'LooseVersion' object has no attribute 'version'
```