### PR TITLE
stop running tests with Python 2.7 since it is no longer supported in GitHub Actions

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10', '3.11']
+        python: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10', '3.11']
         modules_tool: [Lmod-6.6.3, Lmod-7.8.22, Lmod-8.1.14, modules-tcl-1.147, modules-3.2.10, modules-4.1.4]
         module_syntax: [Lua, Tcl]
         # exclude some configuration for non-Lmod modules tool:
         # - don't test with Lua module syntax (only supported in Lmod)
-        # - don't test with Python 3.5 and 3.7+ (only with 2.7 and 3.6), to limit test configurations
+        # - don't test with Python 3.5 and 3.7+ (only with 3.6), to limit test configurations
         exclude:
           - modules_tool: modules-tcl-1.147
             module_syntax: Lua
@@ -36,6 +36,8 @@ jobs:
             python: 3.9
           - modules_tool: modules-tcl-1.147
             python: '3.10'
+          - modules_tool: modules-tcl-1.147
+            python: '3.11'
           - modules_tool: modules-3.2.10
             python: 3.5
           - modules_tool: modules-3.2.10
@@ -46,6 +48,8 @@ jobs:
             python: 3.9
           - modules_tool: modules-3.2.10
             python: '3.10'
+          - modules_tool: modules-3.2.10
+            python: '3.11'
           - modules_tool: modules-4.1.4
             python: 3.5
           - modules_tool: modules-4.1.4
@@ -56,6 +60,8 @@ jobs:
             python: 3.9
           - modules_tool: modules-4.1.4
             python: '3.10'
+          - modules_tool: modules-4.1.4
+            python: '3.11'
       fail-fast: false
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Fix for problem with `actions/setup-python`:
```
Error: Version 2.7 with arch x64 not found
```

Python 2.7 is no longer available in GitHub Actions, see https://github.com/actions/runner-images/issues/7401 and https://github.com/actions/setup-python/issues/672