### PR TITLE
Always override the compiler version check for CUDA installations

### DIFF
--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -156,6 +156,15 @@ class EB_CUDA(Binary):
         # Use C locale to avoid localized questions and crash on CUDA 10.1
         self.cfg.update('preinstallopts', "export LANG=C && ")
 
+        # As a CUDA recipe gets older and the OS gets updated, it is
+        # likely that the system GCC becomes too new for the CUDA version.
+        # Since in EasyBuild we know/expect that CUDA will only ever get used
+        # as a dependency within the context of a toolchain, we can override
+        # the compiler version check that would cause the installation to
+        # fail.
+        self.cfg.update('installopts', "--override")
+
+
         cmd = "%(preinstallopts)s %(interpreter)s %(script)s %(installopts)s" % {
             'preinstallopts': self.cfg['preinstallopts'],
             'interpreter': install_interpreter,

--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -164,7 +164,6 @@ class EB_CUDA(Binary):
         # fail.
         self.cfg.update('installopts', "--override")
 
-
         cmd = "%(preinstallopts)s %(interpreter)s %(script)s %(installopts)s" % {
             'preinstallopts': self.cfg['preinstallopts'],
             'interpreter': install_interpreter,


### PR DESCRIPTION
As the underlying OS gets newer our CUDA recipes eventually fail when the system compiler becomes too new for CUDA. We know the context for these installations (used within higher level toolchains) so it should be ok to always override this check.