### PR TITLE
use `PYPI_SOURCE` constant in generic `PythonPackage` easyblock + custom easyblock for Python

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -45,7 +45,7 @@ from easybuild.base import fancylogger
 from easybuild.easyblocks.python import EBPYTHONPREFIXES, EXTS_FILTER_PYTHON_PACKAGES
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.easyconfig.default import DEFAULT_CONFIG
-from easybuild.framework.easyconfig.templates import TEMPLATE_CONSTANTS
+from easybuild.framework.easyconfig.templates import PYPI_SOURCE
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
 from easybuild.tools.build_log import EasyBuildError, print_msg
 from easybuild.tools.config import build_option
@@ -372,7 +372,7 @@ class PythonPackage(ExtensionEasyBlock):
         if 'source_urls' not in extra_vars:
             # Create a copy so the defaults are not modified by the following line
             src_urls = DEFAULT_CONFIG['source_urls'][:]
-            src_urls[0] = [url for name, url, _ in TEMPLATE_CONSTANTS if name == 'PYPI_SOURCE']
+            src_urls[0] = [PYPI_SOURCE]
             extra_vars['source_urls'] = src_urls
 
         return ExtensionEasyBlock.extra_options(extra_vars=extra_vars)

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -43,7 +43,7 @@ from easybuild.tools import LooseVersion
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import CUSTOM
-from easybuild.framework.easyconfig.templates import TEMPLATE_CONSTANTS
+from easybuild.framework.easyconfig.templates import PYPI_SOURCE
 from easybuild.tools.build_log import EasyBuildError, print_warning
 from easybuild.tools.config import build_option, ERROR, log_path
 from easybuild.tools.modules import get_software_libdir, get_software_root, get_software_version
@@ -149,7 +149,7 @@ class EB_Python(ConfigureMake):
 
         ext_defaults = {
             # Use PYPI_SOURCE as the default for source_urls of extensions.
-            'source_urls': [url for name, url, _ in TEMPLATE_CONSTANTS if name == 'PYPI_SOURCE'],
+            'source_urls': [PYPI_SOURCE],
             # We should enable this (by default) for all extensions because the only installed packages at this point
             # (i.e. those in the site-packages folder) are the default installed ones, e.g. pip & setuptools.
             # And we must upgrade them cleanly, i.e. uninstall them first. This also applies to any other package


### PR DESCRIPTION
Required after the conversion in 

- [x] https://github.com/easybuilders/easybuild-framework/pull/4595