### PR TITLE
Feature improve QuantumESPRESSO easyblock

### DIFF
--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -619,7 +619,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
 
             # Log test-suite errors if present
             if _pass < _tot:
-                # Example output for reported faliures:
+                # Example output for reported failures:
                 # pw_plugins - plugin-pw2casino_1.in (arg(s): 1): **FAILED**.
                 # Different sets of data extracted from benchmark and test.
                 #     Data only in benchmark: p1.

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -381,9 +381,9 @@ class EB_QuantumESPRESSO(ConfigureMake):
                     # need to use [ \t]* instead of \s*, because vars may be undefined as empty,
                     # and we don't want to include newlines
                     if keep:
-                        line = re.sub(fr"^({k}\s*=[ \t]*)(.*)$", fr"\1\2 {v}", line)
+                        line = re.sub(r"^(%s\s*=[ \t]*)(.*)$" % k, r"\1\2 %s" % v, line)
                     else:
-                        line = re.sub(fr"^({k}\s*=[ \t]*).*$", fr"\1{v}", line)
+                        line = re.sub(r"^(%s\s*=[ \t]*).*$" % k, r"\1%s" % v, line)
 
                 # fix preprocessing directives for .f90 files in make.sys if required
                 if LooseVersion(self.version) < LooseVersion("6.0"):
@@ -416,7 +416,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
             fn = os.path.join(self.cfg['start_dir'], 'plugins', 'install', 'make_wannier90.sys')
         try:
             for line in fileinput.input(fn, inplace=1, backup='.orig.eb'):
-                line = re.sub(r"^(LIBS\s*=\s*).*", fr"\1{libs}", line)
+                line = re.sub(r"^(LIBS\s*=\s*).*", r"\1%s" % libs, line)
 
                 sys.stdout.write(line)
 

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -577,7 +577,8 @@ class EB_QuantumESPRESSO(ConfigureMake):
         test_dir = os.path.join(self.start_dir, self.TEST_SUITE_DIR)
 
         pseudo_loc = "https://pseudopotentials.quantum-espresso.org/upf_files/"
-        if LooseVersion(self.version) < LooseVersion("7.0"):
+        # NETWORK_PSEUDO in test_suite/ENVIRONMENT is set to old url for qe 7.0 and older
+        if LooseVersion(self.version) < LooseVersion("7.1"):
             cmd = ' && '.join([
                 "cd %s" % test_dir,
                 "sed -i 's|export NETWORK_PSEUDO=.*|export NETWORK_PSEUDO=%s|g' ENVIRONMENT" % pseudo_loc

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -649,9 +649,9 @@ class EB_QuantumESPRESSO(ConfigureMake):
         perc = spass / max(stot, 1)
         self.log.info("Total tests passed %d out of %d  (%.2f%%)" % (spass, stot, perc * 100))
         if failures:
-            self.log.error("The following tests failed:")
+            self.log.warning("The following tests failed:")
             for failure in failures:
-                self.log.error('|   ' + failure)
+                self.log.warning('|   ' + failure)
             raise EasyBuildError("Test suite failed")
         if perc < thr:
             raise EasyBuildError(

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -425,7 +425,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
             raise EasyBuildError("Failed to patch %s: %s", fn, err)
 
         with open(fn, "r") as f:
-            self.log.debug("Contents of patched %s: %s" % (fn, f.read()))
+            self.log.info("Contents of patched %s: %s" % (fn, f.read()))
 
         # patch default make.sys for wannier
         if LooseVersion(self.version) >= LooseVersion("5"):

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -663,6 +663,13 @@ class EB_QuantumESPRESSO(ConfigureMake):
     def install_step(self):
         """Custom install step for Quantum ESPRESSO."""
 
+        # In QE 7.3 the w90 target is always invoked (even if only used as a library), and the symlink to the
+        # `wannier90.x` executable is generated, but the actual binary is not built. We need to remove the symlink
+        if LooseVersion(self.version) == LooseVersion("7.3.0"):
+            w90_path = os.path.join(self.start_dir, 'bin', 'wannier90.x')
+            if not os.path.exists(os.readlink(w90_path)):
+                os.unlink(w90_path)
+
         # extract build targets as list
         targets = self.cfg['buildopts'].split()
 

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -67,12 +67,13 @@ class EB_QuantumESPRESSO(ConfigureMake):
                 "pw", "pp", "ph", "cp", "hp", "tddfpt", "epw",
                 ], "List of test suite targets to run", CUSTOM],
             'test_suite_allow_failures': [[
-                'relax',
-                'epw_polar',
-                'cp_h2o_scan_libxc',
-                'hp_metal_us_magn',
-                'ph_ahc_diam',
-                'tddfpt_magnons_fe',
+                'relax',  # Too strict thresholds
+                'epw_polar',  # Too strict thresholds
+                'cp_h2o_scan_libxc',  # Too strict thresholds
+                'hp_metal_us_magn',  # Too strict thresholds
+                'hp_soc_UV_paw_magn',  # In 7.3 test has more params than the baseline
+                'ph_ahc_diam',  # Test detects a ! as an energy in baseline
+                'tddfpt_magnons_fe',  # Too strict thresholds
             ], "List of test suite targets that are allowed to fail (name can partially match)", CUSTOM],
             'test_suite_threshold': [0.97, "Threshold for test suite success rate", CUSTOM],
         }
