### PR TITLE
Replace all 'distutils.version' in easyblocks by 'easybuild.tools'

### DIFF
--- a/easybuild/easyblocks/a/abaqus.py
+++ b/easybuild/easyblocks/a/abaqus.py
@@ -32,9 +32,9 @@ EasyBuild support for ABAQUS, implemented as an easyblock
 @author: Jens Timmerman (Ghent University)
 @author: Simon Branford (University of Birmingham)
 """
-from distutils.version import LooseVersion
 import glob
 import os
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.binary import Binary
 from easybuild.framework.easyblock import EasyBlock

--- a/easybuild/easyblocks/a/acml.py
+++ b/easybuild/easyblocks/a/acml.py
@@ -33,7 +33,7 @@ EasyBuild support for AMD Core Math Library (ACML), implemented as an easyblock
 """
 
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM

--- a/easybuild/easyblocks/a/advisor.py
+++ b/easybuild/easyblocks/a/advisor.py
@@ -31,7 +31,7 @@ EasyBuild support for installing the Intel Advisor XE, implemented as an easyblo
 """
 
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.intelbase import IntelBase
 

--- a/easybuild/easyblocks/a/amber.py
+++ b/easybuild/easyblocks/a/amber.py
@@ -31,7 +31,7 @@ Modified by Stephane Thiell (Stanford University) for Amber14
 Enhanced/cleaned up by Kenneth Hoste (HPC-UGent)
 CMake support (Amber 20) added by James Carpenter and Simon Branford (University of Birmingham)
 """
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 import os
 
 import easybuild.tools.environment as env

--- a/easybuild/easyblocks/a/ansys.py
+++ b/easybuild/easyblocks/a/ansys.py
@@ -31,7 +31,7 @@ EasyBuild support for installing ANSYS, implemented as an easyblock
 import os
 import re
 import stat
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.packedbinary import PackedBinary
 from easybuild.tools.build_log import EasyBuildError

--- a/easybuild/easyblocks/a/aocc.py
+++ b/easybuild/easyblocks/a/aocc.py
@@ -34,7 +34,7 @@ Support for installing AOCC, implemented as an easyblock.
 import os
 import stat
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.packedbinary import PackedBinary
 from easybuild.framework.easyconfig import CUSTOM

--- a/easybuild/easyblocks/a/armadillo.py
+++ b/easybuild/easyblocks/a/armadillo.py
@@ -28,7 +28,7 @@ EasyBuild support for Armadillo, implemented as an easyblock
 @author: Kenneth Hoste (Ghent University)
 """
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root

--- a/easybuild/easyblocks/a/atlas.py
+++ b/easybuild/easyblocks/a/atlas.py
@@ -36,7 +36,7 @@ import fileinput
 import re
 import os
 import sys
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import CUSTOM

--- a/easybuild/easyblocks/b/bamtools.py
+++ b/easybuild/easyblocks/b/bamtools.py
@@ -28,7 +28,7 @@ EasyBuild support for BamTools, implemented as an easyblock
 @author: Andreas Panteli (The Cyprus Institute)
 @author: Kenneth Hoste (Ghent University)
 """
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.easyblocks.generic.makecp import MakeCp
 from easybuild.framework.easyconfig import CUSTOM

--- a/easybuild/easyblocks/b/bazel.py
+++ b/easybuild/easyblocks/b/bazel.py
@@ -25,7 +25,7 @@
 """
 EasyBuild support for building and installing Bazel, implemented as an easyblock
 """
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 import glob
 import os
 import tempfile

--- a/easybuild/easyblocks/b/berkeleygw.py
+++ b/easybuild/easyblocks/b/berkeleygw.py
@@ -28,7 +28,7 @@ EasyBuild support for BerkeleyGW, implemented as an easyblock
 @author: Miguel Dias Costa (National University of Singapore)
 """
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.configuremake import ConfigureMake

--- a/easybuild/easyblocks/b/binutils.py
+++ b/easybuild/easyblocks/b/binutils.py
@@ -30,7 +30,7 @@ EasyBuild support for building and installing binutils, implemented as an easybl
 import glob
 import os
 import re
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.configuremake import ConfigureMake

--- a/easybuild/easyblocks/b/boost.py
+++ b/easybuild/easyblocks/b/boost.py
@@ -38,7 +38,7 @@ EasyBuild support for Boost, implemented as an easyblock
 @author: Michele Dolfi (ETH Zurich)
 @author: Simon Branford (University of Birmingham)
 """
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 import fileinput
 import glob
 import os

--- a/easybuild/easyblocks/b/bowtie.py
+++ b/easybuild/easyblocks/b/bowtie.py
@@ -30,7 +30,7 @@ EasyBuild support for building and installing Bowtie, implemented as an easybloc
 @author: Kenneth Hoste (Ghent University)
 @author: Jens Timmerman (Ghent University)
 """
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 import glob
 import os
 import shutil

--- a/easybuild/easyblocks/b/bowtie2.py
+++ b/easybuild/easyblocks/b/bowtie2.py
@@ -16,7 +16,7 @@ EasyBuild support for building and installing Bowtie2, implemented as an easyblo
 @author: Fotis Georgatos (Uni.Lu)
 @author: Kenneth Hoste (Ghent University)
 """
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 import os
 
 from easybuild.easyblocks.generic.makecp import MakeCp

--- a/easybuild/easyblocks/b/bwa.py
+++ b/easybuild/easyblocks/b/bwa.py
@@ -20,7 +20,7 @@ EasyBuild support for building and installing BWA, implemented as an easyblock
 """
 import os
 import glob
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.build_log import EasyBuildError

--- a/easybuild/easyblocks/c/cgal.py
+++ b/easybuild/easyblocks/c/cgal.py
@@ -31,7 +31,7 @@ EasyBuild support for CGAL, implemented as an easyblock
 """
 import os
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.tools.build_log import EasyBuildError

