### PR TITLE
Binary easyblock already adds top level directory to PATH, so no need to do it in the Stata easyblock

### DIFF
--- a/easybuild/easyblocks/s/stata.py
+++ b/easybuild/easyblocks/s/stata.py
@@ -75,9 +75,3 @@ class EB_Stata(PackedBinary):
         regex = re.compile('libpng.*not found', re.M)
         if regex.search(out):
             raise EasyBuildError("Required libpng library for 'stata' is not available")
-
-    def make_module_req_guess(self):
-        """Add top install directory to $PATH for Stata"""
-        guesses = super(EB_Stata, self).make_module_req_guess()
-        guesses['PATH'] = ['']
-        return guesses


### PR DESCRIPTION
The top level directory is already added in the Binary easyblock: https://github.com/easybuilders/easybuild-easyblocks/blob/develop/easybuild/easyblocks/generic/binary.py#L159

```
WARNING: Suppressed adding the following path(s) to $PATH of the module as they were already added:
['']
```