### PR TITLE
Improve depot management in JuliaPackage

### DIFF
--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -86,9 +86,12 @@ class JuliaBundle(Bundle):
             raise EasyBuildError("Julia not included as dependency!")
 
     def make_module_extra(self, *args, **kwargs):
-        """Prepend installation directory to JULIA_DEPOT_PATH in module file."""
+        """
+        Module has to append installation directory to JULIA_DEPOT_PATH to keep
+        the user depot in the top entry. See issue easybuilders/easybuild-easyconfigs#17455
+        """
         txt = super(JuliaBundle, self).make_module_extra()
-        txt += self.module_generator.prepend_paths('JULIA_DEPOT_PATH', [''])
+        txt += self.module_generator.append_paths('JULIA_DEPOT_PATH', [''])
         return txt
 
     def sanity_check_step(self, *args, **kwargs):

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -177,7 +177,10 @@ class JuliaPackage(ExtensionEasyBlock):
         return ExtensionEasyBlock.sanity_check_step(self, EXTS_FILTER_JULIA_PACKAGES, *args, **kwargs)
 
     def make_module_extra(self):
-        """Prepend installation directory to JULIA_DEPOT_PATH in module file."""
+        """
+        Module has to append installation directory to JULIA_DEPOT_PATH to keep
+        the user depot in the top entry. See issue easybuilders/easybuild-easyconfigs#17455
+        """
         txt = super(JuliaPackage, self).make_module_extra()
-        txt += self.module_generator.prepend_paths('JULIA_DEPOT_PATH', [''])
+        txt += self.module_generator.append_paths('JULIA_DEPOT_PATH', [''])
         return txt


### PR DESCRIPTION
* fixes [easybuild-easyconfigs#17961](https://github.com/easybuilders/easybuild-easyconfigs/issues/17961): user depot will be removed from `JULIA_DEPOT_PATH` during installation and depot in `installdir` will be prepended to it
* partial-fix for [easybuild-easyconfigs#17455](https://github.com/easybuilders/easybuild-easyconfigs/issues/17455): paths to depots of loaded modules will be appended to `JULIA_DEPOT_PATH` on module load to preserve the user depot as top entry in the list