### PR TITLE
remove trailing slash in `PETSC_DIR` set by custom easyblock for PETSc

### DIFF
--- a/easybuild/easyblocks/p/petsc.py
+++ b/easybuild/easyblocks/p/petsc.py
@@ -275,8 +275,9 @@ class EB_PETSc(ConfigureMake):
                 self.cfg.update('configopts', ' '.join([withdep + spec for spec in ['=1', inc_spec, lib_spec]]))
 
             # set PETSC_DIR for configure (env) and build_step
-            env.setvar('PETSC_DIR', self.cfg['start_dir'])
-            self.cfg.update('buildopts', 'PETSC_DIR=%s' % self.cfg['start_dir'])
+            petsc_dir = os.path.abspath(self.cfg['start_dir'])
+            env.setvar('PETSC_DIR', petsc_dir)
+            self.cfg.update('buildopts', 'PETSC_DIR=%s' % petsc_dir)
 
             if self.cfg['sourceinstall']:
                 if self.petsc_arch:

--- a/easybuild/easyblocks/p/petsc.py
+++ b/easybuild/easyblocks/p/petsc.py
@@ -279,7 +279,7 @@ class EB_PETSc(ConfigureMake):
                 self.cfg.update('configopts', ' '.join([withdep + spec for spec in ['=1', inc_spec, lib_spec]]))
 
             # set PETSC_DIR for configure (env) and build_step
-            petsc_dir = os.path.abspath(self.cfg['start_dir'])
+            petsc_dir = self.cfg['start_dir'].rstrip(os.path.sep)
             env.setvar('PETSC_DIR', petsc_dir)
             self.cfg.update('buildopts', 'PETSC_DIR=%s' % petsc_dir)
 

--- a/easybuild/easyblocks/p/petsc.py
+++ b/easybuild/easyblocks/p/petsc.py
@@ -257,6 +257,10 @@ class EB_PETSc(ConfigureMake):
                         ss_libs = ["UMFPACK", "KLU", "SPQR", "CHOLMOD", "BTF", "CCOLAMD",
                                    "COLAMD", "CXSparse", "LDL", "RBio", "SLIP_LU", "CAMD", "AMD"]
 
+                    # SLIP_LU was replaced by SPEX in SuiteSparse >= 6.0
+                    if LooseVersion(get_software_version('SuiteSparse')) >= LooseVersion("6.0"):
+                        ss_libs = [x if x != "SLIP_LU" else "SPEX" for x in ss_libs]
+
                     suitesparse_inc = os.path.join(suitesparse, "include")
                     inc_spec = "-include=[%s]" % suitesparse_inc
 


### PR DESCRIPTION
Compilation of PETSc 3.20.3 fails due to wrong format of PETSC_DIR. The PETSC_DIR variable should not contain the trailing slash (see configuration example in https://petsc.org/release/install/install_tutorial/#configuration). 

Older versions of PETSc are probably less sensitive to this error, so I was able to compile PETSc 3.19 both with original easyblock (i.e. with trailing slash) and with the new one (without the slash).