### PR TITLE
allow Python bundles and packages to specify a maximum Python version for the system toolchain

### DIFF
--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -91,6 +91,10 @@ class PythonBundle(Bundle):
         # when system Python is used, the first 'python' command in $PATH will not be $EBROOTPYTHON/bin/python,
         # since $EBROOTPYTHON is set to just 'Python' in that case
         # (see handling of allow_system_deps in EasyBlock.prepare_step)
+        req_py_majver = None
+        req_py_minver = None
+        max_py_majver = None
+        max_py_minver = None
         if which('python') == os.path.join(python_root, 'bin', 'python'):
             # if we're using a proper Python dependency, let det_pylibdir use 'python' like it does by default
             python_cmd = None
@@ -127,9 +131,8 @@ class PythonBundle(Bundle):
             else:
                 raise EasyBuildError("Failed to pick Python command to use")
 
-        if python_cmd:
-            self.all_pylibdirs = get_pylibdirs(python_cmd=python_cmd)
-            self.pylibdir = self.all_pylibdirs[0]
+        self.all_pylibdirs = get_pylibdirs(python_cmd=python_cmd)
+        self.pylibdir = self.all_pylibdirs[0]
 
         # if 'python' is not used, we need to take that into account in the extensions filter
         # (which is also used during the sanity check)

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -107,15 +107,21 @@ class PythonBundle(Bundle):
             if req_py_minver is None:
                 req_py_minver = sys.version_info[1]
 
-            python_cmd = pick_python_cmd(req_maj_ver=req_py_majver, req_min_ver=req_py_minver)
+            # Get the max_py_majver and max_py_minver from the config
+            max_py_majver = self.cfg['max_py_majver']
+            max_py_minver = self.cfg['max_py_minver']
+
+            python_cmd = pick_python_cmd(req_maj_ver=req_py_majver, req_min_ver=req_py_minver, max_py_ver=max_py_majver
+                                         max_py_majver=max_py_majver, max_py_minver=max_py_minver)
 
         if python_cmd:
             self.log.info("Python command being used: %s", python_cmd)
         else:
-            if req_py_majver is not None or req_py_minver is not None:
+            if req_py_majver is not None or req_py_minver is not None or max_py_majver is not None or max_py_minver is not None:
                 raise EasyBuildError(
                     "Failed to pick python command that satisfies requirements in the EasyConfigs "
-                    "(req_py_majver = %s, req_py_minver = %s)", req_py_majver, req_py_minver
+                    "(req_py_majver = %s, req_py_minver = %s, max_py_majver = %s, max_py_minver = %s)"
+                    , req_py_majver, req_py_minver, max_py_majver, max_py_minver
                 )
             else:
                 raise EasyBuildError("Failed to pick Python command to use")

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -117,8 +117,8 @@ class PythonBundle(Bundle):
         if python_cmd:
             self.log.info("Python command being used: %s", python_cmd)
         else:
