### PR TITLE
conditionally add `-Wno-unused-command-line-argument` to `$CFLAGS` to fix error when installing `imkl-FFTW` with RPATH

### DIFF
--- a/easybuild/easyblocks/i/imkl.py
+++ b/easybuild/easyblocks/i/imkl.py
@@ -264,7 +264,7 @@ class EB_imkl(IntelBase):
 
                 # Avoid unused command line arguments (-Wl,rpath...) causeing errors when using RPATH
                 # See https://github.com/easybuilders/easybuild-easyconfigs/pull/18439#issuecomment-1662671054
-                if build_option('rpath'):
+                if build_option('rpath') and os.getenv('CC') in ('icx', 'clang'):
                     cflags = flags + ' -Wno-unused-command-line-argument'
                 else:
                     cflags = flags

--- a/easybuild/easyblocks/i/imkl.py
+++ b/easybuild/easyblocks/i/imkl.py
@@ -262,7 +262,7 @@ class EB_imkl(IntelBase):
                 tmpbuild = tempfile.mkdtemp(dir=self.builddir)
                 self.log.debug("Created temporary directory %s" % tmpbuild)
 
-                # Avoid unused command line arguments (-Wl,rpath...) causeing errors when using RPATH
+                # Avoid unused command line arguments (-Wl,rpath...) causing errors when using RPATH
                 # See https://github.com/easybuilders/easybuild-easyconfigs/pull/18439#issuecomment-1662671054
                 if build_option('rpath') and os.getenv('CC') in ('icx', 'clang'):
                     cflags = flags + ' -Wno-unused-command-line-argument'

--- a/easybuild/easyblocks/i/imkl.py
+++ b/easybuild/easyblocks/i/imkl.py
@@ -46,6 +46,7 @@ import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.intelbase import IntelBase, ACTIVATION_NAME_2012, LICENSE_FILE_NAME_2012
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.config import build_option
 from easybuild.tools.filetools import apply_regex_substitutions, change_dir, mkdir, move_file, remove_dir, write_file
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
@@ -261,6 +262,13 @@ class EB_imkl(IntelBase):
                 tmpbuild = tempfile.mkdtemp(dir=self.builddir)
                 self.log.debug("Created temporary directory %s" % tmpbuild)
 
+                # Avoid unused command line arguments (-Wl,rpath...) causeing errors when using RPATH
+                # See https://github.com/easybuilders/easybuild-easyconfigs/pull/18439#issuecomment-1662671054
+                if build_option('rpath'):
+                    cflags = flags + ' -Wno-unused-command-line-argument'
+                else:
+                    cflags = flags
+
                 # always set INSTALL_DIR, SPEC_OPT, COPTS and CFLAGS
                 # fftw2x(c|f): use $INSTALL_DIR, $CFLAGS and $COPTS
                 # fftw3x(c|f): use $CFLAGS
@@ -268,7 +276,7 @@ class EB_imkl(IntelBase):
                 env.setvar('INSTALL_DIR', tmpbuild)
                 env.setvar('SPEC_OPT', flags)
                 env.setvar('COPTS', flags)
-                env.setvar('CFLAGS', flags)
+                env.setvar('CFLAGS', cflags)
 
                 intdir = os.path.join(interfacedir, lib)
                 change_dir(intdir)


### PR DESCRIPTION
Fix for https://github.com/easybuilders/easybuild-easyconfigs/pull/18439#issuecomment-1662671054 which pops up as:

```
icx: error: -Wl,-rpath=$ORIGIN/../lib64: 'linker' input unused [-Werror,-Wunused-command-line-argument]
icx: error: -Wl,--disable-new-dtags: 'linker' input unused [-Werror,-Wunused-command-line-argument]
```