### PR TITLE
don't auto-enable use of `-DSCOTCH_PTHREAD` when using MPI library other than Intel MPI in SCOTCH easyblock

### DIFF
--- a/easybuild/easyblocks/s/scotch.py
+++ b/easybuild/easyblocks/s/scotch.py
@@ -109,11 +109,6 @@ class EB_SCOTCH(EasyBlock):
         if self.cfg['threadedmpi']:
             cflags += " -DSCOTCH_PTHREAD"
 
-        # For backwards compatability of v2.8.0 this is necessary but could be removed on a major version upgrade
-        mpi_family = self.toolchain.mpi_family()
-        if self.cfg['threadedmpi'] is None and mpi_family not in [toolchain.INTELMPI, toolchain.QLOGICMPI]:
-            cflags += " -DSCOTCH_PTHREAD"
-
         # actually build
         apps = ['scotch', 'ptscotch']
         if LooseVersion(self.version) >= LooseVersion('6.0'):


### PR DESCRIPTION
Should have been done for EB 3.0 according to the comment in the script. No need to convert any old easyconfigs back into the old behavior to try and preserve anything, because old behavior is bad; i'm pretty sure we want this. 

cf. in https://github.com/easybuilders/easybuild-easyconfigs/pull/17459#discussion_r1268199859

Fixes #2972