### PR TITLE
Fix the blas/lapack name passed to meson when building recent scipy versions (>= 1.9.0) on top of Intel MKL

### DIFF
--- a/easybuild/easyblocks/s/scipy.py
+++ b/easybuild/easyblocks/s/scipy.py
@@ -124,7 +124,7 @@ class EB_scipy(FortranPythonPackage, PythonPackage, MesonNinja):
             if lapack_lib == toolchain.FLEXIBLAS:
                 blas_lapack = 'flexiblas'
             elif lapack_lib == toolchain.INTELMKL:
-                blas_lapack = 'mkl'
+                blas_lapack = 'mkl-dynamic-lp64-seq'
             elif lapack_lib == toolchain.OPENBLAS:
                 blas_lapack = 'openblas'
             else:


### PR DESCRIPTION
The meson script expects the ``pkg-config`` name of the MKL package, instead of just 'mkl'.  See https://github.com/easybuilders/easybuild-easyconfigs/pull/18875
