### PR TITLE
add check to make sure that easyblocks that derive from Extension and customize sanity_check_step have a return statement

### DIFF
--- a/easybuild/easyblocks/d/dolfin.py
+++ b/easybuild/easyblocks/d/dolfin.py
@@ -356,4 +356,4 @@ class EB_DOLFIN(CMakePythonPackage):
             'dirs': ['%s/dolfin' % self.pylibdir],
         }
 
-        super(EB_DOLFIN, self).sanity_check_step(custom_paths=custom_paths)
+        return super(EB_DOLFIN, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/e/easybuildmeta.py
+++ b/easybuild/easyblocks/e/easybuildmeta.py
@@ -276,7 +276,8 @@ class EB_EasyBuildMeta(PythonPackage):
             val = self.initial_environ.pop(key)
             self.log.info("$%s found in environment, unset for running sanity check (was: %s)", key, val)
 
-        super(EB_EasyBuildMeta, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
+        return super(EB_EasyBuildMeta, self).sanity_check_step(custom_paths=custom_paths,
+                                                               custom_commands=custom_commands)
 
     def make_module_extra(self):
         """

--- a/easybuild/easyblocks/e/egglib.py
+++ b/easybuild/easyblocks/e/egglib.py
@@ -85,4 +85,4 @@ class EB_EggLib(PythonPackage, ConfigureMake):
             'files': ['bin/egglib', 'lib/libegglib-cpp.a'],
             'dirs': ['include/egglib-cpp', self.pylibdir],
         }
-        super(EB_EggLib, self).sanity_check_step(custom_paths=custom_paths)
+        return super(EB_EggLib, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/f/freesurfer.py
+++ b/easybuild/easyblocks/f/freesurfer.py
@@ -92,4 +92,4 @@ class EB_FreeSurfer(Tarball):
             'dirs': ['bin', 'lib', 'mni'],
         }
 
-        super(EB_FreeSurfer, self).sanity_check_step(custom_paths=custom_paths)
+        return super(EB_FreeSurfer, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/g/gurobi.py
+++ b/easybuild/easyblocks/g/gurobi.py
@@ -93,7 +93,7 @@ class EB_Gurobi(Tarball):
         if get_software_root('Python'):
             custom_commands.append("python -c 'import gurobipy'")
 
-        super(EB_Gurobi, self).sanity_check_step(custom_commands=custom_commands, custom_paths=custom_paths)
+        return super(EB_Gurobi, self).sanity_check_step(custom_commands=custom_commands, custom_paths=custom_paths)
 
     def make_module_extra(self):
         """Custom extra module file entries for Gurobi."""

--- a/easybuild/easyblocks/generic/vscpythonpackage.py
+++ b/easybuild/easyblocks/generic/vscpythonpackage.py
@@ -46,5 +46,6 @@ class VSCPythonPackage(VersionIndependentPythonPackage):
         pythonpath = os.environ.get('PYTHONPATH', '')
         os.environ['PYTHONPATH'] = ''
         kwargs.update({'exts_filter': ('%s -s -S -c "import %%(ext_name)s"' % self.python_cmd, "")})
-        super(VSCPythonPackage, self).sanity_check_step(*args, **kwargs)
+        res = super(VSCPythonPackage, self).sanity_check_step(*args, **kwargs)
         os.environ['PYTHONPATH'] = pythonpath
+        return res

--- a/easybuild/easyblocks/h/hadoop.py
+++ b/easybuild/easyblocks/h/hadoop.py
@@ -106,7 +106,7 @@ class EB_Hadoop(Tarball):
             'files': ['bin/hadoop'] + native_files,
             'dirs': ['etc', 'libexec'],
         }
-        super(EB_Hadoop, self).sanity_check_step(custom_paths=custom_paths)
+        res = super(EB_Hadoop, self).sanity_check_step(custom_paths=custom_paths)
 
         fake_mod_data = self.load_fake_module(purge=True)
         # exit code is ignored, since this cmd exits with 1 if not all native libraries were found
@@ -122,6 +122,8 @@ class EB_Hadoop(Tarball):
                 not_found.append(native_lib)
         if not_found:
             raise EasyBuildError("%s not found by 'hadoop checknative -a'.", ', '.join(not_found))
+
+        return res
 
     def make_module_extra(self):
         """Custom extra module file entries for Hadoop."""

--- a/easybuild/easyblocks/l/libxml2.py
+++ b/easybuild/easyblocks/l/libxml2.py
@@ -153,4 +153,4 @@ class EB_libxml2(ConfigureMake, PythonPackage):
             custom_paths['files'].extend([os.path.join(self.pylibdir, f) for f in pyfiles])
             custom_paths['dirs'].append(self.pylibdir)
 
-        ConfigureMake.sanity_check_step(self, custom_paths=custom_paths)
+        return ConfigureMake.sanity_check_step(self, custom_paths=custom_paths)

--- a/easybuild/easyblocks/m/metagenome_atlas.py
+++ b/easybuild/easyblocks/m/metagenome_atlas.py
@@ -84,7 +84,7 @@ class EB_Metagenome_Atlas(PythonPackage):
             'atlas init --help',
             'atlas run --help',
         ]
-        super(PythonPackage, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
+        return super(PythonPackage, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
 
 
 # obtained from

--- a/easybuild/easyblocks/m/mtl4.py
+++ b/easybuild/easyblocks/m/mtl4.py
@@ -45,7 +45,7 @@ class EB_MTL4(Tarball):
             'dirs': [os.path.join(incpref, x) for x in ["itl", "linear_algebra", "meta_math", "mtl"]],
         }
 
-        super(EB_MTL4, self).sanity_check_step(custom_paths=custom_paths)
+        return super(EB_MTL4, self).sanity_check_step(custom_paths=custom_paths)
 
     def make_module_req_guess(self):
         """Adjust CPATH for MTL4."""

--- a/easybuild/easyblocks/p/picard.py
+++ b/easybuild/easyblocks/p/picard.py
@@ -81,7 +81,7 @@ class EB_picard(Tarball):
             'dirs': [],
         }
 
-        super(EB_picard, self).sanity_check_step(custom_paths=custom_paths)
+        return super(EB_picard, self).sanity_check_step(custom_paths=custom_paths)
 
     def make_module_extra(self):
         """Add module entries specific to picard"""

--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -409,7 +409,7 @@ class EB_PyTorch(PythonPackage):
                 fail_msg = 'found one or more downloaded dependencies: %s' % ', '.join(downloaded_deps)
                 self.sanity_check_fail_msgs.append(fail_msg)
 
-        super(EB_PyTorch, self).sanity_check_step(*args, **kwargs)
+        return super(EB_PyTorch, self).sanity_check_step(*args, **kwargs)
 
     def make_module_req_guess(self):
         """Set extra environment variables for PyTorch."""

--- a/easybuild/easyblocks/r/repeatmasker.py
+++ b/easybuild/easyblocks/r/repeatmasker.py
@@ -126,7 +126,8 @@ class EB_RepeatMasker(Tarball):
 
         custom_commands = ['RepeatMasker']
 
-        super(EB_RepeatMasker, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
+        return super(EB_RepeatMasker, self).sanity_check_step(custom_paths=custom_paths,
+                                                              custom_commands=custom_commands)
 
     def make_module_req_guess(self):
         """Custom guesses for path-like environment variables for RepeatMaskerConfig."""

--- a/easybuild/easyblocks/r/repeatmodeler.py
+++ b/easybuild/easyblocks/r/repeatmodeler.py
@@ -182,7 +182,8 @@ class EB_RepeatModeler(Tarball):
 
         custom_commands = [("RepeatModeler -help 2>&1 | grep 'RepeatModeler - Model repetitive DNA'", '')]
 
-        super(EB_RepeatModeler, self).sanity_check_step(custom_commands=custom_commands, custom_paths=custom_paths)
+        return super(EB_RepeatModeler, self).sanity_check_step(custom_commands=custom_commands,
+                                                               custom_paths=custom_paths)
 
     def make_module_req_guess(self):
         """Custom guesses for path-like environment variables for RepeatModelerConfig."""

--- a/easybuild/easyblocks/s/sepp.py
+++ b/easybuild/easyblocks/s/sepp.py
@@ -86,4 +86,4 @@ class EB_SEPP(PythonPackage):
         }
         custom_commands = ["%s --help" % s for s in scripts]
 
-        super(EB_SEPP, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
+        return super(EB_SEPP, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)

--- a/easybuild/easyblocks/t/tensorrt.py
+++ b/easybuild/easyblocks/t/tensorrt.py
@@ -133,6 +133,4 @@ class EB_TensorRT(PythonPackage, Binary):
 
         custom_commands = ["%s -c 'import tensorrt'" % self.python_cmd]
 
-        res = super(EB_TensorRT, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
-
-        return res
+        return super(EB_TensorRT, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)

--- a/easybuild/easyblocks/t/torchvision.py
+++ b/easybuild/easyblocks/t/torchvision.py
@@ -96,4 +96,4 @@ class EB_torchvision(PythonPackage):
             ])
             custom_commands.append('python -c "%s"' % python_code)
 
-        super(EB_torchvision, self).sanity_check_step(custom_commands=custom_commands)
+        return super(EB_torchvision, self).sanity_check_step(custom_commands=custom_commands)

--- a/easybuild/easyblocks/u/ufc.py
+++ b/easybuild/easyblocks/u/ufc.py
@@ -91,4 +91,4 @@ class EB_UFC(CMakePythonPackage):
             'files': ['include/ufc.h'],
             'dirs': ['lib/python%s/site-packages/%s/' % (self.pyver, x) for x in ['ufc', 'ufc_utils']],
         }
-        super(EB_UFC, self).sanity_check_step(custom_paths=custom_paths)
+        return super(EB_UFC, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/v/vsc_tools.py
+++ b/easybuild/easyblocks/v/vsc_tools.py
@@ -85,7 +85,7 @@ class EB_VSC_minus_tools(PythonPackage):
             'dirs': ['lib'],
         }
 
-        super(EB_VSC_minus_tools, self).sanity_check_step(custom_paths=custom_paths)
+        return super(EB_VSC_minus_tools, self).sanity_check_step(custom_paths=custom_paths)
 
     def make_module_extra(self):
         """Add install path to PYTHONPATH"""


### PR DESCRIPTION
Draft PR, since we should test that adding the `return` statement to the various easyblocks doesn't break anything (it shouldn't).

Motivated by fixes in #2938