### PR TITLE
stop importing from deprecated easybuild.tools.py2vs3 module + stop testing with Python 2.7 and 3.5

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10', '3.11']
+        python: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11']
         modules_tool: [Lmod-6.6.3, Lmod-7.8.22, Lmod-8.1.14, modules-tcl-1.147, modules-3.2.10, modules-4.1.4]
         module_syntax: [Lua, Tcl]
         # exclude some configuration for non-Lmod modules tool:
         # - don't test with Lua module syntax (only supported in Lmod)
-        # - don't test with Python 3.5 and 3.7+ (only with 2.7 and 3.6), to limit test configurations
+        # - don't test with Python 3.7+ (only with 3.6), to limit test configurations
         exclude:
           - modules_tool: modules-tcl-1.147
             module_syntax: Lua
@@ -27,8 +27,6 @@ jobs:
           - modules_tool: modules-4.1.4
             module_syntax: Lua
           - modules_tool: modules-tcl-1.147
-            python: 3.5
-          - modules_tool: modules-tcl-1.147
             python: 3.7
           - modules_tool: modules-tcl-1.147
             python: 3.8
@@ -37,8 +35,6 @@ jobs:
           - modules_tool: modules-tcl-1.147
             python: '3.10'
           - modules_tool: modules-3.2.10
-            python: 3.5
-          - modules_tool: modules-3.2.10
             python: 3.7
           - modules_tool: modules-3.2.10
             python: 3.8
@@ -46,8 +42,6 @@ jobs:
             python: 3.9
           - modules_tool: modules-3.2.10
             python: '3.10'
-          - modules_tool: modules-4.1.4
-            python: 3.5
           - modules_tool: modules-4.1.4
             python: 3.7
           - modules_tool: modules-4.1.4

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -80,7 +80,7 @@ jobs:
           # first determine which branch of easybuild-framework repo to install
           BRANCH=develop
           if [ "x$GITHUB_BASE_REF" = 'xmain' ]; then BRANCH=main; fi
-          if [ "x$GITHUB_BASE_REF" = 'x4.x' ]; then BRANCH=4.x; fi
+          if [ "x$GITHUB_BASE_REF" = 'x5.0.x' ]; then BRANCH=5.0.x; fi
           echo "Using easybuild-framework branch $BRANCH (\$GITHUB_BASE_REF $GITHUB_BASE_REF)"
           git clone -b $BRANCH --depth 10 --single-branch https://github.com/easybuilders/easybuild-framework.git
           cd easybuild-framework; git log -n 1; cd -

