### PR TITLE
Update NCL easyblock for intel

### DIFF
--- a/easybuild/easyblocks/n/ncl.py
+++ b/easybuild/easyblocks/n/ncl.py
@@ -100,8 +100,8 @@ class EB_NCL(EasyBlock):
             'FCompiler': os.getenv('F90'),
             'CcOptions': '-ansi %s' % os.getenv('CFLAGS'),
             'FcOptions': os.getenv('FFLAGS'),
-            'COptimizeFlag': os.getenv('CFLAGS'),
-            'FOptimizeFlag': os.getenv('FFLAGS'),
+            'COptimizeFlag': os.getenv('COPTS', ''),
+            'FOptimizeFlag': os.getenv('FOPTS', ''),
             'ExtraSysLibraries': os.getenv('LDFLAGS'),
             'CtoFLibraries': ctof_libs,
         }

--- a/easybuild/easyblocks/n/ncl.py
+++ b/easybuild/easyblocks/n/ncl.py
@@ -51,7 +51,7 @@ class EB_NCL(EasyBlock):
         - create Makefile.ini using make and run ymake script to create config file
         - patch config file with correct settings, and add missing config entries
         - create config/Site.local file to avoid interactive install
-        - generate Makefile using config/ymkmf sciprt
+        - generate Makefile using config/ymkmf script
         -
         """
 

--- a/easybuild/easyblocks/n/ncl.py
+++ b/easybuild/easyblocks/n/ncl.py
@@ -76,13 +76,20 @@ class EB_NCL(EasyBlock):
         # adjust config file as needed
         ctof_libs = ''
         ifort = get_software_root('ifort')
+        intel_compilers = get_software_root('intel-compilers')
         if ifort:
-            if os.path.exists('%s/lib/intel64/' % ifort) and os.access('%s/lib/intel64/' % ifort, os.R_OK):
-                ctof_libs += '-lm -L%s/lib/intel64/ -lifcore -lifport' % ifort
+            ifortran_libdir = '%s/lib/intel64/' % ifort
+        elif intel_compilers:
+            ifortran_libdir = '%s/compiler/latest/linux/compiler/lib/intel64_lin/' % intel_compilers
+        else:
+            ifortran_libdir = None
+        if ifortran_libdir:
+            if os.path.exists(ifortran_libdir) and os.access(ifortran_libdir, os.R_OK):
+                ctof_libs += '-lm -L%s -lifcore -lifport' % ifortran_libdir
             else:
                 self.log.warning(
                     "Can't find a libdir for ifortran libraries -lifcore -lifport: "
-                    "%s/lib/intel64 doesn't exist or is not accessible." % ifort
+                    "%s doesn't exist or is not accessible." % ifortran_libdir
                 )
         elif get_software_root('GCC'):
             ctof_libs = '-lgfortran -lm'


### PR DESCRIPTION
Update the NCL easyblock to the situation that `intel/2023b` toolchain keeps the libdir for `ifort` compiler in  `intel-compilers`.

This change makes `NCL-6.6.2-intel-2023b.eb` work, see
 -  easybuilders/easybuild-easyconfigs/pull/21176