@@ -383,6 +384,8 @@ class EB_QuantumESPRESSO(ConfigureMake):
         self._add_epw()
         self._add_gipaw()
         self._add_wannier90()
+        
+        run_cmd("module list", log_all=True, log_ok=True, simple=False, regexp=False)
 
         if comp_fam == toolchain.INTELCOMP:
             # Intel compiler must have -assume byterecl (see install/configure)

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -341,7 +341,8 @@ class EB_QuantumESPRESSO(ConfigureMake):
             if self.cfg['with_scalapack']:
                 num_libs.extend(['SCALAPACK'])
             elpa = get_software_root('ELPA')
-            elpa_lib = os.path.join(elpa or '', 'lib', 'libelpa.a' if self.toolchain.options.get('openmp', False) else 'libelpa_openmp.a')
+            elpa_lib = 'libelpa.a' if self.toolchain.options.get('openmp', False) else 'libelpa_openmp.a'
+            elpa_lib = os.path.join(elpa or '', 'lib', elpa_lib)
             for lib in num_libs:
                 if self.toolchain.options.get('openmp', False):
                     val = os.getenv('LIB%s_MT' % lib)

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -340,7 +340,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
         else:
             if 'gipaw' in self.cfg['buildopts']:
                 self.cfg['buildopts'] = self.cfg['buildopts'].replace('gipaw', '')
-                
+
     def _add_wannier90(self):
         """Add Wannier90 support to the build."""
         if self.cfg['with_wannier90']:
@@ -384,7 +384,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
         self._add_epw()
         self._add_gipaw()
         self._add_wannier90()
-        
+
         run_cmd("module list", log_all=True, log_ok=True, simple=False, regexp=False)
 
         if comp_fam == toolchain.INTELCOMP:
@@ -667,7 +667,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
         # `wannier90.x` executable is generated, but the actual binary is not built. We need to remove the symlink
         if LooseVersion(self.version) == LooseVersion("7.3"):
             w90_path = os.path.join(self.start_dir, 'bin', 'wannier90.x')
-            if not os.path.exists(os.readlink(w90_path)):
+            if os.path.islink(w90_path) and not os.path.exists(os.readlink(w90_path)):
                 os.unlink(w90_path)
 
         # extract build targets as list

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -78,7 +78,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
         allowed_toolchains = [toolchain.INTELCOMP, toolchain.GCC]
         if comp_fam not in allowed_toolchains:
             raise EasyBuildError(f"EasyBuild does not yet have support for QuantumESPRESSO with toolchain {comp_fam}")
