### PR TITLE
update sanity check for Mesa >= 22.3

### DIFF
--- a/easybuild/easyblocks/m/mesa.py
+++ b/easybuild/easyblocks/m/mesa.py
@@ -154,7 +154,11 @@ class EB_Mesa(MesonNinja):
         shlib_ext = get_shared_lib_ext()
 
         if LooseVersion(self.version) >= LooseVersion('20.0'):
-            header_files = [os.path.join('include', 'EGL', x) for x in ['eglmesaext.h', 'eglextchromium.h']]
+            header_files = [os.path.join('include', 'EGL', 'eglmesaext.h')]
+            if LooseVersion(self.version) >= LooseVersion('22.3'):
+                header_files.extend([os.path.join('include', 'EGL', 'eglext_angle.h')])
+            else:
+                header_files.extend([os.path.join('include', 'EGL', 'eglextchromium.h')])
             header_files.extend([
                 os.path.join('include', 'GL', 'osmesa.h'),
                 os.path.join('include', 'GL', 'internal', 'dri_interface.h'),


### PR DESCRIPTION
Update sanity check for `eglext_angle.h`, which replaces `eglextchromium.h`. ([egl: Remove eglextchromium.h and import eglext_angle.h](https://gitlab.freedesktop.org/mesa/mesa/-/commit/f5bb9dd738ace274c97507adea073b6c609469b2))