### PR TITLE
Patch `ctypes` for Python installations when filtering `LD_LIBRARY_PATH`

### DIFF
--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -456,6 +456,8 @@ class EB_Python(ConfigureMake):
         if LooseVersion(self.version) >= LooseVersion('3.10') and self.cfg['runtest'] is None:
             self.cfg['runtest'] = 'test'
             # Need to skip some troublesome tests
+            # (socket tests give a permission denied error, may be due to SELinux)
+            # (curses error is from test_background, just ignoring)
             self.cfg['testopts'] = 'TESTOPTS="-x test_socket test_curses "'
         super(EB_Python, self).test_step()
 

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -207,8 +207,7 @@ class EB_Python(ConfigureMake):
             if orig_gcc_so_name:
                 orig_gcc_so_name_regex = r'(\s*)' + re.escape(orig_gcc_so_name) + r'(\s*)'
                 updated_gcc_so_name = (
-                    "os.path.join(os.path.dirname(_findLib_gcc(name)), _get_soname(_findLib_gcc(name)))"
-                    + " or _get_soname(_findLib_ld(name))"
+                    "_findLib_gcc(name) or _findLib_ld(name)"
                 )
                 apply_regex_substitutions(
                     ctypes_util_py,

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -450,6 +450,15 @@ class EB_Python(ConfigureMake):
 
         super(EB_Python, self).build_step(*args, **kwargs)
 
+    def test_step(self):
+        """Test Python build via 'make test'."""
+        # Turn on testing by default for recent Python versions
+        if LooseVersion(self.version) >= LooseVersion('3.10') and self.cfg['runtest'] is None:
+            self.cfg['runtest'] = 'test'
+            # Need to skip some troublesome tests
+            self.cfg['testopts'] = 'TESTOPTS="-x test_socket "'
+        super(EB_Python, self).test_step()
+
     def install_step(self):
         """Extend make install to make sure that the 'python' command is present."""
 

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -206,6 +206,10 @@ class EB_Python(ConfigureMake):
                 orig_gcc_so_name = "_get_soname(_findLib_gcc(name)) or _get_soname(_findLib_ld(name))"
             if orig_gcc_so_name:
                 orig_gcc_so_name_regex = r'(\s*)' + re.escape(orig_gcc_so_name) + r'(\s*)'
+                # _get_soname() takes the full path as an argument and uses objdump to get the SONAME field from
+                # the shared object file. The presence or absence of the SONAME field in the ELF header of a shared
+                # library is influenced by how the library is compiled and linked. For manually built libraries we
+                # may be lacking this field, this approach also solves that problem.
                 updated_gcc_so_name = (
                     "_findLib_gcc(name) or _findLib_ld(name)"
                 )

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -461,18 +461,6 @@ class EB_Python(ConfigureMake):
 
         super(EB_Python, self).build_step(*args, **kwargs)
 
-    def test_step(self):
-        """Test Python build via 'make test'."""
-        # Turn on testing by default for recent Python versions
-        relevant_python = (self.name.lower() == 'python' and LooseVersion(self.version) >= LooseVersion('3.10'))
-        if relevant_python and self.cfg['runtest'] is None:
-            self.cfg['runtest'] = 'test'
-            # Need to skip some troublesome tests
-            # (socket tests give a permission denied error, may be due to SELinux)
-            # (curses error is from test_background, just ignoring)
-            self.cfg['testopts'] = 'TESTOPTS="-x test_socket test_curses "'
-        super(EB_Python, self).test_step()
-
     def install_step(self):
         """Extend make install to make sure that the 'python' command is present."""
 

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -453,7 +453,8 @@ class EB_Python(ConfigureMake):
     def test_step(self):
         """Test Python build via 'make test'."""
         # Turn on testing by default for recent Python versions
-        if LooseVersion(self.version) >= LooseVersion('3.10') and self.cfg['runtest'] is None:
+        relevant_python = (self.name.lower() == 'python' and LooseVersion(self.version) >= LooseVersion('3.10'))
+        if relevant_python and self.cfg['runtest'] is None:
             self.cfg['runtest'] = 'test'
             # Need to skip some troublesome tests
             # (socket tests give a permission denied error, may be due to SELinux)

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -456,7 +456,7 @@ class EB_Python(ConfigureMake):
         if LooseVersion(self.version) >= LooseVersion('3.10') and self.cfg['runtest'] is None:
             self.cfg['runtest'] = 'test'
             # Need to skip some troublesome tests
-            self.cfg['testopts'] = 'TESTOPTS="-x test_socket "'
+            self.cfg['testopts'] = 'TESTOPTS="-x test_socket test_curses "'
         super(EB_Python, self).test_step()
 
     def install_step(self):


### PR DESCRIPTION
`ctypes` relies on `LD_LIBRARY_PATH` and doesn't respect rpath linking, this is a workaround for the EasyBuild context for this setup.