### PR TITLE
4 Conda Fixes to allow Conda.py  to work with Micromamba

### DIFF
--- a/easybuild/easyblocks/generic/conda.py
+++ b/easybuild/easyblocks/generic/conda.py
@@ -64,17 +64,25 @@ class Conda(Binary):
         if (get_software_root('anaconda2') or get_software_root('miniconda2') or
                 get_software_root('anaconda3') or get_software_root('miniconda3')):
             conda_cmd = 'conda'
-        elif get_software_root('mamba'):
-            conda_cmd = 'mamba'
         elif get_software_root('micromamba'):
             conda_cmd = 'micromamba'
+        elif get_software_root('mamba'):
+            conda_cmd = 'mamba'
         else:
-            raise EasyBuildError("No conda/mamba/micromamba available.")
+            raise EasyBuildError("No conda/micromamba/mamba available.")
 
-        # initialize conda environment
+        # initialize conda environment, except for micromamba
         # setuptools is just a choice, but *something* needs to be there
-        cmd = "%s config --add create_default_packages setuptools" % conda_cmd
-        run_cmd(cmd, log_all=True, simple=True)
+        force = '--force'
+        if conda_cmd == 'micromamba':
+            force = ''
+            try:
+                os.rmdir(self.installdir)
+            except:
+                raise EasyBuildError("Could not remove %s as required for Micromamba" % self.installdir)
+        else:
+            cmd = "%s config --add create_default_packages setuptools" % conda_cmd
+            run_cmd(cmd, log_all=True, simple=True)
 
         if self.cfg['environment_file'] or self.cfg['remote_environment']:
 
@@ -84,8 +92,9 @@ class Conda(Binary):
                 env_spec = self.cfg['remote_environment']
 
             # use --force to ignore existing installation directory
-            cmd = "%s %s env create --force %s -p %s" % (self.cfg['preinstallopts'], conda_cmd,
-                                                         env_spec, self.installdir)
+            
+            cmd = "%s %s env create %s %s -p %s" % (self.cfg['preinstallopts'], conda_cmd,
+                                                         force, env_spec, self.installdir)
             run_cmd(cmd, log_all=True, simple=True)
 
         else:
@@ -98,8 +107,8 @@ class Conda(Binary):
 
                 self.log.info("Installed conda requirements")
 
-            cmd = "%s %s create --force -y -p %s %s" % (self.cfg['preinstallopts'], conda_cmd,
-                                                        self.installdir, install_args)
+            cmd = "%s %s create %s -y -p %s %s" % (self.cfg['preinstallopts'], conda_cmd,
+                                                    force, self.installdir, install_args)
             run_cmd(cmd, log_all=True, simple=True)
 
         # clean up

--- a/easybuild/easyblocks/generic/conda.py
+++ b/easybuild/easyblocks/generic/conda.py
@@ -78,7 +78,7 @@ class Conda(Binary):
             force = ''
             try:
                 os.rmdir(self.installdir)
-            except:
+            except BaseException:
                 raise EasyBuildError("Could not remove %s as required for Micromamba" % self.installdir)
         else:
             cmd = "%s config --add create_default_packages setuptools" % conda_cmd
@@ -91,10 +91,9 @@ class Conda(Binary):
             else:
                 env_spec = self.cfg['remote_environment']
 
-            # use --force to ignore existing installation directory
-            
+            # use --force to ignore existing installation directory            
             cmd = "%s %s env create %s %s -p %s" % (self.cfg['preinstallopts'], conda_cmd,
-                                                         force, env_spec, self.installdir)
+                                                    force, env_spec, self.installdir)
             run_cmd(cmd, log_all=True, simple=True)
 
         else:
@@ -108,7 +107,7 @@ class Conda(Binary):
                 self.log.info("Installed conda requirements")
 
             cmd = "%s %s create %s -y -p %s %s" % (self.cfg['preinstallopts'], conda_cmd,
-                                                    force, self.installdir, install_args)
+                                                   force, self.installdir, install_args)
             run_cmd(cmd, log_all=True, simple=True)
 
         # clean up

--- a/easybuild/easyblocks/generic/conda.py
+++ b/easybuild/easyblocks/generic/conda.py
@@ -91,7 +91,7 @@ class Conda(Binary):
             else:
                 env_spec = self.cfg['remote_environment']
 
-            # use --force to ignore existing installation directory            
+            # use --force to ignore existing installation directory
             cmd = "%s %s env create %s %s -p %s" % (self.cfg['preinstallopts'], conda_cmd,
                                                     force, env_spec, self.installdir)
             run_cmd(cmd, log_all=True, simple=True)


### PR DESCRIPTION
These 4 changes will allow EB to use Micromamba as conda /  mamba replacement which is much faster

- Check for existence of `micromamba` first because `mamba` is sometimes used as alias for micromamba but typically not vice versa 
- remove the --force option from command line because Micromamba does not support it. I have requested that they implement it . 
- do not bootstrap config --add create_default_packages setuptools with Micromamba, there is no Python and it does not like setuptools 
- delete the empty installdir os.rmdir(self.installdir) as Micromamba likes to create that itself and complains if it is already there.