### PR TITLE
use `flake8` 7.0.0 for linting easyblocks

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -22,7 +22,8 @@ jobs:
     - name: install Python packages
       run: |
         pip install --upgrade pip
-        pip install --upgrade flake8
+        # fix to this version for develop branch (to avoid needing to fix geant4.py)
+        pip install --upgrade flake8<7.1
 
     - name: Run flake8 to verify PEP8-compliance of Python code
       run: flake8

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         pip install --upgrade pip
         # fix to this version for develop branch (to avoid needing to fix geant4.py)
-        pip install --upgrade flake8<7.1
+        pip install --upgrade "flake8<7.1"
 
     - name: Run flake8 to verify PEP8-compliance of Python code
       run: flake8


### PR DESCRIPTION
Only for `develop` to avoid having to fix `geant4.py` (see https://github.com/easybuilders/easybuild-easyblocks/actions/runs/9552967707/job/26330689071?pr=3364).

Not needed in `5.0.x` as we've removed that section of the easyblock.