### PR TITLE
update WRF easyblock to correctly determine `WRF*` subdirectory for WRF versions >= 4.5.1

### DIFF
--- a/easybuild/easyblocks/w/wrf.py
+++ b/easybuild/easyblocks/w/wrf.py
@@ -54,8 +54,10 @@ from easybuild.tools.run import run_cmd, run_cmd_qa
 def det_wrf_subdir(wrf_version):
     """Determine WRF subdirectory for given WRF version."""
 
-    if LooseVersion(wrf_version) < LooseVersion('4.0') or wrf_version == '4.5.1':
+    if LooseVersion(wrf_version) < LooseVersion('4.0'):
         wrf_subdir = 'WRFV%s' % wrf_version.split('.')[0]
+    elif LooseVersion(wrf_version) >= LooseVersion('4.5.1'):
+        wrf_subdir = 'WRFV%s' % wrf_version
     else:
         wrf_subdir = 'WRF-%s' % wrf_version
 

--- a/easybuild/easyblocks/w/wrf.py
+++ b/easybuild/easyblocks/w/wrf.py
@@ -54,7 +54,7 @@ from easybuild.tools.run import run_cmd, run_cmd_qa
 def det_wrf_subdir(wrf_version):
     """Determine WRF subdirectory for given WRF version."""
 
-    if LooseVersion(wrf_version) < LooseVersion('4.0'):
+    if LooseVersion(wrf_version) < LooseVersion('4.0') or wrf_version == '4.5.1':
         wrf_subdir = 'WRFV%s' % wrf_version.split('.')[0]
     else:
         wrf_subdir = 'WRF-%s' % wrf_version


### PR DESCRIPTION
As of version 4.5.1 the directory name in tar archive has changed:
version < 4.0 -> WRFV3.x
version 4.4 -> WRF-4.4
version 4.5.1 -> WRFV4.5.1

How should we deal with it?

1. Rename `4.5.1-foss-2023a-dmpar/WRFV4.5.1` to `4.5.1-foss-2023a-dmpar/WRF-4.5.1`  when extracting the tar (consistent with 4.4)
2. Install WRF under `4.5.1-foss-2023a-dmpar/WRFV4.5.1` (as suggested in this PR)



