### PR TITLE
add options to `MesonNinja` easyblock to customize `build_cmd`, `install_cmd`, `builddir`

### DIFF
--- a/easybuild/easyblocks/generic/mesonninja.py
+++ b/easybuild/easyblocks/generic/mesonninja.py
@@ -54,7 +54,7 @@ class MesonNinja(EasyBlock):
             'configure_cmd': [DEFAULT_CONFIGURE_CMD, "Configure command to use", CUSTOM],
             'separate_build_dir': [True, "Perform build in a separate directory", CUSTOM],
             'build_cmd': [DEFAULT_BUILD_CMD, "Build command to use", CUSTOM],
-            'builddir': [None, "builddir to pass to meson", CUSTOM],
+            'build_dir': [None, "build_dir to pass to meson", CUSTOM],
             'install_cmd': [DEFAULT_INSTALL_CMD, "Install command to use", CUSTOM],
         })
         return extra_vars
@@ -90,14 +90,14 @@ class MesonNinja(EasyBlock):
                 configure_cmd == DEFAULT_CONFIGURE_CMD):
             configure_cmd += ' setup'
 
-        builddir = self.cfg.get('builddir') or self.start_dir
+        build_dir = self.cfg.get('build_dir') or self.start_dir
 
-        cmd = "%(preconfigopts)s %(configure_cmd)s --prefix %(installdir)s %(configopts)s %(sourcedir)s" % {
+        cmd = "%(preconfigopts)s %(configure_cmd)s --prefix %(installdir)s %(configopts)s %(source_dir)s" % {
             'configopts': self.cfg['configopts'],
             'configure_cmd': configure_cmd,
             'installdir': self.installdir,
             'preconfigopts': self.cfg['preconfigopts'],
-            'sourcedir': builddir,
+            'source_dir': build_dir,
         }
         (out, _) = run_cmd(cmd, log_all=True, simple=False)
         return out

--- a/easybuild/easyblocks/generic/mesonninja.py
+++ b/easybuild/easyblocks/generic/mesonninja.py
@@ -37,7 +37,8 @@ from easybuild.tools.modules import get_software_version
 from easybuild.tools.run import run_cmd
 
 DEFAULT_CONFIGURE_CMD = 'meson'
-
+DEFAULT_BUILD_CMD = 'ninja'
+DEFAULT_INSTALL_CMD = 'ninja'
 
 class MesonNinja(EasyBlock):
     """
@@ -51,6 +52,9 @@ class MesonNinja(EasyBlock):
         extra_vars.update({
             'configure_cmd': [DEFAULT_CONFIGURE_CMD, "Configure command to use", CUSTOM],
             'separate_build_dir': [True, "Perform build in a separate directory", CUSTOM],
+            'build_cmd': [DEFAULT_BUILD_CMD, "Build command to use", CUSTOM],
+            'builddir': [None, "builddir to pass to meson", CUSTOM],
+            'install_cmd': [DEFAULT_INSTALL_CMD, "Install command to use", CUSTOM],
         })
         return extra_vars
 
@@ -85,12 +89,14 @@ class MesonNinja(EasyBlock):
                 configure_cmd == DEFAULT_CONFIGURE_CMD):
             configure_cmd += ' setup'
 
+        builddir = self.cfg.get('builddir') or self.start_dir
+
         cmd = "%(preconfigopts)s %(configure_cmd)s --prefix %(installdir)s %(configopts)s %(sourcedir)s" % {
             'configopts': self.cfg['configopts'],
             'configure_cmd': configure_cmd,
             'installdir': self.installdir,
             'preconfigopts': self.cfg['preconfigopts'],
-            'sourcedir': self.start_dir,
+            'sourcedir': builddir,
         }
         (out, _) = run_cmd(cmd, log_all=True, simple=False)
         return out
@@ -99,12 +105,15 @@ class MesonNinja(EasyBlock):
         """
         Build with Ninja.
         """
+        build_cmd = self.cfg.get('build_cmd') or DEFAULT_BUILD_CMD
+
         parallel = ''
         if self.cfg['parallel']:
             parallel = "-j %s" % self.cfg['parallel']
 
-        cmd = "%(prebuildopts)s ninja %(parallel)s %(buildopts)s" % {
+        cmd = "%(prebuildopts)s %(build_cmd)s %(parallel)s %(buildopts)s" % {
             'buildopts': self.cfg['buildopts'],
+            'build_cmd': build_cmd,
             'parallel': parallel,
             'prebuildopts': self.cfg['prebuildopts'],
         }
@@ -124,13 +133,16 @@ class MesonNinja(EasyBlock):
         """
         Install with 'ninja install'.
         """
+        install_cmd = self.cfg.get('install_cmd') or DEFAULT_INSTALL_CMD
+
         parallel = ''
         if self.cfg['parallel']:
             parallel = "-j %s" % self.cfg['parallel']
 
-        cmd = "%(preinstallopts)s ninja %(parallel)s %(installopts)s install" % {
+        cmd = "%(preinstallopts)s %(install_cmd)s %(parallel)s %(installopts)s install" % {
             'installopts': self.cfg['installopts'],
             'parallel': parallel,
+            'install_cmd': install_cmd,
             'preinstallopts': self.cfg['preinstallopts'],
         }
         (out, _) = run_cmd(cmd, log_all=True, simple=False)

--- a/easybuild/easyblocks/generic/mesonninja.py
+++ b/easybuild/easyblocks/generic/mesonninja.py
@@ -40,6 +40,7 @@ DEFAULT_CONFIGURE_CMD = 'meson'
 DEFAULT_BUILD_CMD = 'ninja'
 DEFAULT_INSTALL_CMD = 'ninja'
 
+
 class MesonNinja(EasyBlock):
     """
     Support for building and installing software with 'meson' and 'ninja'.

--- a/easybuild/easyblocks/generic/mesonninja.py
+++ b/easybuild/easyblocks/generic/mesonninja.py
@@ -51,11 +51,11 @@ class MesonNinja(EasyBlock):
         """Define extra easyconfig parameters specific to MesonNinja."""
         extra_vars = EasyBlock.extra_options(extra_vars)
         extra_vars.update({
-            'configure_cmd': [DEFAULT_CONFIGURE_CMD, "Configure command to use", CUSTOM],
-            'separate_build_dir': [True, "Perform build in a separate directory", CUSTOM],
-            'build_cmd': [DEFAULT_BUILD_CMD, "Build command to use", CUSTOM],
             'build_dir': [None, "build_dir to pass to meson", CUSTOM],
+            'build_cmd': [DEFAULT_BUILD_CMD, "Build command to use", CUSTOM],
+            'configure_cmd': [DEFAULT_CONFIGURE_CMD, "Configure command to use", CUSTOM],
             'install_cmd': [DEFAULT_INSTALL_CMD, "Install command to use", CUSTOM],
+            'separate_build_dir': [True, "Perform build in a separate directory", CUSTOM],
         })
         return extra_vars
 
@@ -106,7 +106,7 @@ class MesonNinja(EasyBlock):
         """
         Build with Ninja.
         """
-        build_cmd = self.cfg.get('build_cmd') or DEFAULT_BUILD_CMD
+        build_cmd = self.cfg.get('build_cmd', DEFAULT_BUILD_CMD)
 
         parallel = ''
         if self.cfg['parallel']:
@@ -134,7 +134,7 @@ class MesonNinja(EasyBlock):
         """
         Install with 'ninja install'.
         """
-        install_cmd = self.cfg.get('install_cmd') or DEFAULT_INSTALL_CMD
+        install_cmd = self.cfg.get('install_cmd', DEFAULT_INSTALL_CMD)
 
         parallel = ''
         if self.cfg['parallel']:


### PR DESCRIPTION
I have a MesonNinja EasyConfig (SU2) that comes bundled with its own meson, but also its own ninja. I need to be able to override the `ninja` command to use the `./ninja` command from the source directory. It also needs to build in a specific folder (`build`), so I need to be able to override the `builddir` (which is mislabelled as `sourcedir` in the EasyBlock) that is passed to the Meson configure command. 