### PR TITLE
update `PythonPackage` easyblock to allow installation of Python packages with `$PIP_REQUIRE_VIRTUALENV` set + move temporary pip folder into build dir

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -426,6 +426,9 @@ class PythonPackage(ExtensionEasyBlock):
         # cfr. https://pip.pypa.io/en/stable/reference/pip_install/#caching
         env.setvar('XDG_CACHE_HOME', os.path.join(self.builddir, 'xdg-cache-home'))
         self.log.info("Using %s as pip cache directory", os.environ['XDG_CACHE_HOME'])
+        # Users or sites may require using a virtualenv for user installations
+        # We need to disable this to be able to install into the modules
+        env.setvar('PIP_REQUIRE_VIRTUALENV', 'false')
 
     def determine_install_command(self):
         """

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -422,6 +422,11 @@ class PythonPackage(ExtensionEasyBlock):
         self.use_setup_py = False
         self.determine_install_command()
 
+        # avoid that pip (ab)uses $HOME/.cache/pip
+        # cfr. https://pip.pypa.io/en/stable/reference/pip_install/#caching
+        env.setvar('XDG_CACHE_HOME', os.path.join(self.builddir, 'xdg-cache-home'))
+        self.log.info("Using %s as pip cache directory", os.environ['XDG_CACHE_HOME'])
+
     def determine_install_command(self):
         """
         Determine install command to use.
@@ -451,11 +456,6 @@ class PythonPackage(ExtensionEasyBlock):
             pip_no_index = self.cfg.get('pip_no_index', None)
             if pip_no_index or (pip_no_index is None and self.cfg.get('download_dep_fail')):
                 self.cfg.update('installopts', '--no-index')
-
-            # avoid that pip (ab)uses $HOME/.cache/pip
-            # cfr. https://pip.pypa.io/en/stable/reference/pip_install/#caching
-            env.setvar('XDG_CACHE_HOME', os.path.join(self.builddir, 'xdg-cache-home'))
-            self.log.info("Using %s as pip cache directory", os.environ['XDG_CACHE_HOME'])
 
         else:
             self.use_setup_py = True

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -454,7 +454,7 @@ class PythonPackage(ExtensionEasyBlock):
 
             # avoid that pip (ab)uses $HOME/.cache/pip
             # cfr. https://pip.pypa.io/en/stable/reference/pip_install/#caching
-            env.setvar('XDG_CACHE_HOME', tempfile.gettempdir())
+            env.setvar('XDG_CACHE_HOME', os.path.join(self.builddir, 'xdg-cache-home'))
             self.log.info("Using %s as pip cache directory", os.environ['XDG_CACHE_HOME'])
 
         else:


### PR DESCRIPTION
Using the tempdir usually works but the contents of that folder are usually build artifacts.
As they might become rather large use the builddir for $XDG_CACHE_HOME instead.
As an alternative `os.path.abspath(build_path())` could be used but that might clash with parallel installations.

The user using EasyBuild might have $PIP_REQUIRE_VIRTUALENV set which will fail the installation of PythonPackages with
> ERROR: Could not find an activated virtualenv (required).

So disable this.
pip 20.2.3+ seems to require `false` as the value instead of any other value (including the empty string)