### PR TITLE
Use build dir for big files/folders while building TensorFlow

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -943,7 +943,12 @@ class EB_TensorFlow(PythonPackage):
         run_cmd(' '.join(cmd), log_all=True, simple=True, log_ok=True)
 
         # run generated 'build_pip_package' script to build the .whl
-        cmd = "bazel-bin/tensorflow/tools/pip_package/build_pip_package %s" % self.builddir
+        cmd = "bazel-bin/tensorflow/tools/pip_package/build_pip_package"
+        # TF uses the temporary folder, which becomes quite large (~2 GB) so use the build folder explicitely.
+        tmp_dir = os.path.join(self.builddir, 'build-pip')
+        mkdir(tmp_dir)
+        cmd = "TMPDIR='%s' " % tmp_dir
+        cmd += "bazel-bin/tensorflow/tools/pip_package/build_pip_package %s" % self.builddir
         run_cmd(cmd, log_all=True, simple=True, log_ok=True)
 
     def test_step(self):
@@ -1104,7 +1109,7 @@ class EB_TensorFlow(PythonPackage):
     def install_step(self):
         """Custom install procedure for TensorFlow."""
         # find .whl file that was built, and install it using 'pip install'
-        if ("-rc" in self.version):
+        if "-rc" in self.version:
             whl_version = self.version.replace("-rc", "rc")
         else:
             whl_version = self.version

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -35,6 +35,7 @@ import os
 import re
 import stat
 import tempfile
+from contextlib import contextmanager
 from itertools import chain
 
 import easybuild.tools.environment as env
@@ -450,6 +451,18 @@ class EB_TensorFlow(PythonPackage):
         # Folder where wrapper binaries can be placed, where required. TODO: Replace by --action_env cmds
         self.wrapper_dir = os.path.join(parent_dir, 'wrapper_bin')
         mkdir(self.wrapper_dir)
+
+    @contextmanager
+    def set_tmp_dir(self):
+        # TF uses the temporary folder, which becomes quite large (~2 GB) so use the build folder explicitely.
+        old_tmpdir = os.environ['TMPDIR']
+        tmpdir = os.path.join(self.builddir, 'tmpdir')
+        mkdir(tmpdir)
+        os.environ['TMPDIR'] = tmpdir
+        try:
+            yield tmpdir
+        finally:
+            os.environ['TMPDIR'] = old_tmpdir
 
     def configure_step(self):
         """Custom configuration procedure for TensorFlow."""
@@ -940,19 +953,12 @@ class EB_TensorFlow(PythonPackage):
             + ['//tensorflow/tools/pip_package:build_pip_package']
         )
 
-        # TF uses the temporary folder, which becomes quite large (~2 GB) so use the build folder explicitely.
-        old_tmpdir = os.environ['TMPDIR']
-        tmpdir = os.path.join(self.builddir, 'tmpdir')
-        mkdir(tmpdir)
-        os.environ['TMPDIR'] = tmpdir
-        try:
+        with self.set_tmp_dir():
             run_cmd(' '.join(cmd), log_all=True, simple=True, log_ok=True)
 
             # run generated 'build_pip_package' script to build the .whl
             cmd = "bazel-bin/tensorflow/tools/pip_package/build_pip_package %s" % self.builddir
             run_cmd(cmd, log_all=True, simple=True, log_ok=True)
-        finally:
-            os.environ['TMPDIR'] = old_tmpdir
 
     def test_step(self):
         """Run TensorFlow unit tests"""
@@ -1075,7 +1081,8 @@ class EB_TensorFlow(PythonPackage):
                 + test_targets
             )
 
-            stdouterr, ec = run_cmd(cmd, log_ok=False, simple=False)
+            with self.set_tmp_dir():
+                stdouterr, ec = run_cmd(cmd, log_ok=False, simple=False)
             if ec:
                 fail_msg = 'Tests on %s (cmd: %s) failed with exit code %s and output:\n%s' % (
                     device, cmd, ec, stdouterr)

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -940,16 +940,19 @@ class EB_TensorFlow(PythonPackage):
             + ['//tensorflow/tools/pip_package:build_pip_package']
         )
 
-        run_cmd(' '.join(cmd), log_all=True, simple=True, log_ok=True)
-
-        # run generated 'build_pip_package' script to build the .whl
-        cmd = "bazel-bin/tensorflow/tools/pip_package/build_pip_package"
         # TF uses the temporary folder, which becomes quite large (~2 GB) so use the build folder explicitely.
-        tmp_dir = os.path.join(self.builddir, 'build-pip')
-        mkdir(tmp_dir)
-        cmd = "TMPDIR='%s' " % tmp_dir
-        cmd += "bazel-bin/tensorflow/tools/pip_package/build_pip_package %s" % self.builddir
-        run_cmd(cmd, log_all=True, simple=True, log_ok=True)
+        old_tmpdir = os.environ['TMPDIR']
+        tmpdir = os.path.join(self.builddir, 'tmpdir')
+        mkdir(tmpdir)
+        os.environ['TMPDIR'] = tmpdir
+        try:
+            run_cmd(' '.join(cmd), log_all=True, simple=True, log_ok=True)
+
+            # run generated 'build_pip_package' script to build the .whl
+            cmd = "bazel-bin/tensorflow/tools/pip_package/build_pip_package %s" % self.builddir
+            run_cmd(cmd, log_all=True, simple=True, log_ok=True)
+        finally:
+            os.environ['TMPDIR'] = old_tmpdir
 
     def test_step(self):
         """Run TensorFlow unit tests"""


### PR DESCRIPTION
build_pip_package (executed after Bazel finishes) uses a temporary folder which gets large (2 GB for TF 2.9).

It uses `$TMPDIR` (via mktemp) which we set to the temporary folder created by Easybuild in PythonPackage but that might have only enough space for logs etc.
As this folder is part of the build put it inside the build directory.