--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -38,7 +38,7 @@ Support for building and installing Clang, implemented as an easyblock.
 import glob
 import os
 import shutil
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.framework.easyconfig import CUSTOM

--- a/easybuild/easyblocks/c/clang_aomp.py
+++ b/easybuild/easyblocks/c/clang_aomp.py
@@ -31,7 +31,7 @@ EasyBuild support for building and installing AOMP version of LLVM/Clang
 import glob
 import os
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 from easybuild.easyblocks.clang import DEFAULT_TARGETS_MAP as LLVM_ARCH_MAP
 from easybuild.easyblocks.generic.bundle import Bundle
 from easybuild.framework.easyblock import EasyBlock

--- a/easybuild/easyblocks/c/cp2k.py
+++ b/easybuild/easyblocks/c/cp2k.py
@@ -42,7 +42,7 @@ import glob
 import re
 import os
 import sys
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.toolchain as toolchain
 from easybuild.framework.easyblock import EasyBlock

--- a/easybuild/easyblocks/c/cplex.py
+++ b/easybuild/easyblocks/c/cplex.py
@@ -31,7 +31,7 @@ EasyBuild support for CPLEX, implemented as an easyblock
 @author: Pieter De Baets (Ghent University)
 @author: Jens Timmerman (Ghent University)
 """
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 import glob
 import os
 import stat

--- a/easybuild/easyblocks/c/cryptography.py
+++ b/easybuild/easyblocks/c/cryptography.py
@@ -27,7 +27,7 @@ EasyBuild support for building and installing cryptography, implemented as an ea
 
 @author: Alexander Grund
 """
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage
 from easybuild.tools.run import run_cmd

--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -38,7 +38,7 @@ import os
 import re
 import stat
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.binary import Binary
 from easybuild.framework.easyconfig import CUSTOM

--- a/easybuild/easyblocks/c/cudacompat.py
+++ b/easybuild/easyblocks/c/cudacompat.py
@@ -31,7 +31,7 @@ Ref: https://docs.nvidia.com/deploy/cuda-compatibility/index.html#manually-insta
 """
 
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.binary import Binary
 from easybuild.framework.easyconfig import CUSTOM, MANDATORY

--- a/easybuild/easyblocks/c/cudnn.py
+++ b/easybuild/easyblocks/c/cudnn.py
@@ -28,7 +28,7 @@ EasyBuild support for cuDNN, implemented as an easyblock
 @author: Simon Branford (University of Birmingham)
 @author: Robert Mijakovic (LuxProvide)
 """
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.tarball import Tarball
 from easybuild.tools.build_log import EasyBuildError

--- a/easybuild/easyblocks/d/dolfin.py
+++ b/easybuild/easyblocks/d/dolfin.py
@@ -32,7 +32,7 @@ import glob
 import os
 import re
 import tempfile
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain

--- a/easybuild/easyblocks/d/doxygen.py
+++ b/easybuild/easyblocks/d/doxygen.py
@@ -33,7 +33,7 @@ EasyBuild support for building and installing Doxygen, implemented as an easyblo
 @author: Balazs Hajgato (Free University Brussels (VUB))
 """
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 from easybuild.tools.run import run_cmd
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 

--- a/easybuild/easyblocks/e/easybuildmeta.py
+++ b/easybuild/easyblocks/e/easybuildmeta.py
@@ -31,7 +31,7 @@ import copy
 import os
 import re
 import sys
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage, det_pip_version
 from easybuild.tools.build_log import EasyBuildError

--- a/easybuild/easyblocks/e/eigen.py
+++ b/easybuild/easyblocks/e/eigen.py
@@ -19,7 +19,7 @@ EasyBuild support for building and installing Eigen, implemented as an easyblock
 
 import os
 import shutil
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.tools.filetools import copy_dir, copy_file, mkdir, apply_regex_substitutions

--- a/easybuild/easyblocks/e/elpa.py
+++ b/easybuild/easyblocks/e/elpa.py
@@ -30,7 +30,7 @@ EasyBuild support for building and installing ELPA, implemented as an easyblock
 @author: Kenneth Hoste (Ghent University)
 """
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.configuremake import ConfigureMake

--- a/easybuild/easyblocks/e/esmf.py
+++ b/easybuild/easyblocks/e/esmf.py
@@ -30,7 +30,7 @@ EasyBuild support for building and installing ESMF, implemented as an easyblock
 @author: Maxime Boissonneault (Digital Research Alliance of Canada)
 """
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain

--- a/easybuild/easyblocks/f/ferret.py
+++ b/easybuild/easyblocks/f/ferret.py
@@ -36,7 +36,7 @@ EasyBuild support for building and installing Ferret, implemented as an easybloc
 
 
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.build_log import EasyBuildError

--- a/easybuild/easyblocks/f/fftw.py
+++ b/easybuild/easyblocks/f/fftw.py
@@ -27,7 +27,7 @@ EasyBuild support for building and installing FFTW, implemented as an easyblock
 
 @author: Kenneth Hoste (HPC-UGent)
 """
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.configuremake import ConfigureMake

--- a/easybuild/easyblocks/f/flex.py
+++ b/easybuild/easyblocks/f/flex.py
@@ -27,7 +27,7 @@ EasyBuild support for building and installing flex, implemented as an easyblock
 
 @author: Kenneth Hoste (Ghent University)
 """
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 import os
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake

--- a/easybuild/easyblocks/f/fluent.py
+++ b/easybuild/easyblocks/f/fluent.py
@@ -29,7 +29,7 @@ EasyBuild support for installing FLUENT, implemented as an easyblock
 """
 import os
 import stat
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.packedbinary import PackedBinary
 from easybuild.framework.easyconfig import CUSTOM