--- a/easybuild/easyblocks/a/abaqus.py
+++ b/easybuild/easyblocks/a/abaqus.py
@@ -32,9 +32,10 @@ EasyBuild support for ABAQUS, implemented as an easyblock
 @author: Jens Timmerman (Ghent University)
 @author: Simon Branford (University of Birmingham)
 """
-from distutils.version import LooseVersion
 import glob
 import os
+from collections import OrderedDict
+from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.binary import Binary
 from easybuild.framework.easyblock import EasyBlock
@@ -45,7 +46,6 @@ from easybuild.tools.filetools import change_dir, symlink, write_file
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd_qa
 from easybuild.tools.systemtools import get_os_name
-from easybuild.tools.py2vs3 import OrderedDict
 
 
 class EB_ABAQUS(Binary):

--- a/easybuild/easyblocks/a/aladin.py
+++ b/easybuild/easyblocks/a/aladin.py
@@ -33,6 +33,7 @@ import re
 import shutil
 import sys
 import tempfile
+from collections import OrderedDict
 
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain
@@ -41,7 +42,6 @@ from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import apply_regex_substitutions, mkdir
 from easybuild.tools.modules import get_software_root, get_software_libdir
-from easybuild.tools.py2vs3 import OrderedDict
 from easybuild.tools.run import run_cmd, run_cmd_qa
 
 

--- a/easybuild/easyblocks/e/easybuildmeta.py
+++ b/easybuild/easyblocks/e/easybuildmeta.py
@@ -31,13 +31,13 @@ import copy
 import os
 import re
 import sys
+from collections import OrderedDict
 from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage, det_pip_version
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import apply_regex_substitutions, change_dir, read_file
 from easybuild.tools.modules import get_software_root_env_var_name
-from easybuild.tools.py2vs3 import OrderedDict
 from easybuild.tools.utilities import flatten
 
 

--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -41,7 +41,6 @@ from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.easyconfig.easyconfig import get_easyblock_class
 from easybuild.tools.build_log import EasyBuildError, print_msg
 from easybuild.tools.modules import get_software_root, get_software_version
-from easybuild.tools.py2vs3 import string_type
 
 
 class Bundle(EasyBlock):
@@ -163,7 +162,7 @@ class Bundle(EasyBlock):
                 # If per-component source URLs are provided, attach them directly to the relevant sources
                 if comp_cfg['source_urls']:
                     for source in comp_cfg['sources']:
-                        if isinstance(source, string_type):
+                        if isinstance(source, str):
                             self.cfg.update('sources', [{'filename': source, 'source_urls': comp_cfg['source_urls']}])
                         elif isinstance(source, dict):
                             # Update source_urls in the 'source' dict to use the one for the components
@@ -266,7 +265,7 @@ class Bundle(EasyBlock):
 
             # find match entries in self.src for this component
             for source in comp.cfg['sources']:
-                if isinstance(source, string_type):
+                if isinstance(source, str):
                     comp_src_fn = source
                 elif isinstance(source, dict):
                     if 'filename' in source:

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -47,7 +47,7 @@ from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.easyconfig.default import DEFAULT_CONFIG
 from easybuild.framework.easyconfig.templates import TEMPLATE_CONSTANTS
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
-from easybuild.tools.asyncprocess import subprocess_popen_text
+from easybuild.tools.run import subprocess_popen_text
 from easybuild.tools.build_log import EasyBuildError, print_msg
 from easybuild.tools.config import build_option
 from easybuild.tools.filetools import mkdir, remove_dir, which

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -47,11 +47,11 @@ from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.easyconfig.default import DEFAULT_CONFIG
 from easybuild.framework.easyconfig.templates import TEMPLATE_CONSTANTS
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
+from easybuild.tools.asyncprocess import subprocess_popen_text
 from easybuild.tools.build_log import EasyBuildError, print_msg
 from easybuild.tools.config import build_option
 from easybuild.tools.filetools import mkdir, remove_dir, which
 from easybuild.tools.modules import get_software_root
-from easybuild.tools.py2vs3 import string_type, subprocess_popen_text
 from easybuild.tools.run import run_cmd
 from easybuild.tools.utilities import nub
 from easybuild.tools.hooks import CONFIGURE_STEP, BUILD_STEP, TEST_STEP, INSTALL_STEP
@@ -503,7 +503,7 @@ class PythonPackage(ExtensionEasyBlock):
             if self._should_unpack_source():
                 # specify current directory
                 loc = '.'
-            elif isinstance(self.src, string_type):
+            elif isinstance(self.src, str):
                 # for extensions, self.src specifies the location of the source file
                 loc = self.src
             else:
@@ -653,7 +653,7 @@ class PythonPackage(ExtensionEasyBlock):
         :param return_output: return output and exit code of test command
         """
 
-        if isinstance(self.cfg['runtest'], string_type):
+        if isinstance(self.cfg['runtest'], str):
             self.testcmd = self.cfg['runtest']
 
         if self.cfg['runtest'] and self.testcmd is not None:

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -47,12 +47,11 @@ from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.easyconfig.default import DEFAULT_CONFIG
 from easybuild.framework.easyconfig.templates import TEMPLATE_CONSTANTS
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
-from easybuild.tools.run import subprocess_popen_text
 from easybuild.tools.build_log import EasyBuildError, print_msg
 from easybuild.tools.config import build_option
 from easybuild.tools.filetools import mkdir, remove_dir, which
 from easybuild.tools.modules import get_software_root
-from easybuild.tools.run import run_cmd
+from easybuild.tools.run import run_cmd, subprocess_popen_text
 from easybuild.tools.utilities import nub
 from easybuild.tools.hooks import CONFIGURE_STEP, BUILD_STEP, TEST_STEP, INSTALL_STEP
 

--- a/easybuild/easyblocks/m/matlab.py
+++ b/easybuild/easyblocks/m/matlab.py
@@ -43,7 +43,6 @@ from easybuild.easyblocks.generic.packedbinary import PackedBinary
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import adjust_permissions, change_dir, copy_file, read_file, write_file
-from easybuild.tools.py2vs3 import string_type
 from easybuild.tools.run import run_cmd
 
 
