### PR TITLE
use regular `configure` instead of wrapper script in easyblock for UCX plugins

### DIFF
--- a/easybuild/easyblocks/u/ucx_plugins.py
+++ b/easybuild/easyblocks/u/ucx_plugins.py
@@ -82,6 +82,8 @@ class EB_UCX_Plugins(ConfigureMake):
         configopts = '--enable-optimizations --without-java --disable-doxygen-doc '
         # omit the lib subdirectory since we are just installing plugins
         configopts += '--libdir=%(installdir)s '
+        # include the configure options from contrib/configure-release
+        configopts += '--disable-logging --disable-debug --disable-assertions --disable-params-check '
 
         cudaroot = get_software_root('CUDAcore') or get_software_root('CUDA')
         if cudaroot:

--- a/easybuild/easyblocks/u/ucx_plugins.py
+++ b/easybuild/easyblocks/u/ucx_plugins.py
@@ -77,7 +77,6 @@ class EB_UCX_Plugins(ConfigureMake):
         if not get_software_root('UCX'):
             raise EasyBuildError("UCX is a required dependency")
 
-        self.cfg['configure_cmd'] = 'contrib/configure-release'
         self.cfg.update('preconfigopts', 'autoreconf -i &&')
 
         configopts = '--enable-optimizations --without-java --disable-doxygen-doc '


### PR DESCRIPTION
Instead of calling `contrib/configure-release`, which is a wrapper that calls `./configure` with some predefined options, the easyblock will now directly call `configure` with those options. This is the same approach as used in the PRs for the UCX easyconfigs: https://github.com/easybuilders/easybuild-easyconfigs/pull/20428.