### PR TITLE
disable the version check of pip in Python packages

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -429,6 +429,8 @@ class PythonPackage(ExtensionEasyBlock):
         # Users or sites may require using a virtualenv for user installations
         # We need to disable this to be able to install into the modules
         env.setvar('PIP_REQUIRE_VIRTUALENV', 'false')
+        # Don't let pip connect to PYPI to check for a new version
+        env.setvar('PIP_DISABLE_PIP_VERSION_CHECK', 'true')
 
     def determine_install_command(self):
         """


### PR DESCRIPTION
When invoking `pip` it will connect to PyPI to check if a new version is available. Not only do we not care about that but we also don't want to connect to anything external which slows down the build at best or fails at worst.

Set the environment variable to disable this in the PythonPackage constructor such that it works for any easyblock deriving from it.

A few installations where I have found a message such as:
> You should consider upgrading via the '/software/rome/r23.04/Python/3.10.4-GCCcore-11.3.0/bin/python -m pip install --upgrade pip' command.

- scipy (SciPy-bundle)
- LAMMPS
- TensorFlow
- pytest-shard
- pytest-rerunfailures