### PR TITLE
enhance `Conda` easyblock: add support for using custom `conda` command (like `mamba`), and clean up after installation

### DIFF
--- a/easybuild/easyblocks/generic/conda.py
+++ b/easybuild/easyblocks/generic/conda.py
@@ -75,7 +75,8 @@ class Conda(Binary):
                 env_spec = self.cfg['remote_environment']
 
             # use --force to ignore existing installation directory
-            cmd = "%s %s env create --force %s -p %s" % (self.cfg['preinstallopts'], conda_cmd, env_spec, self.installdir)
+            cmd = "%s %s env create --force %s -p %s" % (self.cfg['preinstallopts'], conda_cmd,
+                                                         env_spec, self.installdir)
             run_cmd(cmd, log_all=True, simple=True)
 
         else:
@@ -88,7 +89,8 @@ class Conda(Binary):
 
                 self.log.info("Installed conda requirements")
 
-            cmd = "%s %s create --force -y -p %s %s" % (self.cfg['preinstallopts'], conda_cmd, self.installdir, install_args)
+            cmd = "%s %s create --force -y -p %s %s" % (self.cfg['preinstallopts'], conda_cmd,
+                                                        self.installdir, install_args)
             run_cmd(cmd, log_all=True, simple=True)
 
         # clean up

--- a/easybuild/easyblocks/generic/conda.py
+++ b/easybuild/easyblocks/generic/conda.py
@@ -59,6 +59,8 @@ class Conda(Binary):
             super(Conda, self).extract_step()
 
     def install_step(self):
+        """Install software using 'conda env create' or 'conda create' & 'conda install'
+        (or the 'mamba', etc., equivalent)."""
         if (get_software_root('anaconda2') or get_software_root('miniconda2') or
                 get_software_root('anaconda3') or get_software_root('miniconda3')):
             conda_cmd = 'conda'

--- a/easybuild/easyblocks/generic/conda.py
+++ b/easybuild/easyblocks/generic/conda.py
@@ -37,6 +37,7 @@ from easybuild.tools.run import run_cmd
 
 DEFAULT_CONDA_CMD = 'conda'
 
+
 class Conda(Binary):
     """Support for installing software using 'conda'."""
 

--- a/easybuild/easyblocks/generic/conda.py
+++ b/easybuild/easyblocks/generic/conda.py
@@ -35,6 +35,7 @@ from easybuild.easyblocks.generic.binary import Binary
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.run import run_cmd
 from easybuild.tools.modules import get_software_root
+from easybuild.tools.build_log import EasyBuildError
 
 
 class Conda(Binary):

--- a/easybuild/easyblocks/generic/conda.py
+++ b/easybuild/easyblocks/generic/conda.py
@@ -59,7 +59,8 @@ class Conda(Binary):
             super(Conda, self).extract_step()
 
     def install_step(self):
-        if get_software_root('anaconda') or get_software_root('miniconda'):
+        if (get_software_root('anaconda2') or get_software_root('miniconda2') or
+                get_software_root('anaconda3') or get_software_root('miniconda3')):
             conda_cmd = 'conda'
         elif get_software_root('mamba'):
             conda_cmd = 'mamba'
@@ -68,7 +69,6 @@ class Conda(Binary):
         else:
             raise EasyBuildError("No conda/mamba/micromamba available.")
 
-        """Install software using 'conda env create' or 'conda create' & 'conda install'."""
         # initialize conda environment
         # setuptools is just a choice, but *something* needs to be there
         cmd = "%s config --add create_default_packages setuptools" % conda_cmd


### PR DESCRIPTION
- Set `DEFAULT_CONDA_CMD = 'conda'` and allow for user-defined alternative (e.g. `mamba`)
- Run `conda clean -ya` after env installation to clean up cache files