-            
+
         if LooseVersion(self.version) >= LooseVersion("6.1"):
             if comp_fam == toolchain.INTELCOMP:
                 self._dflags += ["-D__INTEL_COMPILER"]
@@ -121,7 +121,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
         if not self.cfg['with_scalapack']:
             self.cfg.update('configopts', '--without-scalapack')
             return
-            
+
         if comp_fam == toolchain.INTELCOMP:
             if get_software_root("impi") and get_software_root("imkl"):
                 if LooseVersion(self.version) >= LooseVersion("6.2"):
@@ -146,7 +146,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
         libxc = get_software_root("libxc")
         if not libxc:
             return
-        
+
         libxc_v = get_software_version("libxc")
         if LooseVersion(libxc_v) < LooseVersion("3.0.1"):
             raise EasyBuildError("Must use libxc >= 3.0.1")
@@ -162,7 +162,6 @@ class EB_QuantumESPRESSO(ConfigureMake):
             self.cfg.update('configopts', f'--with-libxc-prefix={libxc}')
         else:
             self.extra_libs.append(" -lxcf90 -lxc")
-            
 
         self._dflags += ["-D__LIBXC"]
 

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -591,7 +591,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
         failures = []
         for target in targets:
             pcmd = ''
-            if LooseVersion(self.version) < LooseVersion("7.0"):
+            if LooseVersion(self.version) < LooseVersion("7.2"):
                 if parallel > 1:
                     target = target + "-parallel"
                 else:

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -72,6 +72,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
             'with_scalapack': [True, "Enable ScaLAPACK support", CUSTOM],
             'with_ace': [False, "Enable Adaptively Compressed Exchange support", CUSTOM],
             'with_fox': [False, "Enable FoX support", CUSTOM],
+            'with_epw': [True, "Enable EPW support", CUSTOM],
             'with_gipaw': [True, "Enable GIPAW support", CUSTOM],
             'with_wannier90': [False, "Enable Wannier90 support", CUSTOM], 
             'test_threshold': [0.9, "Threshold for test suite success rate", CUSTOM],
@@ -315,6 +316,17 @@ class EB_QuantumESPRESSO(ConfigureMake):
             if LooseVersion(self.version) >= LooseVersion("7.2"):
                 self.cfg.update('configopts', '--with-fox=yes')
 
+    def _add_epw(self):
+        """Add EPW support to the build."""
+        if self.cfg['with_epw']:
+            if LooseVersion(self.version) >= LooseVersion("6.0"):
+                self.cfg.update('buildopts', 'epw', allow_duplicate=False)
+            else:
+                self.log.warning("EPW support is not available in QuantumESPRESSO < 6.0")
+        else:
+            if 'epw' in self.cfg['buildopts']:
+                self.cfg['buildopts'].replace('epw', '')
+
     def _add_gipaw(self):
         """Add GIPAW support to the build."""
         if self.cfg['with_gipaw']:
@@ -366,6 +378,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
         self._add_ace()
         self._add_beef()
         self._add_fox()
+        self._add_epw()
         self._add_gipaw()
         self._add_wannier90()
 

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -413,7 +413,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
 
         # libs is being used for the replacement in the wannier90 files
         libs = []
-        # Only overriding for fcc as the intel flags are already ebing properly
+        # Only overriding for gcc as the intel flags are already being properly
         # set.
         if comp_fam == toolchain.GCC:
             num_libs = ['BLAS', 'LAPACK', 'FFT']

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -652,7 +652,6 @@ class EB_QuantumESPRESSO(ConfigureMake):
             self.log.warning("The following tests failed:")
             for failure in failures:
                 self.log.warning('|   ' + failure)
