### PR TITLE
Fix for plumed genereting patch file inside module location

### DIFF
--- a/easybuild/easyblocks/m/metalwalls.py
+++ b/easybuild/easyblocks/m/metalwalls.py
@@ -31,8 +31,9 @@ import os
 
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain
+from easybuild.tools import LooseVersion
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.modules import get_software_root
+from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
 
 from easybuild.easyblocks.generic.makecp import MakeCp
@@ -77,6 +78,11 @@ class EB_MetalWalls(MakeCp):
         # https://gitlab.com/ampere2/metalwalls/-/wikis/install#plumed
         plumed = get_software_root('PLUMED')
         f90wrap = get_software_root('f90wrap')
+        f90wrap_version = get_software_version('f90wrap')
+
+        if LooseVersion(self.version) <= LooseVersion('21.06.1'):
+            if LooseVersion(f90wrap_version) > LooseVersion('0.2.13'):
+                raise EasyBuildError('MetalWalls version %s requires f90wrap <= 0.2.13' % self.version)
 
         tpl_rgx = 'alltests\\.append(suite_%s)'
         if plumed:

--- a/easybuild/easyblocks/m/metalwalls.py
+++ b/easybuild/easyblocks/m/metalwalls.py
@@ -82,9 +82,9 @@ class EB_MetalWalls(MakeCp):
         if plumed:
             f90flags += ['-fallow-argument-mismatch']  # Code inside ifdef causes mismatch errors
             fppflags += ['-DMW_USE_PLUMED']
-            cmd = ['plumed', 'patch', '--new', 'mw2']
+            cmd = ['touch', 'mw2.diff']
             run_cmd(' '.join(cmd), log_all=False, log_ok=False, simple=False, regexp=False)
-            cmd = ['plumed', 'patch', '--patch', '--shared', '--engine', 'mw2']
+            cmd = ['plumed', 'patch', '-d mw2.diff', '--patch', '--shared', '--engine', 'mw2']
             run_cmd(' '.join(cmd), log_all=True, simple=False)
         else:
             self.log.info('PLUMED not found, excluding from test-suite')


### PR DESCRIPTION
The command

`plumed patch --new mw2` was actually generating an empty `mw2.diff` file under the `$EBROOTPLUMED/lib/plumed/patches` directory which will cause trouble in system where this location is read-only (e.g. EESSI)

Switched to manually generating a `mw2.diff` empty file inside the build folder and point to that using the `-d` option for plumed

Also added a compatibility check as for `f90wrap <= 0.2.13` for `MetalWalls <= 21.06.1`