@@ -160,7 +159,7 @@ class EB_MATLAB(PackedBinary):
         keys = self.cfg['key']
         if keys is None:
             keys = os.getenv('EB_MATLAB_KEY', '00000-00000-00000-00000-00000-00000-00000-00000-00000-00000')
-        if isinstance(keys, string_type):
+        if isinstance(keys, str):
             keys = keys.split(',')
 
         # Compile the installation key regex outside of the loop

--- a/easybuild/easyblocks/m/mcr.py
+++ b/easybuild/easyblocks/m/mcr.py
@@ -44,7 +44,6 @@ from easybuild.easyblocks.generic.packedbinary import PackedBinary
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import adjust_permissions, read_file, write_file
-from easybuild.tools.py2vs3 import string_type
 from easybuild.tools.run import run_cmd
 
 
@@ -116,7 +115,7 @@ class EB_MCR(PackedBinary):
     def sanity_check_step(self):
         """Custom sanity check for MCR."""
         self.set_subdir()
-        if not isinstance(self.subdir, string_type):
+        if not isinstance(self.subdir, str):
             raise EasyBuildError("Could not identify which subdirectory to pick: %s" % self.subdir)
 
         custom_paths = {
@@ -140,7 +139,7 @@ class EB_MCR(PackedBinary):
         self.set_subdir()
         # if no subdir was selected, set it to NOTFOUND
         # this is done to enable the use of --module-only without having an actual MCR installation
-        if not isinstance(self.subdir, string_type):
+        if not isinstance(self.subdir, str):
             self.subdir = 'NOTFOUND'
 
         xapplresdir = os.path.join(self.installdir, self.subdir, 'X11', 'app-defaults')

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -36,7 +36,6 @@ from easybuild.easyblocks.generic.bundle import Bundle
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError, print_warning
 from easybuild.tools.filetools import change_dir, expand_glob_paths, mkdir, read_file, symlink, which, write_file
-from easybuild.tools.py2vs3 import string_type
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import DARWIN, LINUX, get_os_type, get_shared_lib_ext, find_library_path
 
@@ -84,7 +83,7 @@ class EB_OpenSSL_wrapper(Bundle):
 
         if not min_openssl_version:
             min_openssl_version = self.version
-        elif not isinstance(min_openssl_version, string_type):
+        elif not isinstance(min_openssl_version, str):
             min_openssl_version = str(min_openssl_version)
 
         # Minimum OpenSSL version can only increase depth of wrapper version

--- a/easybuild/easyblocks/o/orca.py
+++ b/easybuild/easyblocks/o/orca.py
@@ -36,7 +36,6 @@ from easybuild.easyblocks.generic.packedbinary import PackedBinary
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import write_file
-from easybuild.tools.py2vs3 import string_type
 from easybuild.tools.systemtools import X86_64, get_cpu_architecture
 
 
@@ -112,7 +111,7 @@ class EB_ORCA(PackedBinary, MakeCp):
                     if isinstance(spec, tuple):
                         file_pattern = spec[0]
                         dest_dir = spec[1]
-                    elif isinstance(spec, string_type):
+                    elif isinstance(spec, str):
                         file_pattern = spec
                         dest_dir = ''
                     else:
@@ -120,7 +119,7 @@ class EB_ORCA(PackedBinary, MakeCp):
                             "Found neither string nor tuple as file to copy: '%s' (type %s)", spec, type(spec)
                         )
 
-                    if isinstance(file_pattern, string_type):
+                    if isinstance(file_pattern, str):
                         file_pattern = [file_pattern]
 
                     source_files = []

--- a/easybuild/easyblocks/p/perl.py
+++ b/easybuild/easyblocks/p/perl.py
@@ -39,7 +39,6 @@ from easybuild.tools.config import build_option
 from easybuild.tools.filetools import adjust_permissions
 from easybuild.tools.environment import setvar, unset_env_vars
 from easybuild.tools.modules import get_software_root
-from easybuild.tools.py2vs3 import string_type
 from easybuild.tools.run import run_cmd
 
 # perldoc -lm seems to be the safest way to test if a module is available, based on exit code
@@ -124,7 +123,7 @@ class EB_Perl(ConfigureMake):
         # allow escaping with runtest = False
         if self.cfg['runtest'] is None or self.cfg['runtest']:
             parallel = self.cfg['parallel']