-            raise EasyBuildError("Test suite failed")
         if perc < thr:
             raise EasyBuildError(
                 "Test suite failed with less than %.2f %% (%.2f) success rate" % (thr * 100, perc * 100)

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -296,7 +296,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
         # for guidelines, see include/defs.h.README in sources
         self.dflags = []
         self.repls = []
-        self.extra_libs = self.extra_libs = []
+        self.extra_libs = []
 
         comp_fam = self.toolchain.comp_family()
 

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -526,12 +526,12 @@ class EB_QuantumESPRESSO(ConfigureMake):
             # All done. ERROR: only 6 out of 9 tests passed
             _tot = 0
             _pass = 0
-            rgx = r'All done. (ERROR: only )?(?P<succeded>\d+) out of (?P<total>\d+) tests passed.'
+            rgx = r'All done. (ERROR: only )?(?P<succeeded>\d+) out of (?P<total>\d+) tests passed.'
             for mch in re.finditer(rgx, out):
-                succeded = int(mch.group('succeded'))
+                succeeded = int(mch.group('succeeded'))
                 total = int(mch.group('total'))
                 _tot += total
-                _pass += succeded
+                _pass += succeeded
 
             perc = _pass / max(_tot, 1)
             self.log.info("%s: Passed %d out of %d  (%.2f%%)" % (target, _pass, _tot, perc * 100))

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -666,7 +666,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
                 )
         if num_fail > num_fail_thr:
             raise EasyBuildError(
-                "Test suite failed with more than %d failures %d" % (num_fail_thr, num_fail)
+                "Test suite failed with %d failures (%d failures permitted)" % (num_fail, num_fail_thr)
                 )
 
         return full_out

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -384,7 +384,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
             raise EasyBuildError("Found FoX external module, QuantumESPRESSO" +
                                  "must use the version they include with the source.")
 
-        self.log.debug("List of replacements to perform: %s" % str(self.repls))
+        self.log.info("List of replacements to perform: %s" % str(self.repls))
 
         if LooseVersion(self.version) >= LooseVersion("6"):
             make_ext = '.inc'

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -180,12 +180,12 @@ class EB_QuantumESPRESSO(ConfigureMake):
         elpa = get_software_root("ELPA")
         if not elpa:
             return
-        
+
         elpa_v = get_software_version("ELPA")
 
         if LooseVersion(elpa_v) < LooseVersion("2015"):
             raise EasyBuildError("ELPA versions lower than 2015 are not supported")
-        
+
         if LooseVersion(self.version) >= LooseVersion("6.8"):
             if LooseVersion(elpa_v) >= LooseVersion("2018.11"):
                 self.dflags += ["-D__ELPA"]
@@ -217,7 +217,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
             return
         else:
             raise EasyBuildError("ELPA support is only available in QuantumESPRESSO 5.1.1 and later")
-        
+
         if self.toolchain.options.get('openmp', False):
             elpa_include = 'elpa_openmp-%s' % elpa_v
             elpa_lib = 'libelpa_openmp.a'
@@ -258,7 +258,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
         """Add ACE support to the build."""
         if not self.cfg['with_ace']:
             return
-        
+
         if LooseVersion(self.version) >= LooseVersion("6.2"):
             self.log.warning("ACE support is not available in QuantumESPRESSO >= 6.2")
         elif LooseVersion(self.version) >= LooseVersion("6.0"):
@@ -286,18 +286,8 @@ class EB_QuantumESPRESSO(ConfigureMake):
                 i_mpi_cc = os.getenv('I_MPI_CC', '')
                 if i_mpi_cc == 'icx':
                     env.setvar('I_MPI_CC', 'icc') # Needed cor clib/qmmm_aux.c using <math.h> implicitly
-                # self._repls += [
-                #     ('CFLAGS', '--std=c90', True), # Needed cor clib/qmmm_aux.c using <math.h> implicitly
-                # ]
-            pass
-            # self.cfg.update('configopts', '--with-scalapack=intel')
-            # self._dflags += ["-D__INTEL"]
         elif comp_fam == toolchain.GCC:
