### PR TITLE
remove `hidden=True` from `run_shell_cmd` in `PythonPackage` easyblock for consistency

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -827,7 +827,7 @@ class PythonPackage(ExtensionEasyBlock):
                 extrapath = "export PYTHONPATH=%s &&" % os.pathsep.join(abs_pylibdirs + ['$PYTHONPATH'])
 
                 cmd = self.compose_install_command(test_installdir, extrapath=extrapath)
-                run_shell_cmd(cmd, hidden=True)
+                run_shell_cmd(cmd)
 
                 self.py_post_install_shenanigans(test_installdir)
 


### PR DESCRIPTION
To address
https://github.com/easybuilders/easybuild-easyblocks/pull/3046#discussion_r1444031157 as a followup to #3046