--- a/easybuild/easyblocks/f/freesurfer.py
+++ b/easybuild/easyblocks/f/freesurfer.py
@@ -30,7 +30,7 @@ EasyBuild support for building and installing FreeSurfer, implemented as an easy
 
 import os
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.tarball import Tarball
 from easybuild.framework.easyconfig import MANDATORY

--- a/easybuild/easyblocks/f/fsl.py
+++ b/easybuild/easyblocks/f/fsl.py
@@ -31,7 +31,7 @@ EasyBuild support for building and installing FSL, implemented as an easyblock
 import difflib
 import os
 import re
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 from easybuild.framework.easyblock import EasyBlock

--- a/easybuild/easyblocks/g/g2clib.py
+++ b/easybuild/easyblocks/g/g2clib.py
@@ -40,7 +40,7 @@ from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 
 class EB_g2clib(ConfigureMake):

--- a/easybuild/easyblocks/g/gate.py
+++ b/easybuild/easyblocks/g/gate.py
@@ -34,7 +34,7 @@ EasyBuild support for building and installing Gate, implemented as an easyblock
 """
 import os
 import shutil
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.cmakemake import CMakeMake

--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -39,7 +39,7 @@ import os
 import re
 import shutil
 from copy import copy
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.clang import DEFAULT_TARGETS_MAP as LLVM_ARCH_MAP

--- a/easybuild/easyblocks/g/gctf.py
+++ b/easybuild/easyblocks/g/gctf.py
@@ -36,7 +36,7 @@ from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import adjust_permissions, copy_file, mkdir
 from easybuild.tools.filetools import symlink, write_file
 from easybuild.tools.modules import get_software_root
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 
 class EB_Gctf(EasyBlock):

--- a/easybuild/easyblocks/g/geant4.py
+++ b/easybuild/easyblocks/g/geant4.py
@@ -35,7 +35,7 @@ Geant4 support, implemented as an easyblock.
 import os
 import shutil
 import re
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 from easybuild.framework.easyconfig import CUSTOM

--- a/easybuild/easyblocks/g/ghc.py
+++ b/easybuild/easyblocks/g/ghc.py
@@ -27,7 +27,7 @@ EasyBuild support for binary GHC packages, see http://haskell.org/ghc
 
 @author: Andy Georges (Ghent University)
 """
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 

--- a/easybuild/easyblocks/g/go.py
+++ b/easybuild/easyblocks/g/go.py
@@ -31,7 +31,7 @@ EasyBuild support for building and installing Go, implemented as an easyblock
 import os
 import shutil
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.build_log import EasyBuildError

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -37,7 +37,7 @@ import glob
 import os
 import re
 import shutil
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -36,7 +36,7 @@ EasyBuild support for software that is configured with CMake, implemented as an 
 import glob
 import re
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import BUILD, CUSTOM

--- a/easybuild/easyblocks/generic/gopackage.py
+++ b/easybuild/easyblocks/generic/gopackage.py
@@ -28,7 +28,7 @@ EasyBuild support for Go packages, implemented as an EasyBlock
 @author: Pavel Grochal (INUITS)
 """
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 from easybuild.framework.easyblock import EasyBlock

--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -40,7 +40,7 @@ import re
 import shutil
 import stat
 import tempfile
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 from easybuild.framework.easyblock import EasyBlock

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -30,7 +30,7 @@ EasyBuild support for Julia Packages, implemented as an easyblock
 import os
 import re
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 from easybuild.framework.easyconfig import CUSTOM

--- a/easybuild/easyblocks/generic/mesonninja.py
+++ b/easybuild/easyblocks/generic/mesonninja.py
@@ -28,7 +28,7 @@ EasyBuild support for installing software with Meson & Ninja.
 @author: Kenneth Hoste (Ghent University)
 """
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -37,7 +37,7 @@ import os
 import re
 import sys
 import tempfile
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 from distutils.sysconfig import get_config_vars
 
 import easybuild.tools.environment as env

--- a/easybuild/easyblocks/generic/rpm.py
+++ b/easybuild/easyblocks/generic/rpm.py
@@ -37,7 +37,7 @@ import glob
 import os
 import re
 import tempfile
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 from os.path import expanduser
 
 import easybuild.tools.environment as env

--- a/easybuild/easyblocks/generic/systemcompiler.py
+++ b/easybuild/easyblocks/generic/systemcompiler.py
@@ -31,7 +31,7 @@ EasyBuild support for using (already installed/existing) system compiler instead
 """
 import os
 import re
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.base import fancylogger
 from easybuild.easyblocks.generic.bundle import Bundle

--- a/easybuild/easyblocks/h/healpix.py
+++ b/easybuild/easyblocks/h/healpix.py
@@ -29,7 +29,7 @@ EasyBuild support for building and installing HEALPix, implemented as an easyblo
 @author: Josef Dvoracek (Institute of Physics, Czech Academy of Sciences)
 """
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.configuremake import ConfigureMake

--- a/easybuild/easyblocks/h/hpcg.py
+++ b/easybuild/easyblocks/h/hpcg.py
@@ -37,7 +37,7 @@ from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option
 from easybuild.tools.filetools import mkdir
 from easybuild.tools.run import run_cmd
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 
 class EB_HPCG(ConfigureMake):

