### PR TITLE
fix OpenFOAM easyblock to fix `motorBike` example in sanity check for v >=11

### DIFF
--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -514,7 +514,7 @@ class EB_OpenFOAM(EasyBlock):
                 cmds = [
                         "cp -a %s %s" % (motorbike_path, test_dir),
                         # Make sure the tmpdir for tests ir writeable if read-only-installdir is used
-                        "chmod +w  %s" % test_dir,
+                        "chmod -R +w %s" % test_dir,
                         "cd %s" % os.path.join(test_dir, os.path.basename(motorbike_path)),
                         "source $FOAM_BASH",
                         ". $WM_PROJECT_DIR/bin/tools/RunFunctions",

--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -510,7 +510,7 @@ class EB_OpenFOAM(EasyBlock):
                 else:
                     geom_target_dir = 'triSurface'
 
-            if self.looseversion < LooseVersion('11'):
+            if self.looseversion <= LooseVersion('10'):
                 cmds = [
                         "cp -a %s %s" % (motorbike_path, test_dir),
                         # Make sure the tmpdir for tests ir writeable if read-only-installdir is used

--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -80,7 +80,7 @@ class EB_OpenFOAM(EasyBlock):
 
         self.is_extend = 'extend' in self.name.lower()
         self.is_dot_com = self.looseversion >= LooseVersion('1606')
-        self.is_dot_org = self.looseversion < LooseVersion('1606')
+        self.is_dot_org = self.looseversion <= LooseVersion('100')
 
         if self.is_extend:
             if self.looseversion >= LooseVersion('3.0'):

--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -495,7 +495,10 @@ class EB_OpenFOAM(EasyBlock):
         # only for recent (>= v6.0) versions of openfoam.org variant
         if self.is_dot_org and self.looseversion >= LooseVersion('6'):
             openfoamdir_path = os.path.join(self.installdir, self.openfoamdir)
-            motorbike_path = os.path.join(openfoamdir_path, 'tutorials', 'incompressible', 'simpleFoam', 'motorBike')
+            if self.looseversion <= LooseVersion('10'):
+                motorbike_path = os.path.join(openfoamdir_path, 'tutorials', 'incompressible', 'simpleFoam', 'motorBike')
+            else:
+                motorbike_path = os.path.join(openfoamdir_path, 'tutorials', 'incompressibleFluid', 'motorBike')
             if os.path.exists(motorbike_path):
                 test_dir = tempfile.mkdtemp()
 

--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -80,7 +80,7 @@ class EB_OpenFOAM(EasyBlock):
 
         self.is_extend = 'extend' in self.name.lower()
         self.is_dot_com = self.looseversion >= LooseVersion('1606')
-        self.is_dot_org = self.looseversion <= LooseVersion('100')
+        self.is_dot_org = self.looseversion <= LooseVersion('1600')
 
         if self.is_extend:
             if self.looseversion >= LooseVersion('3.0'):

--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -509,6 +509,8 @@ class EB_OpenFOAM(EasyBlock):
                     geom_target_dir = 'geometry'
                 else:
                     geom_target_dir = 'triSurface'
+            else:
+                raise EasyBuildError("motorBike tutorial not found at %s", motorbike_path)
 
             if self.looseversion <= LooseVersion('10'):
                 cmds = [

--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -500,7 +500,8 @@ class EB_OpenFOAM(EasyBlock):
                     openfoamdir_path, 'tutorials', 'incompressible', 'simpleFoam', 'motorBike'
                 )
             else:
-                motorbike_path = os.path.join(openfoamdir_path, 'tutorials', 'incompressibleFluid', 'motorBike', 'motorBike')
+                motorbike_path = os.path.join(openfoamdir_path, 'tutorials', 'incompressibleFluid',
+                                              'motorBike', 'motorBike')
             if os.path.exists(motorbike_path):
                 test_dir = tempfile.mkdtemp()
 
@@ -542,7 +543,7 @@ class EB_OpenFOAM(EasyBlock):
                         "cp $FOAM_TUTORIALS/resources/geometry/motorBike.obj.gz constant/%s/" % geom_target_dir,
                         "runApplication blockMesh",
                         "runApplication decomposePar -copyZero",
-                        "find . -type f -iname '*level*' -exec rm {} \;",
+                        "find . -type f -iname '*level*' -exec rm {} \\;",
                         "runParallel renumberMesh -overwrite",
                         "runParallel potentialFoam -initialiseUBCs",
                         "runParallel simpleFoam",
@@ -585,4 +586,3 @@ class EB_OpenFOAM(EasyBlock):
                 txt += self.module_generator.set_environment(env_var, val)
 
         return txt
-    


### PR DESCRIPTION
Relaxes the check of .org/.com forks to allow higher version numbers in .org case.
Corrects paths and functions called in `motorBike` example in the sanity check step for OpenFOAM v>=11. Without these changes the `motorBike` sanity check  step won't run on versions 11 and above.