### PR TITLE
make a project environment and manage LOAD_PATH for JuliaPackage

### DIFF
--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -30,13 +30,10 @@ EasyBuild support for bundles of Julia packages, implemented as an easyblock
 import os
 
 from easybuild.easyblocks.generic.bundle import Bundle
-from easybuild.easyblocks.generic.juliapackage import EXTS_FILTER_JULIA_PACKAGES, JULIA_PATHS_SOFT_INIT, JuliaPackage
-from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import mkdir
-from easybuild.tools.modules import get_software_root, get_software_version
+from easybuild.easyblocks.generic.juliapackage import EXTS_FILTER_JULIA_PACKAGES, JuliaPackage
 
 
-class JuliaBundle(Bundle,JuliaPackage):
+class JuliaBundle(Bundle, JuliaPackage):
     """
     Bundle of JuliaPackages: install Julia packages as extensions in a bundle
     Defines custom sanity checks and module environment

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -198,7 +198,6 @@ class JuliaPackage(ExtensionEasyBlock):
                 # install package from local path preserving existing dependencies
                 'Pkg.develop(PackageSpec(path="%s"); preserve=PRESERVE_ALL)' % pkg_source,
                 'Pkg.build("%s")' % os.path.basename(pkg_source),
-                'Pkg.precompile("%s")' % os.path.basename(pkg_source),
             ])
 
         julia_pkg_cmd = '; '.join(julia_pkg_cmd)
@@ -236,6 +235,7 @@ class JuliaPackage(ExtensionEasyBlock):
         # prepare the installation environment
         self.set_pkg_offline()
         self.prepare_julia_env(self.installdir)
+        env.setvar('JULIA_PKG_PRECOMPILE_AUTO', 'true')  # precompile installed packages
 
         # add packages found in dependencies to this installation environment
         for dep in self.cfg.dependencies():

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -69,16 +69,19 @@ class JuliaPackage(ExtensionEasyBlock):
     Julia environement setup during installation:
         - initialize new Julia environment in 'environments' subdir in installation directory
         - remove paths in user depot '~/.julia' from DEPOT_PATH and LOAD_PATH
-        - put installation directory as top DEPOT_PATH, which is the target depot for installations with Pkg
-        - put installation environment as top LOAD_PATH, which is needed to precompile installed packages
-        - add Julia packages found in dependencies of the easyconfig to installation environment, this is needed
+        - put installation directory as top DEPOT_PATH, the target depot for installations with Pkg
+        - put installation environment as top LOAD_PATH, needed to precompile installed packages
+        - add Julia packages found in dependencies of the easyconfig to installation environment, needed
           for Pkg to be aware of those packages and not install them again
-        - add newly installed Julia packages to installation environment, this is automatically done by Pkg
+        - add newly installed Julia packages to installation environment (automatically done by Pkg)
 
     Julia environment setup on module load:
-        - append installation directory to list of DEPOT_PATH, which is needed to load artifacts (JLL packages)
-        - append installation environment to list of LOAD_PATH, which is needed to load packages with `using`
-          command and make them known to Pkg
+        User depot and its shared environment for this version of Julia are kept as top paths of DEPOT_PATH and
+        LOAD_PATH respectively. This ensures that the user can keep using its own environment after loading
+        JuliaPackage modules, installing additional software on its personal depot while still using packages
+        provided by the module. Effectively, this translates to:
+        - append installation directory to list of DEPOT_PATH, only really needed to load artifacts (JLL packages)
+        - append installation Project.toml file to list of LOAD_PATH, needed to load packages with `using` command
     """
 
     @staticmethod
@@ -306,10 +309,11 @@ class JuliaPackage(ExtensionEasyBlock):
     def make_module_extra(self, *args, **kwargs):
         """
         Module load initializes JULIA_DEPOT_PATH and JULIA_LOAD_PATH with default values if they are not set.
+
         Path to installation directory is appended to JULIA_DEPOT_PATH.
-        Path to the environment file of this installation is appended to JULIA_LOAD_PATH.
-        This configuration fulfils the rule that user depot has to be the first path in JULIA_DEPOT_PATH, allows users
-        to use custom Julia environments and makes packages in installation dir available in Julia.
+        Path to the environment file of this installation is prepended to JULIA_LOAD_PATH.
+        This configuration fulfils the rule that user depot has to be the first path in JULIA_DEPOT_PATH,
+        allowing user to add custom Julia packages while having packages in this installation available.
         See issue easybuilders/easybuild-easyconfigs#17455
         """
         mod = super(JuliaPackage, self).make_module_extra()

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -218,9 +218,6 @@ class JuliaPackage(ExtensionEasyBlock):
         # Location of project environment files in install dir
         mkdir(self.julia_env_path(), parents=True)
 
-        self.set_pkg_offline()
-        self.prepare_julia_env(self.installdir)
-
     def configure_step(self):
         """No separate configuration for JuliaPackage."""
         pass
@@ -235,6 +232,10 @@ class JuliaPackage(ExtensionEasyBlock):
 
     def install_step(self):
         """Install Julia package and add all its dependencies to project environment"""
+
+        # prepare the installation environment
+        self.set_pkg_offline()
+        self.prepare_julia_env(self.installdir)
 
         # add packages found in dependencies to this installation environment
         for dep in self.cfg.dependencies():
@@ -260,8 +261,6 @@ class JuliaPackage(ExtensionEasyBlock):
             raise EasyBuildError(errmsg, self.name, self.src)
         ExtensionEasyBlock.run(self, unpack_src=True)
 
-        self.set_pkg_offline()
-        self.prepare_julia_env(self.installdir)  # all extensions share common depot in install dir
         self.install_step()
 
     def sanity_check_step(self, *args, **kwargs):

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -291,6 +291,7 @@ class JuliaPackage(ExtensionEasyBlock):
             raise EasyBuildError(errmsg, self.name, self.src)
         ExtensionEasyBlock.run(self, unpack_src=True)
 
+        self.prepare_julia_env()
         self.install_pkg()
 
     def sanity_check_step(self, *args, **kwargs):


### PR DESCRIPTION
This PR changes a bit how installations of JuliaPackages are handled to get the following improvements:

Fixes https://github.com/easybuilders/easybuild-easyconfigs/issues/19281
Alternative fix for https://github.com/easybuilders/easybuild-easyconfigs/pull/19650

* Properly handle `JuliaPackages` that have other `JuliaPackages` in their `dependencies`. Currently those dependencies are not seen by `Julia.Pkg` which results in packages being re-installed even though they can be found in the deps. This is fixed by adding all Julia packages found across dependencies to the Julia environment of the installation.
* Don't make assumptions about `DEPOT_PATH` and grab it from the Julia environment. This avoids needing `JULIA_DEPOT_PATH` in the shell environment.
* Respect user environment: user depot and its shared environment for this version of Julia are kept as top paths of `DEPOT_PATH` and `LOAD_PATH` respectively. This ensures that the user can keep using its own environment after loading JuliaPackage modules, installing additional software on its personal depot while still using packages provided by the module:
    * Don't reset `DEPOT_PATH` or `LOAD_PATH` on module load unless they are not set at all
    * Append path to installation to `DEPOT_PATH` and path to installation environment to `LOAD_PATH`