--- a/easybuild/easyblocks/i/icc.py
+++ b/easybuild/easyblocks/i/icc.py
@@ -36,7 +36,7 @@ EasyBuild support for install the Intel C/C++ compiler suite, implemented as an 
 
 import os
 import re
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.intelbase import IntelBase, ACTIVATION_NAME_2012, COMP_ALL
 from easybuild.easyblocks.generic.intelbase import LICENSE_FILE_NAME_2012

--- a/easybuild/easyblocks/i/ifort.py
+++ b/easybuild/easyblocks/i/ifort.py
@@ -34,7 +34,7 @@ EasyBuild support for installing the Intel Fortran compiler suite, implemented a
 """
 
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.intelbase import IntelBase
 from easybuild.easyblocks.icc import EB_icc  # @UnresolvedImport

--- a/easybuild/easyblocks/i/imkl.py
+++ b/easybuild/easyblocks/i/imkl.py
@@ -39,7 +39,7 @@ import itertools
 import os
 import shutil
 import tempfile
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain

--- a/easybuild/easyblocks/i/impi.py
+++ b/easybuild/easyblocks/i/impi.py
@@ -34,7 +34,7 @@ EasyBuild support for installing the Intel MPI library, implemented as an easybl
 @author: Alex Domingo (Vrije Universiteit Brussel)
 """
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.intelbase import IntelBase, ACTIVATION_NAME_2012, LICENSE_FILE_NAME_2012

--- a/easybuild/easyblocks/i/inspector.py
+++ b/easybuild/easyblocks/i/inspector.py
@@ -29,7 +29,7 @@ EasyBuild support for installing Intel Inspector, implemented as an easyblock
 @author: Damian Alvarez (Forschungzentrum Juelich GmbH)
 """
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.intelbase import IntelBase, ACTIVATION_NAME_2012, LICENSE_FILE_NAME_2012
 

--- a/easybuild/easyblocks/i/intel_compilers.py
+++ b/easybuild/easyblocks/i/intel_compilers.py
@@ -28,7 +28,7 @@ EasyBuild support for installing Intel compilers, implemented as an easyblock
 @author: Kenneth Hoste (Ghent University)
 """
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.intelbase import IntelBase
 from easybuild.easyblocks.t.tbb import get_tbb_gccprefix

--- a/easybuild/easyblocks/i/ipp.py
+++ b/easybuild/easyblocks/i/ipp.py
@@ -34,7 +34,7 @@ EasyBuild support for installing the Intel Performance Primitives (IPP) library,
 @author: Damian Alvarez (Forschungszentrum Juelich GmbH)
 """
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 import os
 
 from easybuild.easyblocks.generic.intelbase import IntelBase, ACTIVATION_NAME_2012, LICENSE_FILE_NAME_2012

--- a/easybuild/easyblocks/i/itac.py
+++ b/easybuild/easyblocks/i/itac.py
@@ -34,7 +34,7 @@ EasyBuild support for installing the Intel Trace Analyzer and Collector (ITAC), 
 
 import os
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.intelbase import IntelBase
 from easybuild.framework.easyconfig import CUSTOM

--- a/easybuild/easyblocks/j/java.py
+++ b/easybuild/easyblocks/j/java.py
@@ -32,7 +32,7 @@ import glob
 import os
 import stat
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 from easybuild.easyblocks.generic.packedbinary import PackedBinary
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option

--- a/easybuild/easyblocks/j/jaxlib.py
+++ b/easybuild/easyblocks/j/jaxlib.py
@@ -33,7 +33,7 @@ EasyBlock for installing jaxlib, implemented as an easyblock
 import os
 import tempfile
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -34,7 +34,7 @@ import glob
 import os
 import re
 import tempfile
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain

--- a/easybuild/easyblocks/l/lapack.py
+++ b/easybuild/easyblocks/l/lapack.py
@@ -31,7 +31,7 @@ EasyBuild support for building and installing LAPACK, implemented as an easybloc
 @author: Pieter De Baets (Ghent University)
 @author: Jens Timmerman (Ghent University)
 """
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 import glob
 import os
 

--- a/easybuild/easyblocks/l/libint.py
+++ b/easybuild/easyblocks/l/libint.py
@@ -30,7 +30,7 @@ EasyBuild support for building and installing Libint, implemented as an easybloc
 """
 
 import os.path
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import DEFAULT_CONFIGURE_CMD, ConfigureMake
 from easybuild.easyblocks.generic.cmakemake import CMakeMake

--- a/easybuild/easyblocks/l/libqglviewer.py
+++ b/easybuild/easyblocks/l/libqglviewer.py
@@ -33,7 +33,7 @@ from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.build_log import EasyBuildError
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 
 class EB_libQGLViewer(ConfigureMake):

--- a/easybuild/easyblocks/l/libsmm.py
+++ b/easybuild/easyblocks/l/libsmm.py
@@ -33,7 +33,7 @@ EasyBuild support for building and installing the libsmm library, implemented as
 """
 
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.toolchain as toolchain
 from easybuild.framework.easyblock import EasyBlock

--- a/easybuild/easyblocks/l/libxml2.py
+++ b/easybuild/easyblocks/l/libxml2.py
@@ -30,7 +30,7 @@ implemented as an easyblock.
 @author: Alan O'Cais (Juelich Supercomputing Centre)
 @author: Kenneth Hoste (Ghent University)
 """
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 import os
 
 import easybuild.tools.environment as env

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -37,7 +37,7 @@ from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import move_file
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.systemtools import get_cpu_architecture
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 
 class EB_LLVM(CMakeMake):

--- a/easybuild/easyblocks/l/lua.py
+++ b/easybuild/easyblocks/l/lua.py
@@ -28,7 +28,7 @@ EasyBuild support for building and installing Lua, implemented as an easyblock
 @author: Ruben Di Battista (Ecole Polytechnique)
 @author: Kenneth Hoste (Ghent University)
 """
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 import os
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake

--- a/easybuild/easyblocks/m/mathematica.py
+++ b/easybuild/easyblocks/m/mathematica.py
@@ -28,7 +28,7 @@ EasyBuild support for building and installing Mathematica, implemented as an eas
 @author: Kenneth Hoste (Ghent University)
 """
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 import glob
 import os
 

--- a/easybuild/easyblocks/m/matlab.py
+++ b/easybuild/easyblocks/m/matlab.py
@@ -37,7 +37,7 @@ import os
 import stat
 import tempfile
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.packedbinary import PackedBinary
 from easybuild.framework.easyconfig import CUSTOM

--- a/easybuild/easyblocks/m/mcr.py
+++ b/easybuild/easyblocks/m/mcr.py
@@ -38,7 +38,7 @@ import os
 import re
 import shutil
 import stat
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.packedbinary import PackedBinary
 from easybuild.framework.easyconfig import CUSTOM

--- a/easybuild/easyblocks/m/mesa.py
+++ b/easybuild/easyblocks/m/mesa.py
@@ -31,7 +31,7 @@ EasyBuild support for installing Mesa, implemented as an easyblock
 @author: Alexander Grund (TU Dresden)
 """
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.mesonninja import MesonNinja
 from easybuild.tools.filetools import copy_dir

--- a/easybuild/easyblocks/m/metis.py
+++ b/easybuild/easyblocks/m/metis.py
@@ -33,7 +33,7 @@ EasyBuild support for METIS, implemented as an easyblock
 """
 import os
 import shutil
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.build_log import EasyBuildError

--- a/easybuild/easyblocks/m/molpro.py
+++ b/easybuild/easyblocks/m/molpro.py
@@ -30,7 +30,7 @@ EasyBuild support for Molpro, implemented as an easyblock
 import os
 import shutil
 import re
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.binary import Binary
 from easybuild.easyblocks.generic.configuremake import ConfigureMake

--- a/easybuild/easyblocks/m/mono.py
+++ b/easybuild/easyblocks/m/mono.py
@@ -31,7 +31,7 @@ EasyBuild support for Mono, implemented as an easyblock
 @author: Pieter De Baets (Ghent University)
 @author: Jens Timmerman (Ghent University)
 """
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 import os
 import shutil
 

--- a/easybuild/easyblocks/m/mothur.py
+++ b/easybuild/easyblocks/m/mothur.py
@@ -30,7 +30,7 @@ EasyBuild support for Mothur, implemented as an easyblock
 import glob
 import os
 import shutil
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.build_log import EasyBuildError

--- a/easybuild/easyblocks/m/motioncor2.py
+++ b/easybuild/easyblocks/m/motioncor2.py
@@ -32,7 +32,7 @@ import glob
 import os
 import stat
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 from easybuild.easyblocks.generic.packedbinary import PackedBinary
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import adjust_permissions, copy_file, mkdir, write_file

--- a/easybuild/easyblocks/m/mpich.py
+++ b/easybuild/easyblocks/m/mpich.py
@@ -34,7 +34,7 @@ EasyBuild support for building and installing the MPICH MPI library and derivati
 @author: Xavier Besseron (University of Luxembourg)
 """
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.configuremake import ConfigureMake

--- a/easybuild/easyblocks/m/mrbayes.py
+++ b/easybuild/easyblocks/m/mrbayes.py
@@ -36,7 +36,7 @@ EasyBuild support for building and installing MrBayes, implemented as an easyblo
 """
 
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.build_log import EasyBuildError

--- a/easybuild/easyblocks/m/mrtrix.py
+++ b/easybuild/easyblocks/m/mrtrix.py
@@ -27,7 +27,7 @@ EasyBuild support for building and installing MRtrix, implemented as an easybloc
 """
 import glob
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 from easybuild.framework.easyblock import EasyBlock

--- a/easybuild/easyblocks/m/mumps.py
+++ b/easybuild/easyblocks/m/mumps.py
@@ -34,7 +34,7 @@ EasyBuild support for building and installing MUMPS, implemented as an easyblock
 
 import os
 import shutil
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools import toolchain

--- a/easybuild/easyblocks/m/mvapich2.py
+++ b/easybuild/easyblocks/m/mvapich2.py
@@ -34,7 +34,7 @@ EasyBuild support for building and installing the MVAPICH2 MPI library, implemen
 @author: Xavier Besseron (University of Luxembourg)
 """
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.mpich import EB_MPICH
 from easybuild.framework.easyconfig import CUSTOM

--- a/easybuild/easyblocks/m/mxnet.py
+++ b/easybuild/easyblocks/m/mxnet.py
@@ -30,7 +30,7 @@ EasyBuild support for MXNet, implemented as an easyblock
 import glob
 import os
 import shutil
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.makecp import MakeCp

--- a/easybuild/easyblocks/m/mymedialite.py
+++ b/easybuild/easyblocks/m/mymedialite.py
@@ -32,7 +32,7 @@ EasyBuild support for MyMediaLite, implemented as an easyblock
 @author: Jens Timmerman (Ghent University)
 """
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.run import run_cmd

--- a/easybuild/easyblocks/n/namd.py
+++ b/easybuild/easyblocks/n/namd.py
@@ -17,7 +17,7 @@ import glob
 import os
 import re
 import shutil
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.makecp import MakeCp

--- a/easybuild/easyblocks/n/netcdf.py
+++ b/easybuild/easyblocks/n/netcdf.py
@@ -33,7 +33,7 @@ EasyBuild support for building and installing netCDF, implemented as an easybloc
 """
 
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain

