### PR TITLE
update GCC easyblock to ensure that `--sysroot` is passed to linker (but only when it needs to be)

### DIFF
--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -357,9 +357,6 @@ class EB_GCC(ConfigureMake):
             # (see https://gcc.gnu.org/install/configure.html)
             self.cfg.update('configopts', '--with-sysroot=%s' % sysroot)
 
-            # avoid that --sysroot is passed to linker by patching value for SYSROOT_SPEC in gcc/gcc.c
-            apply_regex_substitutions(os.path.join('gcc', 'gcc.c'), [('--sysroot=%R', '')])
-
             # prefix dynamic linkers with sysroot
             # this patches lines like:
             # #define GLIBC_DYNAMIC_LINKER64 "/lib64/ld-linux-x86-64.so.2"


### PR DESCRIPTION
This removes an adjustment to `gcc/gcc.c` which avoided that `--sysroot` is passed to the linker. Since a recent change to how Gentoo supports sysroot (see https://github.com/gentoo/gentoo/pull/28851) we need to change the easyblock for gcc.

A bit of testing revealed that only the removed line(s) are not needed any longer.

So far it has been tested for an EESSI-like environment with a recent compatibility layer version (Gentoo commit from April 17) with:
- ~GCC/9.3.0~ not tested, but might be ignore for EESSI at least
- [x] GCC/10.3.0 on `x86_64/{generic,amd/zen2,intel/broadwell,intel/cascadelake,intel/skylake_avx512` and `aarch64/generic`
- [x] GCC/11.3.0 on `x86_64/{generic,amd/zen2,intel/broadwell,intel/cascadelake,intel/skylake_avx512` and `aarch64/generic`
- [x] GCC/12.2.0 on `x86_64/{generic,amd/zen2,intel/broadwell,intel/cascadelake,intel/skylake_avx512` and `aarch64/generic`