### PR TITLE
pick Tcl/Tk lib directory correctly in R easyblock, may be either `lib` or `lib64`

### DIFF
--- a/easybuild/easyblocks/r/r.py
+++ b/easybuild/easyblocks/r/r.py
@@ -70,8 +70,11 @@ class EB_R(ConfigureMake):
         for dep in ['Tcl', 'Tk']:
             root = get_software_root(dep)
             if root:
-                dep_config = os.path.join(root, 'lib', '%sConfig.sh' % dep.lower())
-                self.cfg.update('configopts', '--with-%s-config=%s' % (dep.lower(), dep_config))
+                for libdir in ['lib', 'lib64']:
+                    dep_config = os.path.join(root, libdir, '%sConfig.sh' % dep.lower())
+                    if os.path.exists(dep_config):
+                        self.cfg.update('configopts', '--with-%s-config=%s' % (dep.lower(), dep_config))
+                        break
 
         if "--with-x=" not in self.cfg['configopts'].lower():
             if get_software_root('X11'):


### PR DESCRIPTION
tcl/tk is not always in lib folder, on gentoo it is in lib64, this commit tests it and picks the right one