### PR TITLE
make sure to raise an error if `pick_python_cmd` returns False for Python bundles/packages

### DIFF
--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -91,6 +91,8 @@ class PythonBundle(Bundle):
         # when system Python is used, the first 'python' command in $PATH will not be $EBROOTPYTHON/bin/python,
         # since $EBROOTPYTHON is set to just 'Python' in that case
         # (see handling of allow_system_deps in EasyBlock.prepare_step)
+        req_py_majver = None
+        req_py_minver = None
         if which('python') == os.path.join(python_root, 'bin', 'python'):
             # if we're using a proper Python dependency, let det_pylibdir use 'python' like it does by default
             python_cmd = None

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -112,7 +112,13 @@ class PythonBundle(Bundle):
         if python_cmd:
             self.log.info("Python command being used: %s", python_cmd)
         else:
-            raise EasyBuildError("Failed to pick Python command to use")
+            if req_py_majver is not None or req_py_minver is not None:
+                raise EasyBuildError(
+                    "Failed to pick python command that satisfies requirements in the EasyConfigs "
+                    "(req_py_majver = %s, req_py_minver = %s)", req_py_majver, req_py_minver
+                )
+            else:
+                raise EasyBuildError("Failed to pick Python command to use")
 
         if python_cmd:
             self.all_pylibdirs = get_pylibdirs(python_cmd=python_cmd)

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -91,8 +91,6 @@ class PythonBundle(Bundle):
         # when system Python is used, the first 'python' command in $PATH will not be $EBROOTPYTHON/bin/python,
         # since $EBROOTPYTHON is set to just 'Python' in that case
         # (see handling of allow_system_deps in EasyBlock.prepare_step)
-        req_py_majver = None
-        req_py_minver = None
         if which('python') == os.path.join(python_root, 'bin', 'python'):
             # if we're using a proper Python dependency, let det_pylibdir use 'python' like it does by default
             python_cmd = None

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -109,8 +109,14 @@ class PythonBundle(Bundle):
 
             python_cmd = pick_python_cmd(req_maj_ver=req_py_majver, req_min_ver=req_py_minver)
 
-        self.all_pylibdirs = get_pylibdirs(python_cmd=python_cmd)
-        self.pylibdir = self.all_pylibdirs[0]
+        if python_cmd:
+            self.log.info("Python command being used: %s", self.python_cmd)
+        else:
+            raise EasyBuildError("Failed to pick Python command to use")
+
+        if python_cmd:
+            self.all_pylibdirs = get_pylibdirs(python_cmd=python_cmd)
+            self.pylibdir = self.all_pylibdirs[0]
 
         # if 'python' is not used, we need to take that into account in the extensions filter
         # (which is also used during the sanity check)

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -110,7 +110,7 @@ class PythonBundle(Bundle):
             python_cmd = pick_python_cmd(req_maj_ver=req_py_majver, req_min_ver=req_py_minver)
 
         if python_cmd:
-            self.log.info("Python command being used: %s", self.python_cmd)
+            self.log.info("Python command being used: %s", python_cmd)
         else:
             raise EasyBuildError("Failed to pick Python command to use")
 

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -111,19 +111,16 @@ class PythonBundle(Bundle):
 
             python_cmd = pick_python_cmd(req_maj_ver=req_py_majver, req_min_ver=req_py_minver)
 
-        if python_cmd:
-            self.log.info("Python command being used: %s", python_cmd)
-        else:
-            if req_py_majver is not None or req_py_minver is not None:
+            # If pick_python_cmd didn't find a (system) python command, we should raise an error
+            if python_cmd:
+                self.log.info("Python command being used: %s", python_cmd)
+            else:
                 raise EasyBuildError(
                     "Failed to pick python command that satisfies requirements in the EasyConfigs "
                     "(req_py_majver = %s, req_py_minver = %s)", req_py_majver, req_py_minver
                 )
-            else:
-                raise EasyBuildError("Failed to pick Python command to use")
 
-        if python_cmd:
-            self.all_pylibdirs = get_pylibdirs(python_cmd=python_cmd)
+        self.all_pylibdirs = get_pylibdirs(python_cmd=python_cmd)
             self.pylibdir = self.all_pylibdirs[0]
 
         # if 'python' is not used, we need to take that into account in the extensions filter

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -119,7 +119,7 @@ class PythonBundle(Bundle):
                 )
 
         self.all_pylibdirs = get_pylibdirs(python_cmd=python_cmd)
-            self.pylibdir = self.all_pylibdirs[0]
+        self.pylibdir = self.all_pylibdirs[0]
 
         # if 'python' is not used, we need to take that into account in the extensions filter
         # (which is also used during the sanity check)

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -109,12 +109,12 @@ class PythonBundle(Bundle):
 
             python_cmd = pick_python_cmd(req_maj_ver=req_py_majver, req_min_ver=req_py_minver)
 
-            # If pick_python_cmd didn't find a (system) python command, we should raise an error
+            # If pick_python_cmd didn't find a (system) Python command, we should raise an error
             if python_cmd:
                 self.log.info("Python command being used: %s", python_cmd)
             else:
                 raise EasyBuildError(
-                    "Failed to pick python command that satisfies requirements in the EasyConfigs "
+                    "Failed to pick Python command that satisfies requirements in the easyconfig "
                     "(req_py_majver = %s, req_py_minver = %s)", req_py_majver, req_py_minver
                 )
 

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -498,8 +498,6 @@ class PythonPackage(ExtensionEasyBlock):
                 python = os.path.join(python_root, 'bin', 'python')
                 self.log.debug("Retaining 'python' command for Python dependency: %s", python)
 
