### PR TITLE
Replace `run_cmd` with `run_shell_cmd` in custom easyblock for MetalWalls

### DIFF
--- a/easybuild/easyblocks/m/metalwalls.py
+++ b/easybuild/easyblocks/m/metalwalls.py
@@ -34,7 +34,7 @@ import easybuild.tools.toolchain as toolchain
 from easybuild.tools import LooseVersion
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root, get_software_version
-from easybuild.tools.run import run_cmd
+from easybuild.tools.run import run_shell_cmd
 
 from easybuild.easyblocks.generic.makecp import MakeCp
 
@@ -89,15 +89,14 @@ class EB_MetalWalls(MakeCp):
             f90flags += ['-fallow-argument-mismatch']  # Code inside ifdef causes mismatch errors
             fppflags += ['-DMW_USE_PLUMED']
             cmd = ['touch', 'mw2.diff']
-            run_cmd(' '.join(cmd), log_all=False, log_ok=False, simple=False, regexp=False)
+            run_shell_cmd(' '.join(cmd), fail_on_error=False)
             cmd = ['plumed', 'patch', '-d mw2.diff', '--patch', '--shared', '--engine', 'mw2']
-            run_cmd(' '.join(cmd), log_all=True, simple=False)
+            run_shell_cmd(' '.join(cmd))
         else:
             self.log.info('PLUMED not found, excluding from test-suite')
             rgx = tpl_rgx % 'plumed'
-            cmd = ['sed', '-i', "'s/^\\( \\+\\)%s$/\\1pass # %s/'" % (rgx, rgx), 'tests/regression_tests.py']
             cmd = ['sed', '-i', "'s/%s/pass/'" % rgx, 'tests/regression_tests.py']
-            run_cmd(' '.join(cmd), log_all=True, simple=False)
+            run_shell_cmd(' '.join(cmd))
 
         if f90wrap:
             if not get_software_root('mpi4py'):
@@ -115,7 +114,7 @@ class EB_MetalWalls(MakeCp):
             self.log.info('f90wrap not found, excluding python interface from test-suite')
             rgx = tpl_rgx % 'python_interface'
             cmd = ['sed', '-i', "'s/%s/pass/'" % rgx, 'tests/regression_tests.py']
-            run_cmd(' '.join(cmd), log_all=True, simple=False)
+            run_shell_cmd(' '.join(cmd))
 
         # Add libraries with LAPACK support
         lapack_shared_libs = os.getenv('LAPACK_SHARED_LIBS', None)


### PR DESCRIPTION
Replaced `run_cmd` with `run_shell_cmd` for 5.0 release