### PR TITLE
remove trailing slash in `SLEPC_DIR` in configure step of custom easyblock for SLEPc

### DIFF
--- a/easybuild/easyblocks/s/slepc.py
+++ b/easybuild/easyblocks/s/slepc.py
@@ -70,7 +70,7 @@ class EB_SLEPc(ConfigureMake):
             raise EasyBuildError("PETSc module not loaded?")
 
         # set SLEPC_DIR environment variable
-        env.setvar('SLEPC_DIR', self.cfg['start_dir'])
+        env.setvar('SLEPC_DIR', self.cfg['start_dir'].rstrip(os.path.sep))
         self.log.debug('SLEPC_DIR: %s' % os.getenv('SLEPC_DIR'))
 
         # optional dependencies


### PR DESCRIPTION
Compilation of SLEPc 3.20.1 (easyconfig pr #19863)  failed because of a trailing slash in SLEPC_DIR. See similar issue for PETSc resolved in easyblock pr #3086