### PR TITLE
fix import of `parse` in `openssl_wrapper.py` for Python 2.7

### DIFF
--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -34,7 +34,7 @@ import re
 try:
     from urllib.parse import urlparse
 except ImportError:
-     from urlparse import urlparse
+    from urlparse import urlparse
 
 from easybuild.tools import LooseVersion
 

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -30,7 +30,11 @@ EasyBuild support for installing a wrapper module file for OpenSSL
 import os
 import re
 
-from urllib.parse import urlparse
+# support python2
+try:
+    from urllib.parse import urlparse
+except ImportError:
+     from urlparse import urlparse
 
 from easybuild.tools import LooseVersion
 

--- a/easybuild/easyblocks/o/openssl_wrapper.py
+++ b/easybuild/easyblocks/o/openssl_wrapper.py
@@ -30,10 +30,10 @@ EasyBuild support for installing a wrapper module file for OpenSSL
 import os
 import re
 
-# support python2
 try:
     from urllib.parse import urlparse
 except ImportError:
+    # fallback for Python 2.7, should be removed for EasyBuild >= 5.0
     from urlparse import urlparse
 
 from easybuild.tools import LooseVersion


### PR DESCRIPTION
At least for a short time longer.

error
```
ERROR: Failed to process easyconfig /rds/projects/2017/branfosj-rse/easybuild/src/easybuild-easyconfigs/easybuild/easyconfigs/venv-py2/easybuild/easyconfigs/o/OpenSSL/OpenSSL-3.eb: Failed to obtain class for EB_OpenSSL_wrapper easyblock (not available?): No module named parse
```

Using `--include-easyblocks-from-pr 3364` works.

* [x] #3365 (to fix the unrelated CI failure)