### PR TITLE
QuantumESPRESSO: Added usage of `--disable-mpi-tests` flag

### DIFF
--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -42,6 +42,7 @@ from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM, EasyConfig
 from easybuild.tools import LooseVersion
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.config import build_option
 from easybuild.tools.filetools import copy_dir, copy_file
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
@@ -347,6 +348,9 @@ class EB_QuantumESPRESSO(EasyBlock):
             Test the compilation using Quantum ESPRESSO's test suite.
             ctest -j NCONCURRENT (NCONCURRENT = max (1, PARALLEL / NPROCS))
             """
+            if not build_option('mpi_tests'):
+                self.log.info("Skipping testing of QuantumESPRESSO since MPI testing is disabled")
+                return
 
             thr = self.cfg.get('test_suite_threshold', 0.97)
             concurrent = max(1, self.cfg.get('parallel', 1) // self._test_nprocs)
@@ -1027,6 +1031,9 @@ class EB_QuantumESPRESSO(EasyBlock):
             Test the compilation using Quantum ESPRESSO's test suite.
             cd test-suite && make run-tests NPROCS=XXX (XXX <= 4)
             """
+            if not build_option('mpi_tests'):
+                self.log.info("Skipping testing of QuantumESPRESSO since MPI testing is disabled")
+                return
 
             thr = self.cfg.get('test_suite_threshold', 0.9)
             stot = 0


### PR DESCRIPTION
QE if compiled with MPI enabled will always run tests using the found `mpicommand`:

- Always true for the CMake version
- Can be avoided in the Makefile version but it is getting deprecated

This PR ensures the test-suite is skipped if `--disable-mpi-tests` tests is used.