### PR TITLE
Update wrf.py for 4.5.2

### DIFF
--- a/easybuild/easyblocks/w/wrf.py
+++ b/easybuild/easyblocks/w/wrf.py
@@ -56,7 +56,8 @@ def det_wrf_subdir(wrf_version):
 
     if LooseVersion(wrf_version) < LooseVersion('4.0'):
         wrf_subdir = 'WRFV%s' % wrf_version.split('.')[0]
-    elif LooseVersion(wrf_version) == LooseVersion('4.5.1'): # WRF 4.5.2 actually use "WRF-4.5.2" subdirectory naming scheme
+    elif LooseVersion(wrf_version) == LooseVersion('4.5.1'):
+        # WRF 4.5.2 actually use "WRF-4.5.2" subdirectory naming scheme
         wrf_subdir = 'WRFV%s' % wrf_version
     else:
         wrf_subdir = 'WRF-%s' % wrf_version

--- a/easybuild/easyblocks/w/wrf.py
+++ b/easybuild/easyblocks/w/wrf.py
@@ -56,7 +56,7 @@ def det_wrf_subdir(wrf_version):
 
     if LooseVersion(wrf_version) < LooseVersion('4.0'):
         wrf_subdir = 'WRFV%s' % wrf_version.split('.')[0]
-    elif LooseVersion(wrf_version) >= LooseVersion('4.5.1'):
+    elif LooseVersion(wrf_version) == LooseVersion('4.5.1'): # WRF 4.5.2 actually use "WRF-4.5.2" subdirectory naming scheme
         wrf_subdir = 'WRFV%s' % wrf_version
     else:
         wrf_subdir = 'WRF-%s' % wrf_version


### PR DESCRIPTION
WRF 4.5.2 actually use "WRF-4.5.2" subdirectory naming scheme. I'm about to make another pull request to add my WRF-4.5.2-intel-2023a.eb easyconfig file, along with an associated patch file, to easyconfigs repo, and I need this change to go through before that.