### PR TITLE
consider both easybuild-easyblocks*.tar.gz and easybuild_easyblocks*tar.gz in CI workflows

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -126,7 +126,7 @@ jobs:
           python setup.py sdist
           ls dist
           export PREFIX=/tmp/$USER/$GITHUB_SHA
-          pip install --prefix $PREFIX dist/easybuild-easyblocks*tar.gz
+          pip install --prefix $PREFIX dist/easybuild[-_]easyblocks*tar.gz
 
     - name: run test suite
       env:


### PR DESCRIPTION
Same as https://github.com/easybuilders/easybuild-framework/pull/4507