--- a/easybuild/easyblocks/n/neuron.py
+++ b/easybuild/easyblocks/n/neuron.py
@@ -41,7 +41,7 @@ from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 
 class EB_NEURON(CMakeMake):

--- a/easybuild/easyblocks/n/numexpr.py
+++ b/easybuild/easyblocks/n/numexpr.py
@@ -26,7 +26,7 @@
 EasyBuild support for building and installing numexpr, implemented as an easyblock
 """
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage
 from easybuild.tools.filetools import write_file

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -45,7 +45,7 @@ from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import change_dir, mkdir, read_file, remove_dir
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 
 class EB_numpy(FortranPythonPackage):

--- a/easybuild/easyblocks/n/nvhpc.py
+++ b/easybuild/easyblocks/n/nvhpc.py
@@ -40,7 +40,7 @@ import stat
 import sys
 import platform
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 from easybuild.easyblocks.generic.packedbinary import PackedBinary
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.filetools import adjust_permissions, write_file

--- a/easybuild/easyblocks/n/nwchem.py
+++ b/easybuild/easyblocks/n/nwchem.py
@@ -36,7 +36,7 @@ import tempfile
 import easybuild.tools.config as config
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError

--- a/easybuild/easyblocks/o/ocaml.py
+++ b/easybuild/easyblocks/o/ocaml.py
@@ -29,7 +29,7 @@ EasyBuild support for building and installing OCaml + opam (+ extensions), imple
 """
 import os
 import re
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.build_log import EasyBuildError

--- a/easybuild/easyblocks/o/openbabel.py
+++ b/easybuild/easyblocks/o/openbabel.py
@@ -36,7 +36,7 @@ from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.systemtools import get_shared_lib_ext
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 
 class EB_OpenBabel(CMakeMake):

--- a/easybuild/easyblocks/o/openblas.py
+++ b/easybuild/easyblocks/o/openblas.py
@@ -7,7 +7,7 @@ EasyBuild support for building and installing OpenBLAS, implemented as an easybl
 """
 import os
 import re
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.systemtools import POWER, get_cpu_architecture, get_shared_lib_ext

--- a/easybuild/easyblocks/o/opencv.py
+++ b/easybuild/easyblocks/o/opencv.py
@@ -30,7 +30,7 @@ EasyBuild support for building and installing OpenCV, implemented as an easybloc
 """
 import glob
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.easyblocks.generic.pythonpackage import det_pylibdir

--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -41,7 +41,7 @@ import re
 import shutil
 import stat
 import tempfile
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain

--- a/easybuild/easyblocks/o/openmpi.py
+++ b/easybuild/easyblocks/o/openmpi.py
@@ -30,7 +30,7 @@ EasyBuild support for OpenMPI, implemented as an easyblock
 """
 import os
 import re
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.configuremake import ConfigureMake

--- a/easybuild/easyblocks/o/openssl.py
+++ b/easybuild/easyblocks/o/openssl.py
@@ -33,7 +33,7 @@ EasyBuild support for OpenSSL, implemented as an easyblock
 import os
 import re
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import CUSTOM

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -30,7 +30,7 @@ EasyBuild support for installing a wrapper module file for OpenSSL
 import os
 import re
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.bundle import Bundle
 from easybuild.framework.easyconfig import CUSTOM

--- a/easybuild/easyblocks/o/orca.py
+++ b/easybuild/easyblocks/o/orca.py
@@ -30,7 +30,7 @@ EasyBuild support for ORCA, implemented as an easyblock
 import glob
 import os
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 from easybuild.easyblocks.generic.makecp import MakeCp
 from easybuild.easyblocks.generic.packedbinary import PackedBinary
 from easybuild.framework.easyconfig import CUSTOM

--- a/easybuild/easyblocks/p/paraver.py
+++ b/easybuild/easyblocks/p/paraver.py
@@ -31,7 +31,7 @@ EasyBuild support for building and installing Paraver, implemented as an easyblo
 """
 import glob
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.build_log import EasyBuildError, print_msg

--- a/easybuild/easyblocks/p/parmetis.py
+++ b/easybuild/easyblocks/p/parmetis.py
@@ -34,7 +34,7 @@ EasyBuild support for ParMETIS, implemented as an easyblock
 """
 import os
 import shutil
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.tools.build_log import EasyBuildError

--- a/easybuild/easyblocks/p/perl.py
+++ b/easybuild/easyblocks/p/perl.py
@@ -28,7 +28,7 @@ EasyBuild support for Perl, implemented as an easyblock
 @author: Jens Timmerman (Ghent University)
 @author: Kenneth Hoste (Ghent University)
 """
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 import glob
 import os
 import stat

--- a/easybuild/easyblocks/p/petsc.py
+++ b/easybuild/easyblocks/p/petsc.py
@@ -29,7 +29,7 @@ EasyBuild support for PETSc, implemented as an easyblock
 """
 import os
 import re
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain

--- a/easybuild/easyblocks/p/pgi.py
+++ b/easybuild/easyblocks/p/pgi.py
@@ -39,7 +39,7 @@ import stat
 import sys
 
 import easybuild.tools.environment as env
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 from easybuild.easyblocks.generic.packedbinary import PackedBinary
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.easyconfig.types import ensure_iterable_license_specs

--- a/easybuild/easyblocks/p/picard.py
+++ b/easybuild/easyblocks/p/picard.py
@@ -35,7 +35,7 @@ Support for building and installing picard, implemented as an easyblock.
 import os
 import re
 import shutil
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.tarball import Tarball
 from easybuild.tools.build_log import EasyBuildError

--- a/easybuild/easyblocks/p/psi.py
+++ b/easybuild/easyblocks/p/psi.py
@@ -29,7 +29,7 @@ EasyBuild support for building and installing PSI, implemented as an easyblock
 @author: Ward Poelmans (Ghent University)
 """
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 import glob
 import os
 import shutil

