### PR TITLE
Add binutils symlinks when building TensorFlow with --rpath

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -49,6 +49,7 @@ from easybuild.tools.filetools import is_readable, read_file, symlink, which, wr
 from easybuild.tools.modules import get_software_root, get_software_version, get_software_libdir
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import AARCH64, X86_64, get_cpu_architecture, get_os_name, get_os_version
+from easybuild.tools.toolchain.toolchain import RPATH_WRAPPERS_SUBDIR
 
 
 CPU_DEVICE = 'cpu'
@@ -464,10 +465,10 @@ class EB_TensorFlow(PythonPackage):
         ld_path = which('ld')
         self.binutils_bin_path = os.path.dirname(ld_path)
         if self.toolchain.is_rpath_wrapper(ld_path):
-            if os.path.basename(os.path.dirname(os.path.dirname(ld_path))) == toolchain.RPATH_WRAPPERS_SUBDIR:
+            if os.path.basename(os.path.dirname(os.path.dirname(ld_path))) == RPATH_WRAPPERS_SUBDIR:
                 # TF expects all binutils binaries in a single path but newer EB puts each in their own subfolder
                 # Add symlinks to each binutils binary into a single folder
-                new_rpath_wrapper_dir = os.path.join(self.wrapper_dir, toolchain.RPATH_WRAPPERS_SUBDIR)
+                new_rpath_wrapper_dir = os.path.join(self.wrapper_dir, RPATH_WRAPPERS_SUBDIR)
                 binutils_bin_path = os.path.join(get_software_root('binutils'), 'bin')
                 self.log.info("Found %s to be an rpath wrapper. Adding symlinks for binutils in %s to %s.",
                               ld_path, binutils_bin_path, new_rpath_wrapper_dir)

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -446,6 +446,7 @@ class EB_TensorFlow(PythonPackage):
         self.output_user_root_dir = os.path.join(parent_dir, 'bazel-root')
         # Folder where wrapper binaries can be placed, where required. TODO: Replace by --action_env cmds
         self.wrapper_dir = os.path.join(parent_dir, 'wrapper_bin')
+        mkdir(self.wrapper_dir)
 
     def configure_step(self):
         """Custom configuration procedure for TensorFlow."""


### PR DESCRIPTION
This fixes a regression by https://github.com/easybuilders/easybuild-framework/pull/2410

Avoids build errors like
> Configuration: 59a0a0e80bc61398ca9fef36ddd3d195f45bc65f8bfbc1a894cf677de7d5d5e9
> Execution platform: @local_execution_config_platform//:platform
> src/main/tools/process-wrapper-legacy.cc:80: "execvp(/tmp/eb-m2n16g8t/tmptk5axscj/rpath_wrappers/ld_wrapper/ar, ...)": No such file or directory
> Target //tensorflow/tools/pip_package:build_pip_package failed to build
