### PR TITLE
don't change `installopts` easyconfig parameter value in-place in `PythonPackage` easyblock

### DIFF
--- a/easybuild/easyblocks/d/dm_reverb.py
+++ b/easybuild/easyblocks/d/dm_reverb.py
@@ -118,8 +118,10 @@ class EB_dm_minus_reverb(PythonPackage):
         whl_file = '%s-%s-cp%s*.whl' % (self.name.replace('-', '_'), self.version, pymajmin)
         whl_path = os.path.join(self.builddir, whl_file)
 
+        installopts = ' '.join([self.cfg['installopts']] + self.py_installopts)
+
         self.install_cmd = PIP_INSTALL_CMD % {
-            'installopts': self.cfg['installopts'],
+            'installopts': installopts,
             'loc': whl_path,
             'prefix': self.installdir,
             'python': self.python_cmd,

--- a/easybuild/easyblocks/generic/versionindependentpythonpackage.py
+++ b/easybuild/easyblocks/generic/versionindependentpythonpackage.py
@@ -72,7 +72,7 @@ class VersionIndependentPythonPackage(PythonPackage):
                 '--record %s' % os.path.join(self.builddir, 'record'),
                 '--no-compile',
             ]
-            self.cfg.update('installopts', ' '.join(extra_installopts))
+            self.py_installopts.extend(extra_installopts)
         else:
             # using easy_install or pip always results in installation that is specific to Python version
             eb_name = self.__class__.__name__

--- a/easybuild/easyblocks/p/pybind11.py
+++ b/easybuild/easyblocks/p/pybind11.py
@@ -80,8 +80,6 @@ class EB_pybind11(CMakePythonPackage):
         build_dir = change_dir(self.cfg['start_dir'])
         PythonPackage.install_step(self)
 
-        # Reset installopts (set by PythonPackage)
-        self.cfg['installopts'] = ''
         change_dir(build_dir)
         CMakeMake.install_step(self)
 

--- a/easybuild/easyblocks/s/scipy.py
+++ b/easybuild/easyblocks/s/scipy.py
@@ -67,23 +67,10 @@ class EB_scipy(FortranPythonPackage, PythonPackage, MesonNinja):
         PythonPackage.__init__(self, *args, **kwargs)
         self.testinstall = True
 
-        if LooseVersion(self.version) >= LooseVersion('1.9'):
-            self.use_meson = True
+        # use Meson/Ninja install procedure for scipy >= 1.9
+        self.use_meson = LooseVersion(self.version) >= LooseVersion('1.9')
 
-            # enforce scipy test suite results if not explicitly disabled for scipy >= 1.9
-            # strip inherited PythonPackage installopts
-            installopts = self.cfg['installopts']
-            pythonpackage_installopts = ['--no-deps', '--ignore-installed', '--no-index', '--egg',
-                                         '--zip-ok', '--no-index']
-            self.log.info("Stripping inherited PythonPackage installopts %s from installopts %s",
-                          pythonpackage_installopts, installopts)
-            for i in pythonpackage_installopts:
-                installopts = installopts.replace(i, '')
-            self.cfg['installopts'] = installopts
-
-        else:
-            self.use_meson = False
-
+        # enforce scipy test suite results if not explicitly disabled for scipy >= 1.9
         if self.cfg['ignore_test_result'] is None:
             # automatically ignore scipy test suite results for scipy < 1.9, as we did in older easyconfigs
             self.cfg['ignore_test_result'] = LooseVersion(self.version) < '1.9'

--- a/easybuild/easyblocks/t/tensorrt.py
+++ b/easybuild/easyblocks/t/tensorrt.py
@@ -101,11 +101,14 @@ class EB_TensorRT(PythonPackage, Binary):
             os.path.join('uff', 'uff-*-py2.py3-none-any.whl'),
             os.path.join('python', 'tensorrt-%s-cp%s-*-linux_x86_64.whl' % (self.version, pyver)),
         ]
+
+        installopts = ' '.join([self.cfg['installopts']] + self.py_installopts)
+
         for whl in whls:
             whl_paths = glob.glob(os.path.join(self.installdir, whl))
             if len(whl_paths) == 1:
                 cmd = PIP_INSTALL_CMD % {
-                    'installopts': self.cfg['installopts'],
+                    'installopts': installopts,
                     'loc': whl_paths[0],
                     'prefix': self.installdir,
                     'python': self.python_cmd,

--- a/easybuild/easyblocks/w/wxpython.py
+++ b/easybuild/easyblocks/w/wxpython.py
@@ -89,7 +89,9 @@ class EB_wxPython(PythonPackage):
             pyver = det_python_version(self.python_cmd)
             pyver = pyver[0] + pyver[2]
 
-            cmd = "pip install --no-deps --prefix=%(prefix)s dist/wxPython-%(version)s-cp%(pyver)s*.whl" % {
+            installopts = ' '.join([self.cfg['installopts']] + self.py_installopts)
+            cmd = "pip install %(installopts)s --prefix=%(prefix)s dist/wxPython-%(version)s-cp%(pyver)s*.whl" % {
+                'installopts': installopts,
                 'prefix': self.installdir,
                 'version': self.version,
                 'pyver': pyver


### PR DESCRIPTION
The `PythonPackage` easyblock currently updates `installopts` in-place when the `determine_install_command` method is called (which is done in the constructor), like it owns the place.

This causes problems for other easyblocks that derive from `PythonPackage` though, especially when `use_pip` is enabled.
For `CMakePythonPackage` for example, it results in options for the `pip install` command being passed to `make install`, which leads to problems like this (for `tmap-20220502-GCC-11.2.0.eb` with `use_pip` set to `True`, or using the changes being made in #3022):

```
== FAILED: Installation ended unsuccessfully: cmd " make install  --verbose  --no-deps  --ignore-installed  --no-index " exited with exit code 2 and output:
make: unrecognized option '--verbose'
make: unrecognized option '--no-deps'
...
```

This fix is important in the context of #3022, where `use_pip` is being enabled by default.

The `VersionIndependentPythonPackage` generic easyblock (which is currently only used by archived easyconfigs) was following the example of `PythonPackage` and was also updated `installopts` in place, so it has been updated to append to the custom `py_installopts` class variable instead.

A couple of other easyblocks that derives from `PythonPackage` assumed that all options for `pip` were available in `installopts`, which is now no longer the case since `py_installopts` must also be taken into account. This includes the easyblocks for `dm-reverb`, `TensorRT`, and `wxPytyon`.

Other easyblock already had a workaround in place for the fact that `PythonPackage` was updating `installopts` in place, while it shouldn't. These easyblocks were updated to remove the workaround, since it's no longer needed: `pybind11` + `scipy`.

Marked as WIP since needs testing first with easyconfigs that use the modified easyblocks, as well as with easyconfigs that use an easyblock like `CMakePythonPackage` (cfr. list of easyconfigs that are currently not enabling `use_pip` in https://github.com/easybuilders/easybuild-easyblocks/pull/3022#issuecomment-1875814148).