### PR TITLE
Remove redundant backslashes in GEANT easyblock

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         pip install --upgrade pip
         # fix to this version for develop branch (to avoid needing to fix geant4.py)
-        pip install --upgrade "flake8<7.1"
+        pip install --upgrade "flake8"
 
     - name: Run flake8 to verify PEP8-compliance of Python code
       run: flake8

--- a/easybuild/easyblocks/g/geant4.py
+++ b/easybuild/easyblocks/g/geant4.py
@@ -96,87 +96,87 @@ class EB_Geant4(CMakeMake):
                 "There exists a config.sh file. Shall I use it to set the defaults? [y]": "n",
                 "Would you like to see the instructions? [n]": "",
                 "[Type carriage return to continue]": "",
-                "Definition of G4SYSTEM variable is Linux-g++. That stands for: 1) OS : Linux" \
-                "2) Compiler : g++ To modify default settings, select number above (e.g. 2) " \
+                "Definition of G4SYSTEM variable is Linux-g++. That stands for: 1) OS : Linux"
+                "2) Compiler : g++ To modify default settings, select number above (e.g. 2) "
                 "[Press [Enter] for default settings]": "2",
                 "Which C++ compiler? [g++]": "$(GPP)",
                 "Confirm your selection or set recommended 'g++'! [*]": "",
-                "Definition of G4SYSTEM variable is Linux-icc. That stands for: 1) OS : Linux 2)" \
-                "Compiler : icc To modify default settings, select number above (e.g. 2) " \
+                "Definition of G4SYSTEM variable is Linux-icc. That stands for: 1) OS : Linux 2)"
+                "Compiler : icc To modify default settings, select number above (e.g. 2) "
                 "[Press [Enter] for default settings]": "",
                 "Do you expect to run these scripts and binaries on multiple machines? [n]": "y",
                 "Where is Geant4 source installed? [%s]" % pwd: "",
-                "Specify the path where Geant4 libraries and source files should be installed." \
+                "Specify the path where Geant4 libraries and source files should be installed."
                 " [%s]" % pwd: dst,
                 "Do you want to copy all Geant4 headers in one directory? [n]": "y",
-                "Please, specify default directory where ALL the Geant4 data is installed:" \
-                "G4LEVELGAMMADATA: %(pwd)s/data/PhotonEvaporation2.0 G4RADIOACTIVEDATA: " \
-                "%(pwd)s/data/RadioactiveDecay3.2 G4LEDATA: %(pwd)s/data/G4EMLOW5.1 G4NEUTRONHPDATA:    " \
-                "%(pwd)s/data/G4NDL3.12 G4ABLADATA: %(pwd)s/data/G4ABLA3.0 You will be asked about " \
+                "Please, specify default directory where ALL the Geant4 data is installed:"
+                "G4LEVELGAMMADATA: %(pwd)s/data/PhotonEvaporation2.0 G4RADIOACTIVEDATA: "
+                "%(pwd)s/data/RadioactiveDecay3.2 G4LEDATA: %(pwd)s/data/G4EMLOW5.1 G4NEUTRONHPDATA:    "
+                "%(pwd)s/data/G4NDL3.12 G4ABLADATA: %(pwd)s/data/G4ABLA3.0 You will be asked about "
                 "customizing these next. [%(pwd)s/data]" % {'pwd': pwd}: "%s/data" % dst,
                 "Directory %s/data doesn't exist. Use that name anyway? [n]" % dst: "y",
