### PR TITLE
make sure user packages are not used in sanity check of PythonBundle

### DIFF
--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -155,6 +155,18 @@ class PythonBundle(Bundle):
 
         return txt
 
+    def load_module(self, *args, **kwargs):
+        """
+        Make sure that $PYTHONNOUSERSITE is defined after loading module file for this software."""
+
+        super(PythonBundle, self).load_module(*args, **kwargs)
+
+        # Don't add user site directory to sys.path (equivalent to python -s),
+        # to avoid that any Python packages installed in $HOME/.local/lib affect the sanity check.
+        # Required here to ensure that it is defined for sanity check commands of the bundle
+        # because the environment is reset to the initial environment right before loading the module
+        env.setvar('PYTHONNOUSERSITE', '1', verbose=False)
+
     def sanity_check_step(self, *args, **kwargs):
         """Custom sanity check for bundle of Python package."""
 


### PR DESCRIPTION
Some PythonBundle ECs (e.g. IPython) use custom sanity checks using python. That might pick up python packages installed to the users `$HOME` which can yield wrong results.
We already take care of this for the extensions sanity check in PythonPackage and for installing extensions in PythonBundle.

However for the sanity check of PythonBundle itself the variable is not defined (even if it was defined during the build) as the environment gets reset when loading the module used for the sanity check.

Hence use the same approach used in PythonPackage and set `$PYTHONNOUSERSITE` after loading the module.