### PR TITLE
disable LLVM build downloads from CI in Rust

### DIFF
--- a/easybuild/easyblocks/r/rust.py
+++ b/easybuild/easyblocks/r/rust.py
@@ -59,6 +59,9 @@ class EB_Rust(ConfigureMake):
 
         self.cfg.update('configopts', "--sysconfdir=%s" % os.path.join(self.installdir, 'etc'))
 
+        # old llvm builds from CI get deleted after a certain time
+        self.cfg.update('configopts', "--set=llvm.download-ci-llvm=false")
+
         # don't use Ninja if it is not listed as a build dependency;
         # may be because Ninja requires Python, and Rust is a build dependency for cryptography
         # which may be included as an extension with Python


### PR DESCRIPTION
```
   Compiling test v0.0.0 (/dev/shm/eb-submit-build/Rust/1.70.0/GCCcore-12.3.0/rustc-1.70.0-src/library/test)
    Finished release [optimized] target(s) in 22.69s
downloading https://ci-artifacts.rust-lang.org/rustc-builds/90c541806f23a127002de5b4038be731ba1458ca/rust-dev-1.70.0-x86_64-unknown-linux-gnu.tar.xz
#=#=#                                                                         ^M##O#-#                                                                        ^M##O=#  #
                                                           ^Mcurl: (22) The requested URL returned error: 404

error: failed to download llvm from ci

    help: old builds get deleted after a certain time
    help: if trying to compile an old commit of rustc, disable `download-ci-llvm` in config.toml:

    [llvm]
    download-ci-llvm = false

Build completed unsuccessfully in 0:05:18
```