### PR TITLE
update LLVM easyblock for LLVM v16: symlink `third-party` to `third-party-<version>.src`

### DIFF
--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -112,7 +112,7 @@ class EB_LLVM(CMakeMake):
                 change_dir(cwd)
             else:
                 raise EasyBuildError("Failed to find unpacked CMake modules directory at %s", cmake_modules_path)
-        
+
         if LooseVersion(self.version) >= LooseVersion('16.0'):
             # make sure that third-party modules are available in build directory,
             # and if so make a 'third-party' symlink so LLVM can find them

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -122,7 +122,7 @@ class EB_LLVM(CMakeMake):
                 symlink('third-party-%s.src' % self.version, 'third-party')
                 change_dir(cwd)
             else:
-                raise EasyBuildError("Failed to find unpacked 'third-party' modules directory at %s", 
+                raise EasyBuildError("Failed to find unpacked 'third-party' modules directory at %s",
                                      third_party_modules_path)
 
         super(EB_LLVM, self).configure_step()

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -112,5 +112,16 @@ class EB_LLVM(CMakeMake):
                 change_dir(cwd)
             else:
                 raise EasyBuildError("Failed to find unpacked CMake modules directory at %s", cmake_modules_path)
+        
+        if LooseVersion(self.version) >= LooseVersion('16.0'):
+            # make sure that third-party modules are available in build directory,
+            # and if so make a 'third-party' symlink so LLVM can find them
+            third_party_modules_path = os.path.join(self.builddir, 'third-party-%s.src' % self.version)
+            if os.path.exists(third_party_modules_path):
+                cwd = change_dir(self.builddir)
+                symlink('third-party-%s.src' % self.version, 'third-party')
+                change_dir(cwd)
+            else:
+                raise EasyBuildError("Failed to find unpacked 'third-party' modules directory at %s", third_party_modules_path)
 
         super(EB_LLVM, self).configure_step()

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -122,6 +122,7 @@ class EB_LLVM(CMakeMake):
                 symlink('third-party-%s.src' % self.version, 'third-party')
                 change_dir(cwd)
             else:
-                raise EasyBuildError("Failed to find unpacked 'third-party' modules directory at %s", third_party_modules_path)
+                raise EasyBuildError("Failed to find unpacked 'third-party' modules directory at %s", 
+                                     third_party_modules_path)
 
         super(EB_LLVM, self).configure_step()


### PR DESCRIPTION
Required to install LLVM-16.x