### PR TITLE
update custom easyblock for Tensorflow for versions 2.14 + 2.15

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -187,7 +187,7 @@ def get_system_libs_for_version(tf_version, as_valid_libs=False):
         ('gast', '2.0.0:'): 'gast_archive',
         ('google.protobuf', '2.0.0:'): 'com_google_protobuf',
         ('keras_applications', '2.0.0:2.2.0'): 'keras_applications_archive',
-        ('opt_einsum', '2.0.0:'): 'opt_einsum_archive',
+        ('opt_einsum', '2.0.0:2.15.0'): 'opt_einsum_archive',
         ('pasta', '2.0.0:'): 'pasta',
         ('six', '2.0.0:'): 'six_archive',  # Part of Python EC
         ('tblib', '2.4.0:'): 'tblib_archive',
@@ -595,6 +595,13 @@ class EB_TensorFlow(PythonPackage):
         # SYCL support removed in 2.4
         if LooseVersion(self.version) < LooseVersion('2.4'):
             config_env_vars['TF_NEED_OPENCL_SYCL'] = '0'
+        # Clang toggle since 2.14.0
+        if LooseVersion(self.version) > LooseVersion('2.13'):
+            config_env_vars['TF_NEED_CLANG'] = '0'
+        # Hermietic python version since 2.14.0
+        if LooseVersion(self.version) > LooseVersion('2.13'):
+            pyver = det_python_version(self.python_cmd)
+            config_env_vars['TF_PYTHON_VERSION'] = '.'.join(pyver.split('.')[:2])
 
         if self._with_cuda:
             cuda_version = get_software_version('CUDA')


### PR DESCRIPTION
In connection to [easyconfigs#20191](https://github.com/easybuilders/easybuild-easyconfigs/pull/20191), this PR reflects changes in tensorflow 2.14 & 2.15:

- removed opt_einsum from valid systemlibs: [tf@fce6afd3b](https://github.com/tensorflow/tensorflow/commit/fce6afd3b#diff-e0ff523fcf)
- new config env for disabling clang: [tf@777dfc8b91](https://github.com/tensorflow/tensorflow/commit/777dfc8b91)
- python version for hermetic python: [tf@e85860e83](https://github.com/tensorflow/tensorflow/commit/e85860e83)