### PR TITLE
support revisions in crates extraction procedure in `Cargo` easyblock

### DIFF
--- a/easybuild/easyblocks/generic/cargo.py
+++ b/easybuild/easyblocks/generic/cargo.py
@@ -314,13 +314,14 @@ def generate_crate_list(sourcedir):
                 if dep['source'] == 'registry+https://github.com/rust-lang/crates.io-index':
                     crates.append((name, version))
                 else:
-                    # Lock file has revision#revision in the url
+                    # Lock file has #revision in the url
                     url, rev = dep['source'].rsplit('#', maxsplit=1)
                     for prefix in ('registry+', 'git+'):
                         if url.startswith(prefix):
                             url = url[len(prefix):]
-                    # Remove branch name if present
+                    # Remove branch name and revision URL parameters if present
                     url = re.sub(r'\?branch=\w+$', '', url)
+                    url = re.sub(r'\?rev=%s+$' % rev, '', url)
                     crates.append((name, version, url, rev))
         else:
             other_crates.append((name, version))


### PR DESCRIPTION
There might be entries like
> source = "git+https://github.com/charliermarsh/rs-async-zip?rev=011b24604fa7bc223daaad7712c0694bac8f0a87#011b24604fa7bc223daaad7712c0694bac8f0a87"

We do handle "?branch=sha#sha" but not "?rev=sha#sha", so extend this to "rev". To be safe match the revision.