-            # self._dflags += ["-D__GFORTRAN"]
             pass
-
-
-        
 
     def configure_step(self):
         """Custom configuration procedure for Quantum ESPRESSO."""

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -420,7 +420,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
             if self.cfg['with_scalapack']:
                 num_libs.extend(['SCALAPACK'])
             elpa = get_software_root('ELPA')
-            elpa_lib = 'libelpa.a' if self.toolchain.options.get('openmp', False) else 'libelpa_openmp.a'
+            elpa_lib = 'libelpa_openmp.a' if self.toolchain.options.get('openmp', False) else 'libelpa.a'
             elpa_lib = os.path.join(elpa or '', 'lib', elpa_lib)
             for lib in num_libs:
                 if self.toolchain.options.get('openmp', False):

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -325,7 +325,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
                 self.log.warning("EPW support is not available in QuantumESPRESSO < 6.0")
         else:
             if 'epw' in self.cfg['buildopts']:
-                self.cfg['buildopts'].replace('epw', '')
+                self.cfg['buildopts'] = self.cfg['buildopts'].replace('epw', '')
             if 'epw' in self.cfg['test_suite_targets']:
                 self.cfg['test_suite_targets'].remove('epw')
 
@@ -338,7 +338,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
             self.cfg.update('buildopts', 'gipaw', allow_duplicate=False)
         else:
             if 'gipaw' in self.cfg['buildopts']:
-                self.cfg['buildopts'].replace('gipaw', '')
+                self.cfg['buildopts'] = self.cfg['buildopts'].replace('gipaw', '')
                 
     def _add_wannier90(self):
         """Add Wannier90 support to the build."""
@@ -346,7 +346,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
             self.cfg.update('buildopts', 'w90', allow_duplicate=False)
         else:
             if 'w90' in self.cfg['buildopts']:
-                self.cfg['buildopts'].replace('w90', '')
+                self.cfg['buildopts'] = self.cfg['buildopts'].replace('w90', '')
 
     def _adjust_compiler_flags(self, comp_fam):
         """Adjust compiler flags based on the compiler family and code version."""
@@ -626,9 +626,10 @@ class EB_QuantumESPRESSO(ConfigureMake):
                     if '**FAILED**' in line:
                         for allowed in allow_fail:
                             if allowed in line:
+                                self.log.info('Ignoring failure: %s' % line)
                                 break
                         else:
-                            failures.append(line.split('-')[0].strip())
+                            failures.append(line)
                         flag = True
                         self.log.warning(line)
                         continue
@@ -645,8 +646,9 @@ class EB_QuantumESPRESSO(ConfigureMake):
         perc = spass / max(stot, 1)
         self.log.info("Total tests passed %d out of %d  (%.2f%%)" % (spass, stot, perc * 100))
         if failures:
-            failed_msg = ', '.join(failures)
-            self.log.error("The following tests failed: %s" % failed_msg)
+            self.log.error("The following tests failed:")
+            for failure in failures:
+                self.log.error('|   ' + failure)
             raise EasyBuildError("Test suite failed")
         if perc < thr:
             raise EasyBuildError(

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -172,7 +172,9 @@ class EB_QuantumESPRESSO(ConfigureMake):
                 self.cfg.update('configopts', '--with-libxc-prefix=%s' % libxc)
             elif LooseVersion(self.version) >= LooseVersion("6.0"):
                 if LooseVersion(libxc_v) >= LooseVersion("5.0"):
-                    raise EasyBuildError("libxc support for QuantumESPRESSO 6.0 to 6.5 only available for libxc <= 4.3.4")
+                    raise EasyBuildError(
+                        "libxc support for QuantumESPRESSO 6.0 to 6.5 only available for libxc <= 4.3.4"
+                        )
                 if LooseVersion(libxc_v) < LooseVersion("4"):
                     raise EasyBuildError("libxc support for QuantumESPRESSO 6.x only available for libxc >= 4")
                 self.cfg.update('configopts', '--with-libxc=yes')
@@ -379,7 +381,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
                     val = ' '.join([elpa_lib, val])
                 self.repls.append(('%s_LIBS' % lib, val, False))
                 libs.append(val)
-            libs = ' '.join(libs)
+        libs = ' '.join(libs)
 
         self.repls.append(('BLAS_LIBS_SWITCH', 'external', False))
         self.repls.append(('LAPACK_LIBS_SWITCH', 'external', False))
@@ -443,7 +445,8 @@ class EB_QuantumESPRESSO(ConfigureMake):
             fn = os.path.join(self.cfg['start_dir'], 'plugins', 'install', 'make_wannier90.sys')
         try:
             for line in fileinput.input(fn, inplace=1, backup='.orig.eb'):
-                line = re.sub(r"^(LIBS\s*=\s*).*", r"\1%s" % libs, line)
+                if libs:
+                    line = re.sub(r"^(LIBS\s*=\s*).*", r"\1%s" % libs, line)
 
                 sys.stdout.write(line)
 
@@ -451,7 +454,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
             raise EasyBuildError("Failed to patch %s: %s", fn, err)
 
         with open(fn, "r") as f:
-            self.log.debug("Contents of patched %s: %s" % (fn, f.read()))
+            self.log.info("Contents of patched %s: %s" % (fn, f.read()))
 
         # patch Makefile of want plugin
         wantprefix = 'want-'

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -653,7 +653,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
 
         # Allow for flaky tests (eg too strict thresholds on results for structure relaxation)
         num_fail = len(failures)
-        num_fail_thr = self.cfg.get('test_suite_max_failures', 0)
+        num_fail_thr = self.cfg.get('test_suite_max_failed', 0)
         perc = spass / max(stot, 1)
         self.log.info("Total tests passed %d out of %d  (%.2f%%)" % (spass, stot, perc * 100))
         if failures:

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -93,49 +93,47 @@ class EB_QuantumESPRESSO(ConfigureMake):
 
     def _add_openmp(self):
         """Add OpenMP support to the build."""
-        if not self.toolchain.options.get('openmp', False) and not self.cfg['hybrid']:
-            return
-        self.cfg.update('configopts', '--enable-openmp')
-        if LooseVersion(self.version) >= LooseVersion("6.2.1"):
-            self.dflags += ["-D_OPENMP"]
-        elif LooseVersion(self.version) >= LooseVersion("5.0"):
-            self.dflags += ["-D__OPENMP"]
+        if self.toolchain.options.get('openmp', False) or self.cfg['hybrid']:
+            self.cfg.update('configopts', '--enable-openmp')
+            if LooseVersion(self.version) >= LooseVersion("6.2.1"):
+                self.dflags += ["-D_OPENMP"]
+            elif LooseVersion(self.version) >= LooseVersion("5.0"):
+                self.dflags += ["-D__OPENMP"]
 
     def _add_mpi(self):
         """Add MPI support to the build."""
         if not self.toolchain.options.get('usempi', False):
             self.cfg.update('configopts', '--disable-parallel')
-            return
-        self.cfg.update('configopts', '--enable-parallel')
-        if LooseVersion(self.version) >= LooseVersion("6.0"):
-            self.dflags += ["-D__MPI"]
-        elif LooseVersion(self.version) >= LooseVersion("5.0"):
-            self.dflags += ["-D__MPI", "-D__PARA"]
+        else:
+            self.cfg.update('configopts', '--enable-parallel')
+            if LooseVersion(self.version) >= LooseVersion("6.0"):
+                self.dflags += ["-D__MPI"]
+            elif LooseVersion(self.version) >= LooseVersion("5.0"):
+                self.dflags += ["-D__MPI", "-D__PARA"]
 
     def _add_scalapack(self, comp_fam):
         """Add ScaLAPACK support to the build."""
         if not self.cfg['with_scalapack']:
             self.cfg.update('configopts', '--without-scalapack')
-            return
-
-        if comp_fam == toolchain.INTELCOMP:
-            if get_software_root("impi") and get_software_root("imkl"):
-                if LooseVersion(self.version) >= LooseVersion("6.2"):
-                    self.cfg.update('configopts', '--with-scalapack=intel')
-                elif LooseVersion(self.version) >= LooseVersion("5.1.1"):
-                    self.cfg.update('configopts', '--with-scalapack=intel')
-                    self.repls += [
-                        ('SCALAPACK_LIBS', os.getenv('LIBSCALAPACK'), False)
-                    ]
-                elif LooseVersion(self.version) >= LooseVersion("5.0"):
-                    self.cfg.update('configopts', '--with-scalapack=yes')
-                self.dflags += ["-D__SCALAPACK"]
-        elif comp_fam == toolchain.GCC:
-            if get_software_root("OpenMPI") and get_software_root("ScaLAPACK"):
-                self.cfg.update('configopts', '--with-scalapack=yes')
-                self.dflags += ["-D__SCALAPACK"]
         else:
-            self.cfg.update('configopts', '--without-scalapack')
+            if comp_fam == toolchain.INTELCOMP:
+                if get_software_root("impi") and get_software_root("imkl"):
+                    if LooseVersion(self.version) >= LooseVersion("6.2"):
+                        self.cfg.update('configopts', '--with-scalapack=intel')
+                    elif LooseVersion(self.version) >= LooseVersion("5.1.1"):
+                        self.cfg.update('configopts', '--with-scalapack=intel')
+                        self.repls += [
+                            ('SCALAPACK_LIBS', os.getenv('LIBSCALAPACK'), False)
+                        ]
+                    elif LooseVersion(self.version) >= LooseVersion("5.0"):
+                        self.cfg.update('configopts', '--with-scalapack=yes')
+                    self.dflags += ["-D__SCALAPACK"]
+            elif comp_fam == toolchain.GCC:
+                if get_software_root("OpenMPI") and get_software_root("ScaLAPACK"):
+                    self.cfg.update('configopts', '--with-scalapack=yes')
+                    self.dflags += ["-D__SCALAPACK"]
+            else:
+                self.cfg.update('configopts', '--without-scalapack')
 
     def _add_libxc(self):
         """Add libxc support to the build."""

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -49,7 +49,7 @@ from easybuild.easyblocks.generic.configuremake import ConfigureMake
 
 class EB_QuantumESPRESSO(ConfigureMake):
     """Support for building and installing Quantum ESPRESSO."""
-    
+
     TEST_SUITE_DIR = "test-suite"
     TEST_SUITE_TARGETS = [
         "run-tests-pw",

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -665,7 +665,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
 
         # In QE 7.3 the w90 target is always invoked (even if only used as a library), and the symlink to the
         # `wannier90.x` executable is generated, but the actual binary is not built. We need to remove the symlink
-        if LooseVersion(self.version) == LooseVersion("7.3.0"):
+        if LooseVersion(self.version) == LooseVersion("7.3"):
             w90_path = os.path.join(self.start_dir, 'bin', 'wannier90.x')
             if not os.path.exists(os.readlink(w90_path)):
                 os.unlink(w90_path)

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -159,17 +159,26 @@ class EB_QuantumESPRESSO(ConfigureMake):
             if LooseVersion(libxc_v) < LooseVersion("3.0.1"):
                 raise EasyBuildError("Must use libxc >= 3.0.1")
             if LooseVersion(self.version) >= LooseVersion("7.0"):
-                if LooseVersion(libxc_v) < LooseVersion("6.0.0"):
-                    raise EasyBuildError("libxc support for QuantumESPRESSO 7.0 only available for libxc >= 6.0.0")
+                if LooseVersion(libxc_v) < LooseVersion("4"):
+                    raise EasyBuildError("libxc support for QuantumESPRESSO 7.x only available for libxc >= 4")
                 self.cfg.update('configopts', '--with-libxc=yes')
                 self.cfg.update('configopts', '--with-libxc-prefix=%s' % libxc)
-            elif LooseVersion(self.version) >= LooseVersion("6.4"):
+            elif LooseVersion(self.version) >= LooseVersion("6.6"):
+                if LooseVersion(libxc_v) >= LooseVersion("6.0"):
+                    raise EasyBuildError("libxc support for QuantumESPRESSO 6.6 to 6.8 only available for libxc < 6.0")
+                if LooseVersion(libxc_v) < LooseVersion("4"):
+                    raise EasyBuildError("libxc support for QuantumESPRESSO 6.x only available for libxc >= 4")
+                self.cfg.update('configopts', '--with-libxc=yes')
+                self.cfg.update('configopts', '--with-libxc-prefix=%s' % libxc)
+            elif LooseVersion(self.version) >= LooseVersion("6.0"):
                 if LooseVersion(libxc_v) >= LooseVersion("5.0"):
-                    raise EasyBuildError("libxc support for QuantumESPRESSO 6.x only available for libxc <= 4.3.4")
+                    raise EasyBuildError("libxc support for QuantumESPRESSO 6.0 to 6.5 only available for libxc <= 4.3.4")
+                if LooseVersion(libxc_v) < LooseVersion("4"):
+                    raise EasyBuildError("libxc support for QuantumESPRESSO 6.x only available for libxc >= 4")
                 self.cfg.update('configopts', '--with-libxc=yes')
                 self.cfg.update('configopts', '--with-libxc-prefix=%s' % libxc)
             else:
-                self.extra_libs += ['-lxcf90', '-lxc']
+                self.extra_libs += ['-L%s/lib' % libxc, '-lxcf90', '-lxc']
 
             self.dflags += ["-D__LIBXC"]
 

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -207,7 +207,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
                     self.dflags += ["-D__ELPA_2015"]
             elif LooseVersion(self.version) >= LooseVersion("6.6"):
                 if LooseVersion(elpa_v) >= LooseVersion("2020"):
-                    raise EasyBuildError("ELPA support for QuantumESPRESSO 6.6 only available up to v2019.xx")
+                    raise EasyBuildError("ELPA support for QuantumESPRESSO 6.6/6.7 only available up to v2019.xx")
                 elif LooseVersion(elpa_v) >= LooseVersion("2018"):
                     self.dflags += ["-D__ELPA"]
                 elif LooseVersion(elpa_v) >= LooseVersion("2015"):


### PR DESCRIPTION
This PR, opened in relation to issue #3234, changes the behavior of the QuantumESPRESSO easyblock in order to make sure the correct compilation flags are used for the majority of versions from 5.x to 7.x.

Also the inclusion of flags has been modularized in order to be easier to mange

The new easyblock has been tested by compiling several QE versions, starting from the latest available `intel` and `foss` recipes and using the `--try-software-version` flag to install different software.
When a valid version of the `HDF5`  `LibXC`  or `ELPA` libraries was not readily available it has been manually disabled from the original config file.
In details: 

  - ELPA and LibXC have not been used for QE<7.x (They are available but would need to recompile a different version in order to test)
  - HDF5 have not been used for QE < 5.2.1 (Support was experimental from 5.0 but in my case i was obtaining segfaults when HDF5 functions were being invoked).

NOTE: Due to a problem with compiling and running  QE with the `intel` toolchain + `openmp`, `openmp` was disabled when using the `intel2022b`

Below the results of a small reframe test ([see PR](https://github.com/reframe-hpc/reframe/pull/3134)) used to check that all codes are able to reach the end without any errors or segfaults.
(The version was scaled down only to check that all codes reach the `JOB DONE` line, considering how small this calculation was, the timings themself are not very significative)
![batch_tests](https://github.com/easybuilders/easybuild-easyblocks/assets/34096612/57fcec15-3391-4528-aa80-8a2cff388c33)