-            if isinstance(self.cfg['runtest'], string_type):
+            if isinstance(self.cfg['runtest'], str):
                 cmd = "make %s" % self.cfg['runtest']
             elif parallel and LooseVersion(self.version) >= LooseVersion('5.30.0'):
                 # run tests in parallel, see https://perldoc.perl.org/perlhack#Parallel-tests;

--- a/easybuild/easyblocks/p/petsc.py
+++ b/easybuild/easyblocks/p/petsc.py
@@ -40,7 +40,6 @@ from easybuild.tools.filetools import symlink, apply_regex_substitutions
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
-from easybuild.tools.py2vs3 import string_type
 
 NO_MPI_CXX_EXT_FLAGS = '-DOMPI_SKIP_MPICXX -DMPICH_SKIP_MPICXX'
 
@@ -218,7 +217,7 @@ class EB_PETSc(ConfigureMake):
 
             deps = [dep['name'] for dep in self.cfg.dependencies() if not dep['name'] in depfilter]
             for dep in deps:
-                if isinstance(dep, string_type):
+                if isinstance(dep, str):
                     dep = (dep, dep)
                 deproot = get_software_root(dep[0])
                 if deproot:

--- a/easybuild/easyblocks/s/scipion.py
+++ b/easybuild/easyblocks/s/scipion.py
@@ -28,6 +28,7 @@ EasyBuild support for building and installing Scipion, implemented as an easyblo
 @author: Kenneth Hoste (Ghent University)
 @author: Ake Sandgren (HPC2N, Umea University)
 """
+import configparser
 import os
 
 from distutils.version import LooseVersion
@@ -35,7 +36,6 @@ from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import copy, mkdir, symlink
 from easybuild.tools.modules import get_software_root, get_software_version
-from easybuild.tools.py2vs3 import configparser
 from easybuild.tools.run import run_cmd
 
 

--- a/easybuild/easyblocks/t/trilinos.py
+++ b/easybuild/easyblocks/t/trilinos.py
@@ -32,6 +32,7 @@ import random
 import re
 
 from distutils.version import LooseVersion
+from string import ascii_letters
 
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
@@ -40,7 +41,6 @@ from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_path
 from easybuild.tools.filetools import mkdir, remove_dir, symlink
 from easybuild.tools.modules import get_software_root
-from easybuild.tools.py2vs3 import ascii_letters
 from easybuild.tools.systemtools import get_shared_lib_ext
 
 

--- a/easybuild/easyblocks/u/ucx_plugins.py
+++ b/easybuild/easyblocks/u/ucx_plugins.py
@@ -32,10 +32,9 @@ from collections import defaultdict
 import os
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
-from easybuild.tools.run import subprocess_popen_text
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
-from easybuild.tools.run import run_cmd
+from easybuild.tools.run import run_cmd, subprocess_popen_text
 from easybuild.tools.systemtools import get_shared_lib_ext
 
 

--- a/easybuild/easyblocks/u/ucx_plugins.py
+++ b/easybuild/easyblocks/u/ucx_plugins.py
@@ -32,7 +32,7 @@ from collections import defaultdict
 import os
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
-from easybuild.tools.asyncprocess import subprocess_popen_text
+from easybuild.tools.run import subprocess_popen_text
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd

--- a/easybuild/easyblocks/u/ucx_plugins.py
+++ b/easybuild/easyblocks/u/ucx_plugins.py
@@ -32,9 +32,9 @@ from collections import defaultdict
 import os
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.asyncprocess import subprocess_popen_text
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
-from easybuild.tools.py2vs3 import subprocess_popen_text
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
 

--- a/test/easyblocks/easyblock_specific.py
+++ b/test/easyblocks/easyblock_specific.py
@@ -33,6 +33,7 @@ import stat
 import sys
 import tempfile
 import textwrap
+from io import StringIO
 from unittest import TestLoader, TextTestRunner
 from test.easyblocks.module import cleanup
 
@@ -49,7 +50,6 @@ from easybuild.tools.environment import modify_env
 from easybuild.tools.filetools import adjust_permissions, remove_dir, write_file
 from easybuild.tools.modules import modules_tool
 from easybuild.tools.options import set_tmpdir
-from easybuild.tools.py2vs3 import StringIO
 
 
 class EasyBlockSpecificTest(TestCase):


### PR DESCRIPTION
* [x] https://github.com/easybuilders/easybuild-framework/pull/4229