-        req_py_majver = None
-        req_py_minver = None
         if python is None:
             # if no Python version requirements are specified,
             # use major/minor version of Python being used in this EasyBuild session
@@ -513,19 +511,24 @@ class PythonPackage(ExtensionEasyBlock):
             # if using system Python, go hunting for a 'python' command that satisfies the requirements
             python = pick_python_cmd(req_maj_ver=req_py_majver, req_min_ver=req_py_minver)
 
-        if python:
+            # Check if we have python by now. If not, and if self.require_python, raise a sensible error
+            if python:
+                self.python_cmd = python
+                self.log.info("Python command being used: %s", self.python_cmd)
+            elif self.require_python:
+                if req_py_majver is not None or req_py_minver is not None:
+                    raise EasyBuildError(
+                        "Failed to pick python command that satisfies requirements in the EasyConfigs "
+                        "(req_py_majver = %s, req_py_minver = %s)", req_py_majver, req_py_minver
+                    )
+                else:
+                    raise EasyBuildError("Failed to pick Python command to use")
+            else:
+                self.log.warning("No Python command found!")
+        else:
             self.python_cmd = python
             self.log.info("Python command being used: %s", self.python_cmd)
-        elif self.require_python:
-            if req_py_majver is not None or req_py_minver is not None:
-                raise EasyBuildError(
-                    "Failed to pick python command that satisfies requirements in the EasyConfigs "
-                    "(req_py_majver = %s, req_py_minver = %s)", req_py_majver, req_py_minver
-                )
-            else:
-                raise EasyBuildError("Failed to pick Python command to use")
-        else:
-            self.log.warning("No Python command found!")
+
 
         if self.python_cmd:
             # set Python lib directories

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -515,7 +515,15 @@ class PythonPackage(ExtensionEasyBlock):
             self.python_cmd = python
             self.log.info("Python command being used: %s", self.python_cmd)
         elif self.require_python:
-            raise EasyBuildError("Failed to pick Python command to use")
+            if req_py_majver is not None or req_py_minver is not None:
+                msg = "Failed to pick Python command that satisfies requirements in the EasyConfigs "
+                msg += "(req_maj_ver = %s, req_min_ver = %s)" % (req_maj_ver, req_min_ver)
+                raise EasyBuildError(
+                    "Failed to pick python command that satisfies requirements in the EasyConfigs "
+                    "(req_maj_ver = %s, req_min_ver = %s)", req_maj_ver, req_min_ver
+                )
+            else:
+                raise EasyBuildError("Failed to pick Python command to use")
         else:
             self.log.warning("No Python command found!")
 

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -498,6 +498,8 @@ class PythonPackage(ExtensionEasyBlock):
                 python = os.path.join(python_root, 'bin', 'python')
                 self.log.debug("Retaining 'python' command for Python dependency: %s", python)
 
+        req_py_majver = None
+        req_py_minver = None
         if python is None:
             # if no Python version requirements are specified,
             # use major/minor version of Python being used in this EasyBuild session

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -516,11 +516,9 @@ class PythonPackage(ExtensionEasyBlock):
             self.log.info("Python command being used: %s", self.python_cmd)
         elif self.require_python:
             if req_py_majver is not None or req_py_minver is not None:
-                msg = "Failed to pick Python command that satisfies requirements in the EasyConfigs "
-                msg += "(req_maj_ver = %s, req_min_ver = %s)" % (req_maj_ver, req_min_ver)
                 raise EasyBuildError(
                     "Failed to pick python command that satisfies requirements in the EasyConfigs "
-                    "(req_maj_ver = %s, req_min_ver = %s)", req_maj_ver, req_min_ver
+                    "(req_py_majver = %s, req_py_minver = %s)", req_py_majver, req_py_minver
                 )
             else:
                 raise EasyBuildError("Failed to pick Python command to use")

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -529,7 +529,6 @@ class PythonPackage(ExtensionEasyBlock):
             self.python_cmd = python
             self.log.info("Python command being used: %s", self.python_cmd)
 
-
         if self.python_cmd:
             # set Python lib directories
             self.set_pylibdirs()

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -511,14 +511,14 @@ class PythonPackage(ExtensionEasyBlock):
             # if using system Python, go hunting for a 'python' command that satisfies the requirements
             python = pick_python_cmd(req_maj_ver=req_py_majver, req_min_ver=req_py_minver)
 
-            # Check if we have python by now. If not, and if self.require_python, raise a sensible error
+            # Check if we have Python by now. If not, and if self.require_python, raise a sensible error
             if python:
                 self.python_cmd = python
                 self.log.info("Python command being used: %s", self.python_cmd)
             elif self.require_python:
                 if req_py_majver is not None or req_py_minver is not None:
                     raise EasyBuildError(
-                        "Failed to pick python command that satisfies requirements in the EasyConfigs "
+                        "Failed to pick Python command that satisfies requirements in the easyconfig "
                         "(req_py_majver = %s, req_py_minver = %s)", req_py_majver, req_py_minver
                     )
                 else:


### PR DESCRIPTION
This was already done for PythonPackage, but not for PythonBundle. I ran into this here https://github.com/easybuilders/easybuild-easyconfigs/pull/21307#issuecomment-2327000584