### PR TITLE
Removed FoX constraint on GIPAW for QuantumESPRESSO easyblock

### DIFF
--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -317,7 +317,6 @@ class EB_QuantumESPRESSO(ConfigureMake):
     def _add_fox(self):
         """Add FoX support to the build."""
         if self.cfg['with_fox']:
-            # Needed for using gipaw with QuantumESPRESSO 7.2 and later
             if LooseVersion(self.version) >= LooseVersion("7.2"):
                 self.cfg.update('configopts', '--with-fox=yes')
 
@@ -338,9 +337,6 @@ class EB_QuantumESPRESSO(ConfigureMake):
     def _add_gipaw(self):
         """Add GIPAW support to the build."""
         if self.cfg['with_gipaw']:
-            if LooseVersion(self.version) >= LooseVersion("7.2"):
-                if not self.cfg['with_fox']:
-                    raise EasyBuildError("GIPAW requires FoX enabled in QuantumESPRESSO 7.2 and later")
             self.cfg.update('buildopts', 'gipaw', allow_duplicate=False)
         else:
             if 'gipaw' in self.cfg['buildopts']:


### PR DESCRIPTION
Removing the requirement of compiling FoX in order to use GIPAW with QuantumESPRESSO >=7.2.

FoX has been made optional in QE from v7.2 (before 7.2 FoX is always compiled) and, as indicated in [this commit](https://github.com/dceresoli/qe-gipaw/commit/00b2bd4877b89d417e7bf30c49bb3366ac6fc247), FoX has been removed as a dependency of GIPAW.

Tested by running [one of the GIPAW examples](https://github.com/dceresoli/qe-gipaw/tree/master/examples/quartz) with v7.2 intel/foss and 7.3 intel/foss from [easyconfig PR #20070](https://github.com/easybuilders/easybuild-easyconfigs/pull/20070)