### PR TITLE
stop running easyblocks test suite with Lmod 7.x

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11']
-        modules_tool: [Lmod-7.8.22, Lmod-8.1.14, modules-tcl-1.147, modules-3.2.10, modules-4.1.4]
+        modules_tool: [Lmod-8.1.14, modules-tcl-1.147, modules-3.2.10, modules-4.1.4]
         module_syntax: [Lua, Tcl]
         # exclude some configuration for non-Lmod modules tool:
         # - don't test with Lua module syntax (only supported in Lmod)


### PR DESCRIPTION
Lmod >= 8.0 is required for EasyBuild 5.x, see https://github.com/easybuilders/easybuild-framework/pull/4424