-            if req_py_majver is not None or req_py_minver is not None or 
-               max_py_majver is not None or max_py_minver is not None:
+            if (req_py_majver is not None or req_py_minver is not None or 
+                max_py_majver is not None or max_py_minver is not None):
                 raise EasyBuildError(
                     "Failed to pick python command that satisfies requirements in the EasyConfigs "
                     "(req_py_majver = %s, req_py_minver = %s, max_py_majver = %s, max_py_minver = %s)",

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -112,7 +112,13 @@ class PythonBundle(Bundle):
         if python_cmd:
             self.log.info("Python command being used: %s", python_cmd)
         else:
-            raise EasyBuildError("Failed to pick Python command to use")
+            if req_py_majver is not None or req_py_minver is not None:
+                raise EasyBuildError(
+                    "Failed to pick python command that satisfies requirements in the EasyConfigs "
+                    "(req_py_majver = %s, req_py_minver = %s)", req_py_majver, req_py_minver
+                )
+            else:
+                raise EasyBuildError("Failed to pick Python command to use")
 
         if python_cmd:
             self.all_pylibdirs = get_pylibdirs(python_cmd=python_cmd)

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -111,17 +111,18 @@ class PythonBundle(Bundle):
             max_py_majver = self.cfg['max_py_majver']
             max_py_minver = self.cfg['max_py_minver']
 
-            python_cmd = pick_python_cmd(req_maj_ver=req_py_majver, req_min_ver=req_py_minver, max_py_ver=max_py_majver
+            python_cmd = pick_python_cmd(req_maj_ver=req_py_majver, req_min_ver=req_py_minver,
                                          max_py_majver=max_py_majver, max_py_minver=max_py_minver)
 
         if python_cmd:
             self.log.info("Python command being used: %s", python_cmd)
         else:
-            if req_py_majver is not None or req_py_minver is not None or max_py_majver is not None or max_py_minver is not None:
+            if req_py_majver is not None or req_py_minver is not None or 
+               max_py_majver is not None or max_py_minver is not None:
                 raise EasyBuildError(
                     "Failed to pick python command that satisfies requirements in the EasyConfigs "
-                    "(req_py_majver = %s, req_py_minver = %s, max_py_majver = %s, max_py_minver = %s)"
-                    , req_py_majver, req_py_minver, max_py_majver, max_py_minver
+                    "(req_py_majver = %s, req_py_minver = %s, max_py_majver = %s, max_py_minver = %s)",
+                    req_py_majver, req_py_minver, max_py_majver, max_py_minver
                 )
             else:
                 raise EasyBuildError("Failed to pick Python command to use")

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -118,18 +118,15 @@ class PythonBundle(Bundle):
             python_cmd = pick_python_cmd(req_maj_ver=req_py_majver, req_min_ver=req_py_minver,
                                          max_py_majver=max_py_majver, max_py_minver=max_py_minver)
 
-        if python_cmd:
-            self.log.info("Python command being used: %s", python_cmd)
-        else:
-            if (req_py_majver is not None or req_py_minver is not None or 
-                    max_py_majver is not None or max_py_minver is not None):
+            # If pick_python_cmd didn't find a (system) python command, we should raise an error
+            if python_cmd:
+                self.log.info("Python command being used: %s", python_cmd)
+            else:
                 raise EasyBuildError(
                     "Failed to pick python command that satisfies requirements in the EasyConfigs "
                     "(req_py_majver = %s, req_py_minver = %s, max_py_majver = %s, max_py_minver = %s)",
                     req_py_majver, req_py_minver, max_py_majver, max_py_minver
                 )
-            else:
-                raise EasyBuildError("Failed to pick Python command to use")
 
         self.all_pylibdirs = get_pylibdirs(python_cmd=python_cmd)
         self.pylibdir = self.all_pylibdirs[0]

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -91,10 +91,6 @@ class PythonBundle(Bundle):
         # when system Python is used, the first 'python' command in $PATH will not be $EBROOTPYTHON/bin/python,
         # since $EBROOTPYTHON is set to just 'Python' in that case
         # (see handling of allow_system_deps in EasyBlock.prepare_step)
-        req_py_majver = None
-        req_py_minver = None
-        max_py_majver = None
-        max_py_minver = None
         if which('python') == os.path.join(python_root, 'bin', 'python'):
             # if we're using a proper Python dependency, let det_pylibdir use 'python' like it does by default
             python_cmd = None

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -118,7 +118,7 @@ class PythonBundle(Bundle):
             self.log.info("Python command being used: %s", python_cmd)
         else:
             if (req_py_majver is not None or req_py_minver is not None or 
-                max_py_majver is not None or max_py_minver is not None):
+                    max_py_majver is not None or max_py_minver is not None):
                 raise EasyBuildError(
                     "Failed to pick python command that satisfies requirements in the EasyConfigs "
                     "(req_py_majver = %s, req_py_minver = %s, max_py_majver = %s, max_py_minver = %s)",

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -130,19 +130,19 @@ def pick_python_cmd(req_maj_ver=None, req_min_ver=None, max_py_majver=None, max_
                 log.debug("Minimal requirement for minor Python version not satisfied: %s vs %s", pyver, req_majmin_ver)
                 return False
 
-       if max_maj_ver is not None:
-           if max_min_ver is None:
-               max_majmin_ver = '%s.0' % max_maj_ver
-            else:
-               max_majmin_ver = '%s.%s' % (max_maj_ver, max_min_ver)
+        if max_maj_ver is not None:
+            if max_min_ver is None:
+                max_majmin_ver = '%s.0' % max_maj_ver
+             else:
+                max_majmin_ver = '%s.%s' % (max_maj_ver, max_min_ver)
 
-            pyver = det_python_version(python_cmd)
+             pyver = det_python_version(python_cmd)
 
-            if LooseVersion(pyver) > LooseVersion(max_majmin_ver)
-                log.debug("Python version (%s) on the system is newer than the maximum python version "
-                          "specified in the easyconfig %s",
-                          pyver, max_majmin_ver)
-                return False
+             if LooseVersion(pyver) > LooseVersion(max_majmin_ver)
+                 log.debug("Python version (%s) on the system is newer than the maximum python version "
+                           "specified in the easyconfig %s",
+                           pyver, max_majmin_ver)
+                 return False
 
         # all check passed
         log.debug("All check passed for Python command '%s'!", python_cmd)

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -133,16 +133,16 @@ def pick_python_cmd(req_maj_ver=None, req_min_ver=None, max_py_majver=None, max_
         if max_maj_ver is not None:
             if max_min_ver is None:
                 max_majmin_ver = '%s.0' % max_maj_ver
-             else:
+            else:
                 max_majmin_ver = '%s.%s' % (max_maj_ver, max_min_ver)
 
-             pyver = det_python_version(python_cmd)
+            pyver = det_python_version(python_cmd)
 
-             if LooseVersion(pyver) > LooseVersion(max_majmin_ver)
-                 log.debug("Python version (%s) on the system is newer than the maximum python version "
-                           "specified in the easyconfig %s",
+            if LooseVersion(pyver) > LooseVersion(max_majmin_ver)
+                log.debug("Python version (%s) on the system is newer than the maximum python version "
+                          "specified in the easyconfig %s",
                            pyver, max_majmin_ver)
-                 return False
+                return False
 
         # all check passed
         log.debug("All check passed for Python command '%s'!", python_cmd)

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -514,8 +514,6 @@ class PythonPackage(ExtensionEasyBlock):
                 python = os.path.join(python_root, 'bin', 'python')
                 self.log.debug("Retaining 'python' command for Python dependency: %s", python)
 
-        req_py_majver = None
-        req_py_minver = None
         if python is None:
             # if no Python version requirements are specified,
             # use major/minor version of Python being used in this EasyBuild session
@@ -534,21 +532,25 @@ class PythonPackage(ExtensionEasyBlock):
             python = pick_python_cmd(req_maj_ver=req_py_majver, req_min_ver=req_py_minver,
                                      max_py_majver=max_py_majver, max_py_minver=max_py_minver)
 
-        if python:
+            # Check if we have python by now. If not, and if self.require_python, raise a sensible error
+            if python:
+                self.python_cmd = python
+                self.log.info("Python command being used: %s", self.python_cmd)
+            elif self.require_python:
+                if (req_py_majver is not None or req_py_minver is not None
+                        or max_py_majver is not None or max_py_minver is not None):
+                    raise EasyBuildError(
+                        "Failed to pick python command that satisfies requirements in the EasyConfigs "
+                        "(req_py_majver = %s, req_py_minver = %s, max_py_majver = %s, max_py_minver = %s)",
+                        req_py_majver, req_py_minver, max_py_majver, max_py_minver
+                    )
+                else:
+                    raise EasyBuildError("Failed to pick Python command to use")
+            else:
+                self.log.warning("No Python command found!")
+        else:
             self.python_cmd = python
             self.log.info("Python command being used: %s", self.python_cmd)
-        elif self.require_python:
-            if (req_py_majver is not None or req_py_minver is not None
-                    or max_py_majver is not None or max_py_minver is not None):
-                raise EasyBuildError(
-                    "Failed to pick python command that satisfies requirements in the EasyConfigs "
-                    "(req_py_majver = %s, req_py_minver = %s, max_py_majver = %s, max_py_minver = %s)",
-                    req_py_majver, req_py_minver, max_py_majver, max_py_minver
-                )
-            else:
-                raise EasyBuildError("Failed to pick Python command to use")
-        else:
-            self.log.warning("No Python command found!")
 
         if self.python_cmd:
             # set Python lib directories

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -515,7 +515,15 @@ class PythonPackage(ExtensionEasyBlock):
             self.python_cmd = python
             self.log.info("Python command being used: %s", self.python_cmd)
         elif self.require_python:
-            raise EasyBuildError("Failed to pick Python command to use")
+            if req_py_majver is not None or req_py_minver is not None:
+                msg = "Failed to pick Python command that satisfies requirements in the EasyConfigs "
+                msg += "(req_maj_ver = %s, req_min_ver = %s)" % (req_maj_ver, req_min_ver)
+                raise EasyBuildError(
+                    "Failed to pick python command that satisfies requirements in the EasyConfigs "
+                    "(req_maj_ver = %s, req_min_ver = %s)", req_maj_ver, req_min_ver
+                )
+            else:
+                raise EasyBuildError("Failed to pick Python command to use")
         else:
             self.log.warning("No Python command found!")
 

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -130,11 +130,11 @@ def pick_python_cmd(req_maj_ver=None, req_min_ver=None, max_py_majver=None, max_
                 log.debug("Minimal requirement for minor Python version not satisfied: %s vs %s", pyver, req_majmin_ver)
                 return False
 
-        if max_maj_ver is not None:
-            if max_min_ver is None:
-                max_majmin_ver = '%s.0' % max_maj_ver
+        if max_py_majver is not None:
+            if max_py_minver is None:
+                max_majmin_ver = '%s.0' % max_py_majver
             else:
-                max_majmin_ver = '%s.%s' % (max_maj_ver, max_min_ver)
+                max_majmin_ver = '%s.%s' % (max_py_majver, max_py_minver)
 
             pyver = det_python_version(python_cmd)
 

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -539,8 +539,8 @@ class PythonPackage(ExtensionEasyBlock):
             if req_py_majver is not None or req_py_minver is not None or max_py_majver is not None or max_py_minver is not None:
                 raise EasyBuildError(
                     "Failed to pick python command that satisfies requirements in the EasyConfigs "
-                    "(req_py_majver = %s, req_py_minver = %s, max_py_majver = %s, max_py_minver = %s)"
-                    , req_py_majver, req_py_minver, max_py_majver, max_py_minver
+                    "(req_py_majver = %s, req_py_minver = %s, max_py_majver = %s, max_py_minver = %s)",
+                    req_py_majver, req_py_minver, max_py_majver, max_py_minver
                 )
             else:
                 raise EasyBuildError("Failed to pick Python command to use")

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -83,7 +83,7 @@ def det_python_version(python_cmd):
     return out.strip()
 
 
-def pick_python_cmd(req_maj_ver=None, req_min_ver=None, max_maj_ver=None, max_min_ver=None):
+def pick_python_cmd(req_maj_ver=None, req_min_ver=None, max_py_majver=None, max_py_minver=None):
     """
     Pick 'python' command to use, based on specified version requirements.
     If the major version is specified, it must be an exact match (==).
@@ -524,9 +524,13 @@ class PythonPackage(ExtensionEasyBlock):
             if req_py_minver is None:
                 req_py_minver = sys.version_info[1]
 
+            # Get the max_py_majver and max_py_minver from the config
+            max_py_majver = self.cfg['max_py_majver']
+            max_py_minver = self.cfg['max_py_minver']
+
             # if using system Python, go hunting for a 'python' command that satisfies the requirements
             python = pick_python_cmd(req_maj_ver=req_py_majver, req_min_ver=req_py_minver,
-                                     max_py_majver=max_py_majver, max_py_minver)
+                                     max_py_majver=max_py_majver, max_py_minver=max_py_minver)
 
         if python:
             self.python_cmd = python

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -514,6 +514,8 @@ class PythonPackage(ExtensionEasyBlock):
                 python = os.path.join(python_root, 'bin', 'python')
                 self.log.debug("Retaining 'python' command for Python dependency: %s", python)
 
+        req_py_majver = None
+        req_py_minver = None
         if python is None:
             # if no Python version requirements are specified,
             # use major/minor version of Python being used in this EasyBuild session

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -139,8 +139,8 @@ def pick_python_cmd(req_maj_ver=None, req_min_ver=None, max_py_majver=None, max_
             pyver = det_python_version(python_cmd)
 
             if LooseVersion(pyver) > LooseVersion(max_majmin_ver):
-                log.debug("Python version (%s) on the system is newer than the maximum python version "
-                          "specified in the easyconfig %s",
+                log.debug("Python version (%s) on the system is newer than the maximum supported "
+                          "Python version specified in the easyconfig (%s)",
                           pyver, max_majmin_ver)
                 return False
 

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -537,7 +537,7 @@ class PythonPackage(ExtensionEasyBlock):
             self.log.info("Python command being used: %s", self.python_cmd)
         elif self.require_python:
             if (req_py_majver is not None or req_py_minver is not None
-                or max_py_majver is not None or max_py_minver is not None):
+                    or max_py_majver is not None or max_py_minver is not None):
                 raise EasyBuildError(
                     "Failed to pick python command that satisfies requirements in the EasyConfigs "
                     "(req_py_majver = %s, req_py_minver = %s, max_py_majver = %s, max_py_minver = %s)",

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -516,11 +516,9 @@ class PythonPackage(ExtensionEasyBlock):
             self.log.info("Python command being used: %s", self.python_cmd)
         elif self.require_python:
             if req_py_majver is not None or req_py_minver is not None:
-                msg = "Failed to pick Python command that satisfies requirements in the EasyConfigs "
-                msg += "(req_maj_ver = %s, req_min_ver = %s)" % (req_maj_ver, req_min_ver)
                 raise EasyBuildError(
                     "Failed to pick python command that satisfies requirements in the EasyConfigs "
-                    "(req_maj_ver = %s, req_min_ver = %s)", req_maj_ver, req_min_ver
+                    "(req_py_majver = %s, req_py_minver = %s)", req_py_majver, req_py_minver
                 )
             else:
                 raise EasyBuildError("Failed to pick Python command to use")

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -138,10 +138,10 @@ def pick_python_cmd(req_maj_ver=None, req_min_ver=None, max_py_majver=None, max_
 
             pyver = det_python_version(python_cmd)
 
-            if LooseVersion(pyver) > LooseVersion(max_majmin_ver)
+            if LooseVersion(pyver) > LooseVersion(max_majmin_ver):
                 log.debug("Python version (%s) on the system is newer than the maximum python version "
                           "specified in the easyconfig %s",
-                           pyver, max_majmin_ver)
+                          pyver, max_majmin_ver)
                 return False
 
         # all check passed

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -536,7 +536,8 @@ class PythonPackage(ExtensionEasyBlock):
             self.python_cmd = python
             self.log.info("Python command being used: %s", self.python_cmd)
         elif self.require_python:
-            if req_py_majver is not None or req_py_minver is not None or max_py_majver is not None or max_py_minver is not None:
+            if (req_py_majver is not None or req_py_minver is not None
+                or max_py_majver is not None or max_py_minver is not None):
                 raise EasyBuildError(
                     "Failed to pick python command that satisfies requirements in the EasyConfigs "
                     "(req_py_majver = %s, req_py_minver = %s, max_py_majver = %s, max_py_minver = %s)",


### PR DESCRIPTION
We implement support for specifying a maximum python version for EasyConfigs that use system python (through the `max_py_majver`, `max_py_minver` keywords). This is is required for  https://github.com/easybuilders/easybuild-easyconfigs/pull/21307 which has one EasyConfig that will only work on the python 3.6 - 3.11 range (3.12 will fail because the setuptools is too old, but newer setuptools do not support `python3.6`).

This PR is built on top of https://github.com/easybuilders/easybuild-easyblocks/pull/3430 . That one should probably be reviewed & merged first, after which this PR should be synced with develop.