### PR TITLE
update `Cargo` easyblock to extract crates into a vendor subdir and overwrite git repo URLs with local paths

### DIFF
--- a/easybuild/easyblocks/generic/cargo.py
+++ b/easybuild/easyblocks/generic/cargo.py
@@ -61,6 +61,16 @@ class Cargo(ExtensionEasyBlock):
 
         return extra_vars
 
+    @staticmethod
+    def crate_src_filename(pkg_name, pkg_version):
+        """Crate tarball filename based on package name and version"""
+        return "{0}-{1}.tar.gz".format(pkg_name, pkg_version)
+
+    @staticmethod
+    def crate_download_filename(pkg_name, pkg_version):
+        """Crate download filename based on package name and version"""
+        return "{0}/{1}/download".format(pkg_name, pkg_version)
+
     def rustc_optarch(self):
         """Determines what architecture to target.
         Translates GENERIC optarch, and respects rustc specific optarch.
@@ -112,10 +122,9 @@ class Cargo(ExtensionEasyBlock):
             sources = []
             for crate_info in self.crates:
                 if len(crate_info) == 2:
-                    crate, version = crate_info
                     sources.append({
-                        'download_filename': crate + '/' + version + '/download',
-                        'filename': crate + '-' + version + '.tar.gz',
+                        'download_filename': self.crate_download_filename(*crate_info),
+                        'filename': self.crate_src_filename(*crate_info),
                         'source_urls': [CRATESIO_SOURCE],
                         'alt_location': 'crates.io',
                     })

--- a/easybuild/easyblocks/generic/cargo.py
+++ b/easybuild/easyblocks/generic/cargo.py
@@ -63,12 +63,12 @@ class Cargo(ExtensionEasyBlock):
         return extra_vars
 
     @staticmethod
-    def crate_src_filename(pkg_name, pkg_version):
+    def crate_src_filename(pkg_name, pkg_version, *args):
         """Crate tarball filename based on package name and version"""
         return "{0}-{1}.tar.gz".format(pkg_name, pkg_version)
 
     @staticmethod
-    def crate_download_filename(pkg_name, pkg_version):
+    def crate_download_filename(pkg_name, pkg_version, *args):
         """Crate download filename based on package name and version"""
         return "{0}/{1}/download".format(pkg_name, pkg_version)
 
@@ -137,7 +137,7 @@ class Cargo(ExtensionEasyBlock):
                         repo_name = repo_name[:-4]
                     sources.append({
                         'git_config': {'url': url, 'repo_name': repo_name, 'commit': rev},
-                        'filename': crate + '-' + version + '.tar.gz',
+                        'filename': self.crate_src_filename(crate, version),
                     })
 
             self.cfg.update('sources', sources)

--- a/easybuild/easyblocks/generic/cargo.py
+++ b/easybuild/easyblocks/generic/cargo.py
@@ -103,7 +103,7 @@ class Cargo(ExtensionEasyBlock):
         """Constructor for Cargo easyblock."""
         super(Cargo, self).__init__(*args, **kwargs)
         self.cargo_home = os.path.join(self.builddir, '.cargo')
-        self.vendor_dir = os.path.join(self.builddir, 'vendor')
+        self.vendor_dir = os.path.join(self.builddir, 'easybuild_vendor')
         env.setvar('CARGO_HOME', self.cargo_home)
         env.setvar('RUSTC', 'rustc')
         env.setvar('RUSTDOC', 'rustdoc')

--- a/easybuild/easyblocks/generic/cargo.py
+++ b/easybuild/easyblocks/generic/cargo.py
@@ -26,6 +26,7 @@
 EasyBuild support for installing Cargo packages (Rust lang package system)
 
 @author: Mikael Oehman (Chalmers University of Technology)
+@author: Alex Domingo (Vrije Universiteit Brussel)
 """
 
 import os


### PR DESCRIPTION
This evolved into a 2x1 PR, apologies for the added complexity.

## Fix 1: extract crates into vendor subdir

Currently, the sources of the main `Cargo` package and the sources of all crates are all extracted into `builddir`. This is known to make some installations fail. The presence of the main sources alongside its dependencies can make `cargo` trip in identifying availability of _vendored sources_. See related [comment below](https://github.com/easybuilders/easybuild-easyblocks/pull/3118#issuecomment-1919459702).

Not all `Cargo` packages are affected, but it seems to happen on more complex packaging. For instance, known failure is a package with a virtual workspace distributing multiple crates plus a another package in a subdir.

This PR solves this issue by extracting the list of `crates` into a separate _vendor_ subdir without any sources of the main packages (_i.e._ items in the `sources` list of the easyconfig). This follows the same approach carried out by the `cargo vendor` command.

## Fix 2: overwrite crates from git repos with local paths

I hit another issue where `cargo` was failing to locate the extracted sources of a dependency pulled from a git repo. The sources are properly downloaded and extracted from the git repo and the checksuming of the local sources is done properly. However, `Cargo.lock` of the main package being installed does not list any checksum for those dependencies pulled from a git repo, so `cargo` has no way to correlate the extracted folder to this dependency.

This PR solves this issue by overwriting the repo URL of each package pulled from a git repo with the local paths to the corresponding extracted folders. This is done in the generated `.cargo/config.toml` file by using the `[patch.URL]` directive as describe in the [rust docs](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#overriding-repository-url) instead of `[source.URL]`.

For instace,

```
[source."https://github.com/ritchie46/jsonpath"]
git = "https://github.com/ritchie46/jsonpath"
rev = "24eaf0b4416edff38a4d1b6b17bc4b9f3f047b4b"
```
becomes
```
[patch."https://github.com/ritchie46/jsonpath"]
jsonpath_lib = { path = "/user/brussel/101/vsc10122/easybuild/install/skylake/build/polars/0.19.19/gfbf-2023a/easybuild_vendor/jsonpath" }
```

## Changelog
* extract crates into `self.builddir.easybuild_vendor`
* add static methods to generate filenames for downloaded tarballs and local tarballs
* be smarter in setting `finalpath` of extracted sources by detecting
* use global templates to generate `.cargo/config.toml` file
* replace `[source.URL]` with `[patch.URL]` to overwrite git repos with local paths to extracted sources
