### PR TITLE
replace `log.warn` with `log.warning`

### DIFF
--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -331,15 +331,15 @@ class EB_Clang(CMakeMake):
             if not res.output.startswith("unlimited"):
                 disable_san_tests = True
                 self.log.warning("There is a virtual memory limit set of %s KB. The tests of the "
-                              "sanitizers will be disabled as they need unlimited virtual "
-                              "memory unless --strict=error is used." % res.output.strip())
+                                 "sanitizers will be disabled as they need unlimited virtual "
+                                 "memory unless --strict=error is used." % res.output.strip())
 
             # the same goes for unlimited stacksize
             res = run_shell_cmd("ulimit -s", fail_on_error=False)
             if res.output.startswith("unlimited"):
                 disable_san_tests = True
                 self.log.warning("The stacksize limit is set to unlimited. This causes the ThreadSanitizer "
-                              "to fail. The sanitizers tests will be disabled unless --strict=error is used.")
+                                 "to fail. The sanitizers tests will be disabled unless --strict=error is used.")
 
             if (disable_san_tests or self.cfg['skip_sanitizer_tests']) and build_option('strict') != run.ERROR:
                 self.log.debug("Disabling the sanitizer tests")

--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -330,7 +330,7 @@ class EB_Clang(CMakeMake):
             res = run_shell_cmd("ulimit -v", fail_on_error=False)
             if not res.output.startswith("unlimited"):
                 disable_san_tests = True
-                self.log.warn("There is a virtual memory limit set of %s KB. The tests of the "
+                self.log.warning("There is a virtual memory limit set of %s KB. The tests of the "
                               "sanitizers will be disabled as they need unlimited virtual "
                               "memory unless --strict=error is used." % res.output.strip())
 
@@ -338,7 +338,7 @@ class EB_Clang(CMakeMake):
             res = run_shell_cmd("ulimit -s", fail_on_error=False)
             if res.output.startswith("unlimited"):
                 disable_san_tests = True
-                self.log.warn("The stacksize limit is set to unlimited. This causes the ThreadSanitizer "
+                self.log.warning("The stacksize limit is set to unlimited. This causes the ThreadSanitizer "
                               "to fail. The sanitizers tests will be disabled unless --strict=error is used.")
 
             if (disable_san_tests or self.cfg['skip_sanitizer_tests']) and build_option('strict') != run.ERROR:

--- a/easybuild/easyblocks/c/clang_aomp.py
+++ b/easybuild/easyblocks/c/clang_aomp.py
@@ -153,7 +153,7 @@ class EB_Clang_minus_AOMP(Bundle):
                 self.cfg_method[name](comp)
                 self.log.info(msg)
             else:
-                self.log.warn("Component %s has no configure method!" % name)
+                self.log.warning("Component %s has no configure method!" % name)
 
     def sanity_check_step(self):
         """

--- a/easybuild/easyblocks/generic/gopackage.py
+++ b/easybuild/easyblocks/generic/gopackage.py
@@ -116,7 +116,7 @@ class GoPackage(EasyBlock):
             run_shell_cmd('go test ./...')
 
             self.log.warning('Include generated go.mod and go.sum via patch to ensure locked dependencies '
-                          'and run this easyconfig again.')
+                             'and run this easyconfig again.')
             run_shell_cmd('cat go.mod')
             run_shell_cmd('cat go.sum')
 

--- a/easybuild/easyblocks/generic/gopackage.py
+++ b/easybuild/easyblocks/generic/gopackage.py
@@ -81,7 +81,7 @@ class GoPackage(EasyBlock):
         go_sum_file = 'go.sum'
 
         if not os.path.exists(go_mod_file) or not os.path.isfile(go_mod_file):
-            self.log.warn("go.mod not found! This is not natively supported go module. Trying to init module.")
+            self.log.warning("go.mod not found! This is not natively supported go module. Trying to init module.")
 
             if self.cfg['modulename'] is None:
                 raise EasyBuildError("Installing non-native go module. You need to specify 'modulename' in easyconfig")
@@ -115,7 +115,7 @@ class GoPackage(EasyBlock):
             run_shell_cmd('go build ./...')
             run_shell_cmd('go test ./...')
 
-            self.log.warn('Include generated go.mod and go.sum via patch to ensure locked dependencies '
+            self.log.warning('Include generated go.mod and go.sum via patch to ensure locked dependencies '
                           'and run this easyconfig again.')
             run_shell_cmd('cat go.mod')
             run_shell_cmd('cat go.sum')

--- a/easybuild/easyblocks/p/pyquante.py
+++ b/easybuild/easyblocks/p/pyquante.py
@@ -43,6 +43,6 @@ class EB_PyQuante(PythonPackage):
             self.log.info("Building Libint extension")
             self.cfg.update('installopts', "--enable-libint")
         else:
-            self.log.warn("Not building Libint extension")
+            self.log.warning("Not building Libint extension")
 
         super(EB_PyQuante, self).configure_step()

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -702,7 +702,7 @@ class EB_TensorFlow(PythonPackage):
         configure_py_contents = read_file('configure.py')
         for key, val in sorted(config_env_vars.items()):
             if key.startswith('TF_') and key not in configure_py_contents:
-                self.log.warn('Did not find %s option in configure.py. Setting might not have any effect', key)
+                self.log.warning('Did not find %s option in configure.py. Setting might not have any effect', key)
             env.setvar(key, val)
 
         # configure.py (called by configure script) already calls bazel to determine the bazel version

--- a/easybuild/easyblocks/v/vmd.py
+++ b/easybuild/easyblocks/v/vmd.py
@@ -150,9 +150,9 @@ class EB_VMD(ConfigureMake):
             if deps['OptiX']:
                 self.log.info("Building with Nvidia OptiX %s support", get_software_version('OptiX'))
             else:
-                self.log.warn("Not building with Nvidia OptiX support!")
+                self.log.warning("Not building with Nvidia OptiX support!")
         else:
-            self.log.warn("Not building with CUDA nor OptiX support!")
+            self.log.warning("Not building with CUDA nor OptiX support!")
 
         # see http://www.ks.uiuc.edu/Research/vmd/doxygen/configure.html
         # LINUXAMD64: Linux 64-bit


### PR DESCRIPTION
`log.warn` has been deprecated since Python 3.3 and will be removed in Python 3.13.