### PR TITLE
do not run unit tests on Python 3.5

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10', '3.11']
+        python: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11']
         modules_tool: [Lmod-6.6.3, Lmod-7.8.22, Lmod-8.1.14, modules-tcl-1.147, modules-3.2.10, modules-4.1.4]
         module_syntax: [Lua, Tcl]
         # exclude some configuration for non-Lmod modules tool:
         # - don't test with Lua module syntax (only supported in Lmod)
-        # - don't test with Python 3.5 and 3.7+ (only with 3.6), to limit test configurations
+        # - don't test with Python 3.7+ (only with 3.6), to limit test configurations
         exclude:
           - modules_tool: modules-tcl-1.147
             module_syntax: Lua
@@ -27,8 +27,6 @@ jobs:
           - modules_tool: modules-4.1.4
             module_syntax: Lua
           - modules_tool: modules-tcl-1.147
-            python: 3.5
-          - modules_tool: modules-tcl-1.147
             python: 3.7
           - modules_tool: modules-tcl-1.147
             python: 3.8
@@ -37,9 +35,6 @@ jobs:
           - modules_tool: modules-tcl-1.147
             python: '3.10'
           - modules_tool: modules-tcl-1.147
-            python: '3.11'
-          - modules_tool: modules-3.2.10
-            python: 3.5
           - modules_tool: modules-3.2.10
             python: 3.7
           - modules_tool: modules-3.2.10
@@ -50,8 +45,6 @@ jobs:
             python: '3.10'
           - modules_tool: modules-3.2.10
             python: '3.11'
-          - modules_tool: modules-4.1.4
-            python: 3.5
           - modules_tool: modules-4.1.4
             python: 3.7
           - modules_tool: modules-4.1.4

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -35,6 +35,7 @@ jobs:
           - modules_tool: modules-tcl-1.147
             python: '3.10'
           - modules_tool: modules-tcl-1.147
+            python: '3.11'
           - modules_tool: modules-3.2.10
             python: 3.7
           - modules_tool: modules-3.2.10


### PR DESCRIPTION
From https://github.com/easybuilders/easybuild-easyblocks/actions/runs/9030743894/job/24821557865?pr=3311

```
Could not fetch URL https://pypi.python.org/simple/pip/: There was a problem confirming the ssl certificate: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:728) - skipping
Error: Could not find a version that satisfies the requirement pip (from versions: )
Error: No matching distribution found for pip
Error: The process '/usr/bin/bash' failed with exit code 1
```