### PR TITLE
disable `use_pip` by default for PyTorch, except for recent versions (>= 2.1)

### DIFF
--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -54,8 +54,14 @@ class EB_PyTorch(PythonPackage):
             'excluded_tests': [{}, "Mapping of architecture strings to list of tests to be excluded", CUSTOM],
             'max_failed_tests': [0, "Maximum number of failing tests", CUSTOM],
         })
+
+        # disable use of pip to install PyTorch by default, overwriting the default set in PythonPackage;
+        # see also https://github.com/easybuilders/easybuild-easyblocks/pull/3022
+        extra_vars['use_pip'][0] = None
+
         extra_vars['download_dep_fail'][0] = True
         extra_vars['sanity_pip_check'][0] = True
+
         # Make pip show output of build process as that may often contain errors or important warnings
         extra_vars['pip_verbose'][0] = True
 
@@ -68,6 +74,13 @@ class EB_PyTorch(PythonPackage):
         # Test as-if pytorch was installed
         self.testinstall = True
         self.tmpdir = tempfile.mkdtemp(suffix='-pytorch-build')
+
+        # opt-in to using pip to install PyTorch for sufficiently recent version (>= 2.1),
+        # unless it's otherwise specified
+        pytorch_version = LooseVersion(self.version)
+        if self.cfg['use_pip'] is None and pytorch_version >= '2.1':
+            self.log.info("Auto-enabling use of pip to install PyTorch, since 'use_pip' is not set")
+            self.cfg['use_pip'] = True
 
     def fetch_step(self, skip_checksums=False):
         """Fetch sources for installing PyTorch, including those for tests."""


### PR DESCRIPTION
Up until now, we've only enabled `use_pip` for the latest versions of `PyTorch` (>= 2.1).

It's probably not worth the effort to also do that for older PyTorch versions, so we need to overrule the changing default in `PythonPackage` (cfr. https://github.com/easybuilders/easybuild-easyblocks/pull/3022)

With this approach, old `PyTorch` easyconfigs could explicitly set `use_pip = False`, and future PyTorch easyconfigs could opt-in to not using `pip` by using `use_pip = False`, should the need arise (since PyTorch currently still uses the legacy install procedure that involves `setup.py build`).