--- a/easybuild/easyblocks/p/psmpi.py
+++ b/easybuild/easyblocks/p/psmpi.py
@@ -30,7 +30,7 @@ EasyBuild support for building and installing the ParaStationMPI library, implem
 
 import easybuild.tools.toolchain as toolchain
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 from easybuild.easyblocks.mpich import EB_MPICH
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -38,7 +38,7 @@ import re
 import fileinput
 import sys
 import tempfile
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.configuremake import ConfigureMake

--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -32,7 +32,7 @@ import os
 import re
 import tempfile
 import easybuild.tools.environment as env
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError, print_warning

--- a/easybuild/easyblocks/q/qscintilla.py
+++ b/easybuild/easyblocks/q/qscintilla.py
@@ -29,7 +29,7 @@ author: Kenneth Hoste (HPC-UGent)
 author: Maxime Boissonneault (Compute Canada)
 """
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.easyblocks.generic.pythonpackage import det_pylibdir

--- a/easybuild/easyblocks/q/qt.py
+++ b/easybuild/easyblocks/q/qt.py
@@ -28,7 +28,7 @@ EasyBuild support for building and installing Qt, implemented as an easyblock
 @author: Kenneth Hoste (Ghent University)
 """
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -33,7 +33,7 @@ import os
 import re
 import shutil
 import sys
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain

--- a/easybuild/easyblocks/r/r.py
+++ b/easybuild/easyblocks/r/r.py
@@ -30,7 +30,7 @@ EasyBuild support for building and installing R, implemented as an easyblock
 """
 import os
 import re
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.configuremake import ConfigureMake

--- a/easybuild/easyblocks/r/repeatmasker.py
+++ b/easybuild/easyblocks/r/repeatmasker.py
@@ -25,7 +25,7 @@
 """
 EasyBuild support for building and installing RepeatMasker, implemented as an easyblock
 """
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 import os
 
 from easybuild.easyblocks.generic.tarball import Tarball

--- a/easybuild/easyblocks/r/rmpi.py
+++ b/easybuild/easyblocks/r/rmpi.py
@@ -33,7 +33,7 @@ EasyBuild support for building and installing the Rmpi R library, implemented as
 @author: Balazs Hajgato (Vrije Universiteit Brussel)
 """
 import easybuild.tools.toolchain as toolchain
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 from easybuild.easyblocks.generic.rpackage import RPackage
 
 

--- a/easybuild/easyblocks/r/root.py
+++ b/easybuild/easyblocks/r/root.py
@@ -28,7 +28,7 @@ EasyBuild support for ROOT, implemented as an easyblock
 @author: Kenneth Hoste (Ghent University)
 @author: Jens Timmerman (Ghent University)
 """
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 import os
 
 from easybuild.framework.easyconfig import CUSTOM

--- a/easybuild/easyblocks/s/samtools.py
+++ b/easybuild/easyblocks/s/samtools.py
@@ -19,7 +19,7 @@ EasyBuild support for building SAMtools (SAM - Sequence Alignment/Map), implemen
 @author: Fotis Georgatos (Uni.Lu)
 @author: Kenneth Hoste (Ghent University)
 """
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 import glob
 import os
 import stat

--- a/easybuild/easyblocks/s/scalapack.py
+++ b/easybuild/easyblocks/s/scalapack.py
@@ -34,7 +34,7 @@ EasyBuild support for building and installing ScaLAPACK, implemented as an easyb
 
 import glob
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.blacs import det_interface  # @UnresolvedImport

--- a/easybuild/easyblocks/s/scalasca1.py
+++ b/easybuild/easyblocks/s/scalasca1.py
@@ -29,7 +29,7 @@ EasyBuild support for Scalasca v1.x, implemented as an easyblock
 @author: Bernd Mohr (Juelich Supercomputing Centre)
 """
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.configuremake import ConfigureMake

--- a/easybuild/easyblocks/s/scipion.py
+++ b/easybuild/easyblocks/s/scipion.py
@@ -30,7 +30,7 @@ EasyBuild support for building and installing Scipion, implemented as an easyblo
 """
 import os
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import copy, mkdir, symlink

--- a/easybuild/easyblocks/s/scipy.py
+++ b/easybuild/easyblocks/s/scipy.py
@@ -35,7 +35,7 @@ EasyBuild support for building and installing scipy, implemented as an easyblock
 """
 import os
 import tempfile
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain

--- a/easybuild/easyblocks/s/scotch.py
+++ b/easybuild/easyblocks/s/scotch.py
@@ -32,7 +32,7 @@ EasyBuild support for SCOTCH, implemented as an easyblock
 @author: Jens Timmerman (Ghent University)
 """
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.toolchain as toolchain
 from easybuild.framework.easyblock import EasyBlock

--- a/easybuild/easyblocks/s/siesta.py
+++ b/easybuild/easyblocks/s/siesta.py
@@ -32,7 +32,7 @@ import os
 import stat
 
 import easybuild.tools.toolchain as toolchain
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError

--- a/easybuild/easyblocks/s/slepc.py
+++ b/easybuild/easyblocks/s/slepc.py
@@ -30,7 +30,7 @@ EasyBuild support for SLEPc, implemented as an easyblock
 
 import os
 import re
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.configuremake import ConfigureMake

