### PR TITLE
Add support for conda provided by miniforge

### DIFF
--- a/easybuild/easyblocks/generic/conda.py
+++ b/easybuild/easyblocks/generic/conda.py
@@ -62,7 +62,8 @@ class Conda(Binary):
         """Install software using 'conda env create' or 'conda create' & 'conda install'
         (or the 'mamba', etc., equivalent)."""
         if (get_software_root('anaconda2') or get_software_root('miniconda2') or
-                get_software_root('anaconda3') or get_software_root('miniconda3')):
+                get_software_root('anaconda3') or get_software_root('miniconda3') or
+                get_software_root('miniforge3')):
             conda_cmd = 'conda'
         elif get_software_root('mamba'):
             conda_cmd = 'mamba'


### PR DESCRIPTION
Closes #3259

Add support for Miniforge3 (instead of Miniconda3).

I have added to the 'conda' command section, although recent miniforge3 releases also package (and use internally) 'mamba'.