-                "Please, specify default directory where the Geant4 data is installed: " \
-                "1) G4LEVELGAMMADATA: %(dst)s/data/PhotonEvaporation2.0 2) G4RADIOACTIVEDATA: " \
-                "%(dst)s/data/RadioactiveDecay3.2 3) G4LEDATA: %(dst)s/data/G4EMLOW5.1 4) G4NEUTRONHPDATA: " \
-                "%(dst)s/data/G4NDL3.12 5) G4ABLADATA: %(dst)s/data/G4ABLA3.0 To modify default settings, " \
+                "Please, specify default directory where the Geant4 data is installed: "
+                "1) G4LEVELGAMMADATA: %(dst)s/data/PhotonEvaporation2.0 2) G4RADIOACTIVEDATA: "
+                "%(dst)s/data/RadioactiveDecay3.2 3) G4LEDATA: %(dst)s/data/G4EMLOW5.1 4) G4NEUTRONHPDATA: "
+                "%(dst)s/data/G4NDL3.12 5) G4ABLADATA: %(dst)s/data/G4ABLA3.0 To modify default settings, "
                 "select number above (e.g. 2) [Press [Enter] for default settings]" % {'dst': dst}: "",
                 "Please, specify where CLHEP is installed: CLHEP_BASE_DIR: ": clhepdir,
                 "Please, specify where CLHEP is installed: CLHEP_BASE_DIR: [%s]" % clhepdir: "",
-                "You can customize paths and library name of you CLHEP installation: 1) CLHEP_INCLUDE_DIR: " \
-                "%(clhepdir)s/include 2) CLHEP_LIB_DIR: %(clhepdir)s/lib 3) CLHEP_LIB: CLHEP To modify " \
+                "You can customize paths and library name of you CLHEP installation: 1) CLHEP_INCLUDE_DIR: "
+                "%(clhepdir)s/include 2) CLHEP_LIB_DIR: %(clhepdir)s/lib 3) CLHEP_LIB: CLHEP To modify "
                 "default settings, select number above (e.g. 2) [Press [Enter] for default settings]" %
                 {'clhepdir': clhepdir}: "",
-                "By default 'static' (.a) libraries are built. Do you want to build 'shared' (.so) " \
+                "By default 'static' (.a) libraries are built. Do you want to build 'shared' (.so) "
                 "libraries? [n]": "y",
-                "You selected to build 'shared' (.so) libraries. Do you want to build 'static' (.a) " \
+                "You selected to build 'shared' (.so) libraries. Do you want to build 'static' (.a) "
                 "libraries too? [n]": "y",
                 "Do you want to build 'global' compound libraries? [n]": "",
                 "Do you want to compile libraries in DEBUG mode (-g)? [n]": "",
-                "G4UI_NONE If this variable is set, no UI sessions nor any UI libraries are built. " \
-                "This can be useful when running a pure batch job or in a user framework having its own " \
+                "G4UI_NONE If this variable is set, no UI sessions nor any UI libraries are built. "
+                "This can be useful when running a pure batch job or in a user framework having its own "
                 "UI system. Do you want to set this variable ? [n]": "",
-                "G4UI_BUILD_XAW_SESSION G4UI_USE_XAW Specifies to include and use the XAW interfaces in " \
-                "the application to be built. The XAW (X11 Athena Widget set) extensions are required to " \
+                "G4UI_BUILD_XAW_SESSION G4UI_USE_XAW Specifies to include and use the XAW interfaces in "
+                "the application to be built. The XAW (X11 Athena Widget set) extensions are required to "
                 "activate and build this driver. [n]": "",
-                "G4UI_BUILD_XM_SESSION G4UI_USE_XM Specifies to include and use the XM Motif based user " \
+                "G4UI_BUILD_XM_SESSION G4UI_USE_XM Specifies to include and use the XM Motif based user "
                 "interfaces. The XM Motif extensions are required to activate and build this driver. [n]": "",
-                "G4VIS_NONE If this variable is set, no visualization drivers will be built or used. Do " \
+                "G4VIS_NONE If this variable is set, no visualization drivers will be built or used. Do "
                 "you want to set this variable ? [n]": "n",
-                "G4VIS_BUILD_OPENGLX_DRIVER G4VIS_USE_OPENGLX It is an interface to the de facto standard " \
-                "3D graphics library, OpenGL. It is well suited for real-time fast visualization and " \
+                "G4VIS_BUILD_OPENGLX_DRIVER G4VIS_USE_OPENGLX It is an interface to the de facto standard "
+                "3D graphics library, OpenGL. It is well suited for real-time fast visualization and "
                 "prototyping. The X11 version of the OpenGL libraries is required. [n]": "",
