### PR TITLE
ensure localrc is created in the correct subdir for NVHPC v22.9+

### DIFF
--- a/easybuild/easyblocks/n/nvhpc.py
+++ b/easybuild/easyblocks/n/nvhpc.py
@@ -165,7 +165,8 @@ class EB_NVHPC(PackedBinary):
             sys.stdout.write(line)
 
         if LooseVersion(self.version) >= LooseVersion('22.9'):
-            cmd = "%s -x %s" % (makelocalrc_filename, compilers_subdir)
+            bin_subdir = os.path.join(compilers_subdir, "bin")
+            cmd = "%s -x %s" % (makelocalrc_filename, bin_subdir)
         else:
             cmd = "%s -x %s -g77 /" % (makelocalrc_filename, compilers_subdir)
         run_cmd(cmd, log_all=True, simple=True)

--- a/easybuild/easyblocks/n/nvhpc.py
+++ b/easybuild/easyblocks/n/nvhpc.py
@@ -36,8 +36,10 @@ EasyBuild support for installing NVIDIA HPC SDK compilers, based on the easybloc
 import os
 import fileinput
 import re
+import shutil
 import stat
 import sys
+import tempfile
 import platform
 
 from easybuild.tools import LooseVersion
@@ -66,6 +68,14 @@ append LDLIBARGS=$library_path;
 # also include the location where libm & co live on Debian-based systems
 # cfr. https://github.com/easybuilders/easybuild-easyblocks/pull/919
 append LDLIBARGS=-L/usr/lib/x86_64-linux-gnu;
+"""
+
+# contents for minimal example compiled in sanity check, used to catch issue
+# seen in: https://github.com/easybuilders/easybuild-easyblocks/pull/3240
+NVHPC_MINIMAL_EXAMPLE = """
+#include <ranges>
+
+int main(){ return 0; }
 """
 
 
@@ -205,6 +215,19 @@ class EB_NVHPC(PackedBinary):
         }
         custom_commands = ["%s -v" % compiler for compiler in compiler_names]
         super(EB_NVHPC, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
+
+        # compile minimal example using -std=c++20 to catch issue where it picks up the wrong GCC
+        # (as long as system gcc is < 9.0)
+        # see: https://github.com/easybuilders/easybuild-easyblocks/pull/3240
+        tmpdir = tempfile.mkdtemp()
+        write_file(os.path.join(tmpdir, 'minimal.cpp'), NVHPC_MINIMAL_EXAMPLE)
+        os.chdir(tmpdir)
+        cmd = "nvc++ -std=c++20 minimal.cpp -o minimal"
+        run_cmd(cmd, log_all=True, simple=True)
+        try:
+            shutil.rmtree(tmpdir)
+        except OSError as err:
+            raise EasyBuildError("Failed to remove temporary sanity check directory %s: %s", tmpdir, err)
 
     def _nvhpc_extended_components(self, dirs, basepath, env_vars_dirs):
         """

--- a/easybuild/easyblocks/n/nvhpc.py
+++ b/easybuild/easyblocks/n/nvhpc.py
@@ -215,13 +215,14 @@ class EB_NVHPC(PackedBinary):
 
         custom_commands = ["%s -v" % compiler for compiler in compiler_names]
 
-        # compile minimal example using -std=c++20 to catch issue where it picks up the wrong GCC
-        # (as long as system gcc is < 9.0)
-        # see: https://github.com/easybuilders/easybuild-easyblocks/pull/3240
-        tmpdir = tempfile.mkdtemp()
-        write_file(os.path.join(tmpdir, 'minimal.cpp'), NVHPC_MINIMAL_EXAMPLE)
-        minimal_compiler_cmd = "cd %s && nvc++ -std=c++20 minimal.cpp -o minimal" % tmpdir
-        custom_commands.append(minimal_compiler_cmd)
+        if LooseVersion(self.version) >= LooseVersion('21'):
+            # compile minimal example using -std=c++20 to catch issue where it picks up the wrong GCC
+            # (as long as system gcc is < 9.0)
+            # see: https://github.com/easybuilders/easybuild-easyblocks/pull/3240
+            tmpdir = tempfile.mkdtemp()
+            write_file(os.path.join(tmpdir, 'minimal.cpp'), NVHPC_MINIMAL_EXAMPLE)
+            minimal_compiler_cmd = "cd %s && nvc++ -std=c++20 minimal.cpp -o minimal" % tmpdir
+            custom_commands.append(minimal_compiler_cmd)
 
         super(EB_NVHPC, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
 

--- a/easybuild/easyblocks/n/nvhpc.py
+++ b/easybuild/easyblocks/n/nvhpc.py
@@ -36,7 +36,6 @@ EasyBuild support for installing NVIDIA HPC SDK compilers, based on the easybloc
 import os
 import fileinput
 import re
-import shutil
 import stat
 import sys
 import tempfile


### PR DESCRIPTION
To fix issue reported in slack. Currently, compiling the following minimal example fails:
```bash
$ cat minimal.cpp
#include <ranges>

int main(){ return 0; }
$ nvc++ -std=c++20 minimal.cpp -o minimal
"minimal.cpp", line 1: catastrophic error: cannot open source file "ranges"
  #include <ranges>
                   ^

1 catastrophic error detected in the compilation of "minimal.cpp".
Compilation terminated.
```

Ss noticed by @branfosj:

During the install we use `makelocalrc` to generate a `localrc` file. This has a bunch of pointers to the GCC install.
In my working 22.3 install, there is one of these files. In `Linux_x86_64/22.3/compilers/bin/localrc`
In my broken 24.1 install there are two of them
```
Linux_x86_64/24.1/compilers/bin/localrc
Linux_x86_64/24.1/compilers/localrc
```
The second of these is the one generated by EB and is correct. The first one has a mix of OS GCC and EB GCC in it.

(created using `eb --new-pr`)
