### PR TITLE
NVHPC: Set DEFCUDAVERSION and DEFSTDPARCOMPUTECAP correctly in localrc

### DIFF
--- a/easybuild/easyblocks/n/nvhpc.py
+++ b/easybuild/easyblocks/n/nvhpc.py
@@ -175,7 +175,10 @@ class EB_NVHPC(PackedBinary):
 
         if LooseVersion(self.version) >= LooseVersion('22.9'):
             bin_subdir = os.path.join(compilers_subdir, "bin")
-            cmd = "%s -x %s" % (makelocalrc_filename, bin_subdir)
+            cmd = "%s -x %s -cuda %s -stdpar %s" % (makelocalrc_filename,
+                                                    bin_subdir,
+                                                    default_cuda_version,
+                                                    default_compute_capability)
         else:
             cmd = "%s -x %s -g77 /" % (makelocalrc_filename, compilers_subdir)
         run_cmd(cmd, log_all=True, simple=True)


### PR DESCRIPTION
Without these changes those variables are not defined correctly. Example of the resulting difference:

```diff
-set DEFCUDAVERSION=12.3;
-set DEFSTDPARCOMPUTECAP=;
+set DEFCUDAVERSION=12;
+set DEFSTDPARCOMPUTECAP=80;
```