### PR TITLE
use ERROR global from tools.config in clang easyblock

### DIFF
--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -43,7 +43,7 @@ from easybuild.tools import LooseVersion
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.toolchains.compiler.clang import Clang
-from easybuild.tools import run
+from easybuild.tools.config import ERROR
 from easybuild.tools.build_log import EasyBuildError, print_warning
 from easybuild.tools.config import build_option
 from easybuild.tools.filetools import apply_regex_substitutions, change_dir, mkdir, symlink, which
@@ -341,7 +341,7 @@ class EB_Clang(CMakeMake):
                 self.log.warning("The stacksize limit is set to unlimited. This causes the ThreadSanitizer "
                                  "to fail. The sanitizers tests will be disabled unless --strict=error is used.")
 
-            if (disable_san_tests or self.cfg['skip_sanitizer_tests']) and build_option('strict') != run.ERROR:
+            if (disable_san_tests or self.cfg['skip_sanitizer_tests']) and build_option('strict') != ERROR:
                 self.log.debug("Disabling the sanitizer tests")
                 self.disable_sanitizer_tests()
 


### PR DESCRIPTION
`tools.run` no longer imports `ERROR` from `tools.config` in 5.0.x, so it has to be directly imported from its origin.

Fixes following error on Clang builds:
```
EasyBuild crashed! Please consider reporting a bug, this should not happen...

Traceback (most recent call last):
  File "/usr/lib64/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib64/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/theia/scratch/brussel/101/vsc10122/easybuild/easybuild-framework/easybuild/main.py", line 788, in <module>
    main_with_hooks()
  File "/theia/scratch/brussel/101/vsc10122/easybuild/easybuild-framework/easybuild/main.py", line 774, in main_with_hooks
    main(args=args, prepared_cfg_data=(init_session_state, eb_go, cfg_settings))
  File "/theia/scratch/brussel/101/vsc10122/easybuild/easybuild-framework/easybuild/main.py", line 730, in main
    hooks, do_build)
  File "/theia/scratch/brussel/101/vsc10122/easybuild/easybuild-framework/easybuild/main.py", line 565, in process_eb_args
    exit_on_failure=exit_on_failure)
  File "/theia/scratch/brussel/101/vsc10122/easybuild/easybuild-framework/easybuild/main.py", line 173, in build_and_install_software
    raise ec_res['err']
  File "/theia/scratch/brussel/101/vsc10122/easybuild/easybuild-framework/easybuild/main.py", line 134, in build_and_install_software
    (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env)
  File "/theia/scratch/brussel/101/vsc10122/easybuild/easybuild-framework/easybuild/framework/easyblock.py", line 4301, in build_and_install_one
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/theia/scratch/brussel/101/vsc10122/easybuild/easybuild-framework/easybuild/framework/easyblock.py", line 4176, in run_all_steps
    self.run_step(step_name, step_methods)
  File "/theia/scratch/brussel/101/vsc10122/easybuild/easybuild-framework/easybuild/framework/easyblock.py", line 4011, in run_step
    step_method(self)()
  File "/theia/scratch/brussel/101/vsc10122/easybuild/easybuild-easyblocks/easybuild/easyblocks/c/clang.py", line 344, in configure_step
    if (disable_san_tests or self.cfg['skip_sanitizer_tests']) and build_option('strict') != run.ERROR:
AttributeError: module 'easybuild.tools.run' has no attribute 'ERROR'
```