### PR TITLE
update custom easyblock for Intel MPI easyblock for v2021.11

### DIFF
--- a/easybuild/easyblocks/i/impi.py
+++ b/easybuild/easyblocks/i/impi.py
@@ -208,7 +208,7 @@ EULA=accept
             mpi_mods.extend(['mpi_base.mod', 'mpi_constants.mod', 'mpi_sizeofs.mod'])
 
         if impi_ver >= LooseVersion('2021'):
-            mpi_subdir = os.path.join('mpi', self.version)
+            mpi_subdir = self.get_versioned_subdir('mpi')
             bin_dir = os.path.join(mpi_subdir, 'bin')
             include_dir = os.path.join(mpi_subdir, 'include')
             lib_dir = os.path.join(mpi_subdir, 'lib', 'release')
@@ -223,11 +223,15 @@ EULA=accept
             lib_dir = 'lib%s' % suff
             mpi_mods.extend(['i_malloc.h'])
 
+        mpi_mods_dir = include_dir
+        if impi_ver >= LooseVersion('2021.11'):
+            mpi_mods_dir = os.path.join(mpi_mods_dir, 'mpi')
+
         shlib_ext = get_shared_lib_ext()
         custom_paths = {
             'files': [os.path.join(bin_dir, 'mpi%s' % x) for x in ['icc', 'icpc', 'ifort']] +
             [os.path.join(include_dir, 'mpi%s.h' % x) for x in ['cxx', 'f', '', 'o', 'of']] +
-            [os.path.join(include_dir, x) for x in mpi_mods] +
+            [os.path.join(mpi_mods_dir, x) for x in mpi_mods] +
             [os.path.join(lib_dir, 'libmpi.%s' % shlib_ext)] +
             [os.path.join(lib_dir, 'libmpi.a')],
             'dirs': [],
@@ -239,7 +243,10 @@ EULA=accept
             if impi_ver >= LooseVersion('2017'):
                 # Add minimal test program to sanity checks
                 if impi_ver >= LooseVersion('2021'):
-                    impi_testsrc = os.path.join(self.installdir, 'mpi', self.version, 'test', 'test.c')
+                    impi_testsrc = os.path.join(self.installdir, self.get_versioned_subdir('mpi'))
+                    if impi_ver >= LooseVersion('2021.11'):
+                        impi_testsrc = os.path.join(impi_testsrc, 'opt', 'mpi')
+                    impi_testsrc = os.path.join(impi_testsrc, 'test', 'test.c')
                 else:
                     impi_testsrc = os.path.join(self.installdir, 'test', 'test.c')
 
@@ -247,12 +254,7 @@ EULA=accept
                 self.log.info("Adding minimal MPI test program to sanity checks: %s", impi_testsrc)
 
                 # Build test program with appropriate compiler from current toolchain
-                comp_fam = self.toolchain.comp_family()
-                if comp_fam == toolchain.INTELCOMP:
-                    build_comp = 'mpiicc'
-                else:
-                    build_comp = 'mpicc'
-                build_cmd = "%s %s -o %s" % (build_comp, impi_testsrc, impi_testexe)
+                build_cmd = "mpicc -cc=%s %s -o %s" % (os.getenv('CC'), impi_testsrc, impi_testexe)
 
                 # Execute test program with appropriate MPI executable for target toolchain
                 params = {'nr_ranks': self.cfg['parallel'], 'cmd': impi_testexe}
@@ -283,7 +285,7 @@ EULA=accept
 
             impi_ver = LooseVersion(self.version)
             if impi_ver >= LooseVersion('2021'):
-                mpi_subdir = os.path.join('mpi', self.version)
+                mpi_subdir = self.get_versioned_subdir('mpi')
                 lib_dirs = [
                     os.path.join(mpi_subdir, 'lib'),
                     os.path.join(mpi_subdir, 'lib', 'release'),
@@ -294,10 +296,13 @@ EULA=accept
                     os.path.join(mpi_subdir, 'bin'),
                     os.path.join(mpi_subdir, 'libfabric', 'bin'),
                 ]
-                manpath = os.path.join(mpi_subdir, 'man')
+                if impi_ver >= LooseVersion('2021.11'):
+                    manpath = os.path.join(mpi_subdir, 'share', 'man')
+                else:
+                    manpath = os.path.join(mpi_subdir, 'man')
 
                 if self.cfg['ofi_internal']:
-                    libfabric_dir = os.path.join('mpi', self.version, 'libfabric')
+                    libfabric_dir = os.path.join(mpi_subdir, 'libfabric')
                     lib_dirs.append(os.path.join(libfabric_dir, 'lib'))
                     path_dirs.append(os.path.join(libfabric_dir, 'bin'))
                     guesses['FI_PROVIDER_PATH'] = [os.path.join(libfabric_dir, 'lib', 'prov')]
@@ -332,7 +337,7 @@ EULA=accept
         """Overwritten from Application to add extra txt"""
 
         if LooseVersion(self.version) >= LooseVersion('2021'):
-            mpiroot = os.path.join(self.installdir, 'mpi', self.version)
+            mpiroot = os.path.join(self.installdir, self.get_versioned_subdir('mpi'))
         else:
             mpiroot = self.installdir
 
@@ -361,10 +366,20 @@ EULA=accept
 
         if self.cfg['set_mpi_wrapper_aliases_intel'] or self.cfg['set_mpi_wrappers_all']:
             # do the same for mpiicc/mpiipc/mpiifort to be consistent, even if they may not exist
-            txt += self.module_generator.set_alias('mpiicc', 'mpiicc -cc=icc')
-            txt += self.module_generator.set_alias('mpiicpc', 'mpiicpc -cxx=icpc')
+            if (get_software_root('intel-compilers') and
+                LooseVersion(get_software_version('intel-compilers')) >= LooseVersion('2024')):
+                txt += self.module_generator.set_alias('mpiicc', 'mpiicc -cc=icx')
+                txt += self.module_generator.set_alias('mpiicpc', 'mpiicpc -cxx=icpx')
+            else:
+                txt += self.module_generator.set_alias('mpiicc', 'mpiicc -cc=icc')
+                txt += self.module_generator.set_alias('mpiicpc', 'mpiicpc -cxx=icpc')
             # -fc also works, but -f90 takes precedence
             txt += self.module_generator.set_alias('mpiifort', 'mpiifort -f90=ifort')
+
+            if LooseVersion(self.version) >= LooseVersion('2021.11'):
+                txt += self.module_generator.set_alias('mpiicx', 'mpiicx -cc=icx')
+                txt += self.module_generator.set_alias('mpiicpx', 'mpiicpx -cxx=icpx')
+                txt += self.module_generator.set_alias('mpiifx', 'mpiifx -f90=ifx')
 
         # set environment variable UCX_TLS to 'all', this works in all hardware configurations
         # needed with UCX regardless of the transports available (even without a Mellanox HCA)

--- a/easybuild/easyblocks/i/impi.py
+++ b/easybuild/easyblocks/i/impi.py
@@ -367,7 +367,7 @@ EULA=accept
         if self.cfg['set_mpi_wrapper_aliases_intel'] or self.cfg['set_mpi_wrappers_all']:
             # do the same for mpiicc/mpiipc/mpiifort to be consistent, even if they may not exist
             if (get_software_root('intel-compilers') and
-                LooseVersion(get_software_version('intel-compilers')) >= LooseVersion('2024')):
+                    LooseVersion(get_software_version('intel-compilers')) >= LooseVersion('2024')):
                 txt += self.module_generator.set_alias('mpiicc', 'mpiicc -cc=icx')
                 txt += self.module_generator.set_alias('mpiicpc', 'mpiicpc -cxx=icpx')
             else:

--- a/easybuild/easyblocks/i/impi.py
+++ b/easybuild/easyblocks/i/impi.py
@@ -42,7 +42,7 @@ from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option
 from easybuild.tools.filetools import apply_regex_substitutions, change_dir, extract_file, mkdir, write_file
-from easybuild.tools.modules import get_software_root
+from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
 from easybuild.tools.toolchain.mpi import get_mpi_cmd_template


### PR DESCRIPTION
* use get_versioned_subdir()
* Fortran .mod files moved from include to include/mpi
* test.c moved from test to opt/mpi/test
* use mpicc -cc=$CC to pickup present compiler (could be icx)
* man pages moved from man to share/man
* adjust aliases to not use icc/icpc for 2024 compilers and add aliases for icx/icpx/ifx.