-                "G4VIS_BUILD_OPENGLXM_DRIVER G4VIS_USE_OPENGLXM It is an interface to the de facto " \
-                "standard 3D graphics library, OpenGL. It is well suited for real-time fast visualization " \
-                "and prototyping. The X11 version of the OpenGL libraries and the Motif Xm extension is " \
+                "G4VIS_BUILD_OPENGLXM_DRIVER G4VIS_USE_OPENGLXM It is an interface to the de facto "
+                "standard 3D graphics library, OpenGL. It is well suited for real-time fast visualization "
+                "and prototyping. The X11 version of the OpenGL libraries and the Motif Xm extension is "
                 "required. [n]": "",
-                "G4VIS_BUILD_DAWN_DRIVER G4VIS_USE_DAWN DAWN drivers are interfaces to the Fukui Renderer " \
-                "DAWN. DAWN is a vectorized 3D PostScript processor suited to prepare technical high " \
+                "G4VIS_BUILD_DAWN_DRIVER G4VIS_USE_DAWN DAWN drivers are interfaces to the Fukui Renderer "
+                "DAWN. DAWN is a vectorized 3D PostScript processor suited to prepare technical high "
                 "quality outputs for presentation and/or documentation. [n]": "",
-                "G4VIS_BUILD_OIX_DRIVER G4VIS_USE_OIX The OpenInventor driver is based on OpenInventor tech" \
+                "G4VIS_BUILD_OIX_DRIVER G4VIS_USE_OIX The OpenInventor driver is based on OpenInventor tech"
                 "nology for scientific visualization. The X11 version of OpenInventor is required. [n]": "",
-                "G4VIS_BUILD_RAYTRACERX_DRIVER G4VIS_USE_RAYTRACERX Allows for interactive ray-tracing " \
+                "G4VIS_BUILD_RAYTRACERX_DRIVER G4VIS_USE_RAYTRACERX Allows for interactive ray-tracing "
                 "graphics through X11. The X11 package is required. [n]": "",
-                "G4VIS_BUILD_VRML_DRIVER G4VIS_USE_VRML These driver generate VRML files, which describe " \
+                "G4VIS_BUILD_VRML_DRIVER G4VIS_USE_VRML These driver generate VRML files, which describe "
                 "3D scenes to be visualized with a proper VRML viewer. [n]": "",
-                "G4LIB_BUILD_GDML Setting this variable will enable building of the GDML plugin module " \
-                "embedded in Geant4 for detector description persistency. It requires your system to have " \
+                "G4LIB_BUILD_GDML Setting this variable will enable building of the GDML plugin module "
+                "embedded in Geant4 for detector description persistency. It requires your system to have "
                 "the XercesC library and headers installed. Do you want to set this variable? [n]": "",
-                "G4LIB_BUILD_G3TOG4 The utility module 'g3tog4' will be built by setting this variable. " \
-                "NOTE: it requires a valid FORTRAN compiler to be installed on your system and the " \
-                "'cernlib' command in the path, in order to build the ancillary tools! Do you want to " \
+                "G4LIB_BUILD_G3TOG4 The utility module 'g3tog4' will be built by setting this variable. "
+                "NOTE: it requires a valid FORTRAN compiler to be installed on your system and the "
+                "'cernlib' command in the path, in order to build the ancillary tools! Do you want to "
                 "build 'g3tog4' ? [n]": "",
-                "G4LIB_BUILD_ZLIB Do you want to activate compression for output files generated by the " \
+                "G4LIB_BUILD_ZLIB Do you want to activate compression for output files generated by the "
                 "HepRep visualization driver? [n]": "y",
-                "G4ANALYSIS_USE Activates the configuration setup for allowing plugins to analysis tools " \
-                "based on AIDA (Astract Interfaces for Data Analysis). In order to use AIDA features and " \
-                "compliant analysis tools, the proper environment for these tools will have to be set " \
+                "G4ANALYSIS_USE Activates the configuration setup for allowing plugins to analysis tools "
+                "based on AIDA (Astract Interfaces for Data Analysis). In order to use AIDA features and "
+                "compliant analysis tools, the proper environment for these tools will have to be set "
                 "(see documentation for the specific analysis tools). [n]": "",
                 "Press [Enter] to start installation or use a shell escape to edit config.sh: ": "",
                 # extra questions and answers for version 9.2.p03
                 "Directory %s doesn't exist. Use that name anyway? [n]" % dst: "y",
