### PR TITLE
also consider 'normalised' package name with underscore rather than dash in EasyBuild easyblock

### DIFF
--- a/easybuild/easyblocks/e/easybuildmeta.py
+++ b/easybuild/easyblocks/e/easybuildmeta.py
@@ -133,7 +133,10 @@ class EB_EasyBuildMeta(PythonPackage):
         try:
             subdirs = os.listdir(self.builddir)
             for pkg in self.easybuild_pkgs:
-                seldirs = [x for x in subdirs if x.startswith(pkg)]
+                # also consider "normalized" package name, with dashes ('-') replaced by underscores ('_'),
+                # which is being enforced by recent versions of setuptools (>= 69.0.3?)
+                pkg_norm = pkg.replace('-', '_')
+                seldirs = [x for x in subdirs if x.startswith(pkg) or x.startswith(pkg_norm)]
                 if len(seldirs) != 1:
                     # setuptools is optional since it may be available in the OS;
                     # vsc-install and vsc-base sources are optional,


### PR DESCRIPTION
Recent versions of setuptools (>=69.0.3?) enforce normalized package names by replacing dashes (`-`) with underscores (`_`) in the package name.

This affects the source tarballs of EasyBuild v4.9.2 (and likely also more recent versions going forward), so the custom easyblock for installing EasyBuild must consider package names with both dash (like `easybuild-framework`) and underscore (like `easybuild_framework`).

Without this, installing EasyBuild v4.9.2 with an existing EasyBuild release like v4.9.1 fails with an error like:
```
Failed to find required EasyBuild package easybuild-framework (subdirs: ['easybuild_easyconfigs-4.9.2', 'easybuild_framework-4.9.2', 'easybuild_easyblocks-4.9.2'], seldirs: [])")
```

That's because it's expecting to find a subdirectory like `easybuild-framework-4.9.2` after unpacking the source tarball for `easybuild-framework` v4.9.2, but only `easybuild_framework-4.9.2` is found (alongside the subdirectory for the unpacked `easybuild-easyblocks` and `easybuild-easyconfigs` packages).


This is annoying, since anyone who will be using `eb --install-latest-eb-release` or `eb EasyBuild-4.9.2.eb` (or equivalent, via `--from-pr`) will be hitting this, unless they use `eb --include-easyblocks-from-pr 3358`.