### PR TITLE
Explicitly call `csh` in custom easyblock for WPS

### DIFF
--- a/easybuild/easyblocks/w/wps.py
+++ b/easybuild/easyblocks/w/wps.py
@@ -237,7 +237,9 @@ class EB_WPS(EasyBlock):
         """Build in install dir using compile script."""
         cmd = ' '.join([
             self.cfg['prebuildopts'],
-            './' + self.compile_script,
+            # compile script rely on /bin/csh
+            # Better call csh command to allow tcsh build dependency
+            'csh ' + self.compile_script,
             self.cfg['buildopts'],
         ])
         run_cmd(cmd, log_all=True, simple=True)

--- a/easybuild/easyblocks/w/wps.py
+++ b/easybuild/easyblocks/w/wps.py
@@ -239,7 +239,7 @@ class EB_WPS(EasyBlock):
             self.cfg['prebuildopts'],
             # compile script rely on /bin/csh
             # Better call csh command to allow tcsh build dependency
-            'csh ' + self.compile_script,
+            'csh ./' + self.compile_script,
             self.cfg['buildopts'],
         ])
         run_cmd(cmd, log_all=True, simple=True)
@@ -344,7 +344,7 @@ class EB_WPS(EasyBlock):
                     raise EasyBuildError("Could not find Vtable file to use for testing ungrib")
 
                 # run link_grib.csh script
-                cmd = "%s %s*" % (os.path.join(wpsdir, "link_grib.csh"), grib_file_prefix)
+                cmd = "csh %s %s*" % (os.path.join(wpsdir, "link_grib.csh"), grib_file_prefix)
                 run_cmd(cmd, log_all=True, simple=True)
 
                 # run ungrib.exe


### PR DESCRIPTION
For system that doesn't have csh installed, /bin/csh won't call into the csh provided by tcsh module (if loaded as a build dependency). Tested and confirmed working on a Rocky 9 Haswell server.