### PR TITLE
set `$LIBRARY_PATH` and disable building of NVPTX offload support on RISC-V systems

### DIFF
--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -140,6 +140,11 @@ class EB_GCC(ConfigureMake):
         if get_os_name() not in ['ubuntu', 'debian']:
             self.cfg.update('unwanted_env_vars', ['LIBRARY_PATH'])
 
+        # disable NVPTX on RISC-V
+        if get_cpu_family() == RISCV:
+            self.log.warning('Setting withnvptx to False, since we are building on a RISC-V system')
+            self.cfg['withnvptx'] = False
+
     def create_dir(self, dirname):
         """
         Create a dir to build in.

--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -619,6 +619,10 @@ class EB_GCC(ConfigureMake):
                 'val': os.getenv('LD_LIBRARY_PATH')
             }
             env.setvar('LD_LIBRARY_PATH', ld_lib_path)
+            if get_cpu_family() == RISCV:
+                # on RISC-V the compilers built in stage 1 fail to find some libraries from the lib dir,
+                # so let's also set $LIBRARY_PATH to work around it
+                env.setvar('LIBRARY_PATH', ld_lib_path)
 
             #
             # STAGE 2: build GMP/PPL/CLooG for stage 3
@@ -1057,7 +1061,7 @@ class EB_GCC(ConfigureMake):
         guesses.update({
             'PATH': ['bin'],
             'CPATH': [],
-            'LIBRARY_PATH': [],
+            'LIBRARY_PATH': ['lib', 'lib64'] if get_cpu_family() == RISCV else [],
             'LD_LIBRARY_PATH': ['lib', 'lib64'],
             'MANPATH': ['man', 'share/man']
         })


### PR DESCRIPTION
Not entirely sure why this is needed, but on my RISC-V system the build will fail (in stage 2 and at the end in the sanity check) with errors like:
```
nvme/easybuild/software/binutils/2.40/bin/ld: cannot find -lgcc_s: No such file or directory
```
Even though `libgcc_s.so` is just in the `lib` directory of the stage 1 / final installation directory. For some reason, it doesn't seem to be in GCC's internal search path. By setting `$LIBRARY_PATH`, it does pick it up.