--- a/easybuild/easyblocks/s/snphylo.py
+++ b/easybuild/easyblocks/s/snphylo.py
@@ -31,7 +31,7 @@ EasyBuild support for SNPyhlo, implemented as an easyblock
 import os
 import re
 import stat
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.tools.build_log import EasyBuildError

--- a/easybuild/easyblocks/s/suitesparse.py
+++ b/easybuild/easyblocks/s/suitesparse.py
@@ -36,7 +36,7 @@ import fileinput
 import re
 import os
 import sys
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.build_log import EasyBuildError

--- a/easybuild/easyblocks/s/superlu.py
+++ b/easybuild/easyblocks/s/superlu.py
@@ -30,7 +30,7 @@ EasyBuild support for building and installing the SuperLU library, implemented a
 """
 
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.tools.build_log import EasyBuildError

--- a/easybuild/easyblocks/t/tbb.py
+++ b/easybuild/easyblocks/t/tbb.py
@@ -37,7 +37,7 @@ EasyBuild support for installing the Intel Threading Building Blocks (TBB) libra
 import glob
 import os
 import shutil
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.easyblocks.generic.intelbase import INSTALL_MODE_NAME_2015, INSTALL_MODE_2015

--- a/easybuild/easyblocks/t/tensorrt.py
+++ b/easybuild/easyblocks/t/tensorrt.py
@@ -30,7 +30,7 @@ EasyBuild support for building and installing TensorRT, implemented as an easybl
 """
 import glob
 import os
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.binary import Binary
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage, PIP_INSTALL_CMD

--- a/easybuild/easyblocks/t/tinker.py
+++ b/easybuild/easyblocks/t/tinker.py
@@ -31,7 +31,7 @@ import glob
 import os
 import tempfile
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.toolchain as toolchain
 from easybuild.framework.easyblock import EasyBlock

--- a/easybuild/easyblocks/t/tkinter.py
+++ b/easybuild/easyblocks/t/tkinter.py
@@ -33,7 +33,7 @@ module to use Tcl/Tk.
 import glob
 import os
 import tempfile
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.pythonpackage import det_pylibdir

--- a/easybuild/easyblocks/t/trilinos.py
+++ b/easybuild/easyblocks/t/trilinos.py
@@ -31,7 +31,7 @@ import os
 import random
 import re
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.cmakemake import CMakeMake

--- a/easybuild/easyblocks/t/trinity.py
+++ b/easybuild/easyblocks/t/trinity.py
@@ -36,7 +36,7 @@ EasyBuild support for building and installing Trinity, implemented as an easyblo
 import glob
 import os
 import shutil
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.toolchain as toolchain
 from easybuild.framework.easyblock import EasyBlock

--- a/easybuild/easyblocks/u/ufc.py
+++ b/easybuild/easyblocks/u/ufc.py
@@ -27,7 +27,7 @@ EasyBuild support for UFC, implemented as an easyblock
 
 @author: Kenneth Hoste (Ghent University)
 """
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.cmakepythonpackage import CMakePythonPackage
 from easybuild.tools.build_log import EasyBuildError

--- a/easybuild/easyblocks/v/vmd.py
+++ b/easybuild/easyblocks/v/vmd.py
@@ -31,7 +31,7 @@ EasyBuild support for VMD, implemented as an easyblock
 """
 import os
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.easyblocks.generic.pythonpackage import det_pylibdir
 from easybuild.tools.build_log import EasyBuildError

--- a/easybuild/easyblocks/v/vtune.py
+++ b/easybuild/easyblocks/v/vtune.py
@@ -28,7 +28,7 @@ EasyBuild support for installing Intel VTune, implemented as an easyblock
 @author: Kenneth Hoste (Ghent University)
 @author: Damian Alvarez (Forschungzentrum Juelich GmbH)
 """
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 import os
 
 from easybuild.easyblocks.generic.intelbase import IntelBase, ACTIVATION_NAME_2012, LICENSE_FILE_NAME_2012

--- a/easybuild/easyblocks/w/wien2k.py
+++ b/easybuild/easyblocks/w/wien2k.py
@@ -39,7 +39,7 @@ import re
 import shutil
 import sys
 import tempfile
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain

--- a/easybuild/easyblocks/w/wps.py
+++ b/easybuild/easyblocks/w/wps.py
@@ -35,7 +35,7 @@ EasyBuild support for building and installing WPS, implemented as an easyblock
 import os
 import re
 import tempfile
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain

--- a/easybuild/easyblocks/w/wrf.py
+++ b/easybuild/easyblocks/w/wrf.py
@@ -35,7 +35,7 @@ EasyBuild support for building and installing WRF, implemented as an easyblock
 import os
 import re
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain

--- a/easybuild/easyblocks/w/wxpython.py
+++ b/easybuild/easyblocks/w/wxpython.py
@@ -32,7 +32,7 @@ EasyBuild support for wxPython, implemented as an easyblock
 import glob
 import os
 
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage, det_python_version
 from easybuild.tools.filetools import change_dir, symlink
 from easybuild.tools.modules import get_software_root

--- a/easybuild/easyblocks/x/xmipp.py
+++ b/easybuild/easyblocks/x/xmipp.py
@@ -34,7 +34,7 @@ import glob
 import os
 
 import easybuild.tools.environment as env
-from distutils.version import LooseVersion
+from easybuild.tools import LooseVersion
 from easybuild.easyblocks.generic.scons import SCons
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import apply_regex_substitutions, change_dir


### PR DESCRIPTION
Backport of #3018 without the change to `setup.py` and `__init__.py`

Avoids the deprecation warnings currently issued.