### PR TITLE
reset modules loaded by PythonPackage to let ExtensionEasyBlock handle `multi_deps` correctly

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -923,6 +923,12 @@ class PythonPackage(ExtensionEasyBlock):
             else:
                 raise EasyBuildError("Failed to determine pip version!")
 
+        # ExtensionEasyBlock handles loading modules correctly for multi_deps, so we clean up fake_mod_data
+        # and let ExtensionEasyBlock do its job
+        if 'Python' in self.cfg["multi_deps"] and self.fake_mod_data:
+            self.clean_up_fake_module(self.fake_mod_data)
+            self.sanity_check_module_loaded = False
+
         parent_success, parent_fail_msg = super(PythonPackage, self).sanity_check_step(*args, **kwargs)
 
         if parent_fail_msg:


### PR DESCRIPTION
`PythonPackage`'s `sanity_check_step` loads modules, but is unaware of the handling of `multi_deps` done by the `ExtensionEasyBlock` version of `sanity_check_step`. 

This PR unloads the modules loaded during `PythonPackage`'s version to let `ExtensionEasyBlock` handle `multi_deps` correctly. 