-                "Specify the path where the Geant4 data libraries PhotonEvaporation%s " \
-                "RadioactiveDecay%s G4EMLOW%s G4NDL%s G4ABLA%s are " \
-                "installed. For now, a flat directory structure is assumed, and this can be customized " \
+                "Specify the path where the Geant4 data libraries PhotonEvaporation%s "
+                "RadioactiveDecay%s G4EMLOW%s G4NDL%s G4ABLA%s are "
+                "installed. For now, a flat directory structure is assumed, and this can be customized "
                 "at the next step if needed. [%s/data]" % (self.cfg['PhotonEvaporationVersion'],
                                                            self.cfg['G4RadioactiveDecayVersion'],
                                                            self.cfg['G4EMLOWVersion'],
@@ -184,14 +184,14 @@ class EB_Geant4(CMakeMake):
                                                            self.cfg['G4ABLAVersion'],
                                                            pwd
                                                            ): "%s/data" % dst,
-                "Please enter 1) Another path to search in 2) 'f' to force the use of the path " \
-                "you entered previously (the data libraries are not needed to build Geant4, but " \
-                "are needed to run applications later). 3) 'c' to customize the data paths, e.g. " \
+                "Please enter 1) Another path to search in 2) 'f' to force the use of the path "
+                "you entered previously (the data libraries are not needed to build Geant4, but "
+                "are needed to run applications later). 3) 'c' to customize the data paths, e.g. "
                 "if you have the data libraries installed in different locations. [f]": "",
-                "G4UI_BUILD_QT_SESSION G4UI_USE_QT Setting these variables will enable the building " \
-                "of the G4 Qt based user interface module and the use of this module in your " \
-                "applications respectively. The Qt3 or Qt4 headers, libraries and moc application are " \
-                "required to enable the building of this module. Do you want to enable build and use of " \
+                "G4UI_BUILD_QT_SESSION G4UI_USE_QT Setting these variables will enable the building "
+                "of the G4 Qt based user interface module and the use of this module in your "
+                "applications respectively. The Qt3 or Qt4 headers, libraries and moc application are "
+                "required to enable the building of this module. Do you want to enable build and use of "
                 "this module? [n]": "",
                 # extra questions and answers for version 9.4.po1
                 "What is the path to the Geant4 source tree? [%s]" % pwd: "",
@@ -204,9 +204,9 @@ class EB_Geant4(CMakeMake):
                 "Do you want to build libraries with debugging information? [n]": "",
                 "Specify the path where the Geant4 data libraries are installed: [%s/data]" % pwd: "%s/data" % dst,
                 "How many parallel jobs should make launch? [1]": "%s" % self.cfg['parallel'],
-                "Please enter 1) Another path to search in 2) 'f' to force the use of the path you entered " \
-                "previously (the data libraries are NOT needed to build Geant4, but are needed to run " \
-                "applications later). 3) 'c' to customize the data paths, e.g. if you have the data " \
+                "Please enter 1) Another path to search in 2) 'f' to force the use of the path you entered "
+                "previously (the data libraries are NOT needed to build Geant4, but are needed to run "
+                "applications later). 3) 'c' to customize the data paths, e.g. if you have the data "
                 "libraries installed in different locations. [f]": "",
                 "Enable building of User Interface (UI) modules? [y]": "",
                 "Enable building of the XAW (X11 Athena Widget set) UI module? [n]": "",


### PR DESCRIPTION
This is causing CI to fail suddenly, see https://github.com/ocaisa/easybuild-easyblocks/actions/runs/10111159687/job/27962541425

There's no real way of testing this as it only applies to old (archived) versions of Geant4 (see https://github.com/easybuilders/easybuild-easyblocks/pull/3394/files#diff-709e5f8d7395f32564d55701217becbde05841477a60bbe696992a2488b19b8eR85)