### PR TITLE
set `$R_LIBS_USER` in `RPackage` easyblock to avoid picking up on R packages installed in home directory

### DIFF
--- a/easybuild/easyblocks/generic/rpackage.py
+++ b/easybuild/easyblocks/generic/rpackage.py
@@ -40,6 +40,7 @@ from easybuild.easyblocks.generic.configuremake import check_config_guess, obtai
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.environment import setvar
 from easybuild.tools.filetools import mkdir, copy_file
 from easybuild.tools.run import run_cmd, parse_log_for_error
 
@@ -267,6 +268,11 @@ class RPackage(ExtensionEasyBlock):
 
         :return: Shell command to run + string to pass to stdin.
         """
+
+        # set $R_LIBS_USER to non-existing path in build directory,
+        # to avoid picking up on R packages installed in home directory of current user
+        # (from ~/R/x86_64-pc-linux-gnu-library/<version>)
+        setvar('R_LIBS_USER', os.path.join(self.builddir, 'r_libs'))
 
         # determine location
         if isinstance(self.master, EB_R):


### PR DESCRIPTION
Motivating example: I ran into a weird problem when installing `R-4.3.2-gfbf-2023a.eb`:

```
== 2024-08-09 15:05:50,697 build_log.py:171 ERROR EasyBuild crashed with an error (at easybuild/base/exceptions.py:126 in __init__): cmd " R CMD INSTALL /tmp/vsc40003/easybuild/R/4.3.2/gfbf-2023a/pkgload//
pkgload   --library=/apps/gent/RHEL9/zen4-ib/software/R/4.3.2-gfbf-2023a/lib64/R/library --no-clean-on-error " exited with exit code 1 and output:
* installing *source* package pkgload ...
** package pkgload successfully unpacked and MD5 sums checked
** using staged installation
** R
** inst
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
** building package indices
** testing if installed package can be loaded from temporary location
** testing if installed package can be loaded from final location
Error in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]) :
  there is no package called brio
Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
Execution halted
ERROR: loading failed
```

Turns out that I had some R packages installed in the home directory of the account I was using:

```
$ ls -lrt ~/R/x86_64-pc-linux-gnu-library/4.3
total 7
drwxr-xr-x 12 vsc40003 vsc40003 4096 Jul 31 10:24 renv
drwxr-xr-x 11 vsc40003 vsc40003 4096 Jul 31 14:38 digest
drwxr-xr-x  8 vsc40003 vsc40003 4096 Jul 31 14:38 purrr
drwxr-xr-x 10 vsc40003 vsc40003 4096 Jul 31 14:38 rmarkdown
drwxr-xr-x 11 vsc40003 vsc40003 4096 Jul 31 14:38 testthat
drwxr-xr-x 10 vsc40003 vsc40003 4096 Jul 31 14:38 xml2
drwxr-xr-x  8 vsc40003 vsc40003 4096 Jul 31 14:38 yaml
```

`testthat` depends on `brio`, and it seems like `pkgload` tries to use `testthat` if it seems to be installed...

By setting `$R_LIBS_USER`, we can ignore the packages installed in `~/R/*`.