### PR TITLE
ignore user python packages by using `-s` option when running Python code via `python -c`

### DIFF
--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -757,7 +757,7 @@ class EB_Clang(CMakeMake):
 
         if self.cfg['python_bindings']:
             custom_paths['files'].extend([os.path.join("lib", "python", "clang", "cindex.py")])
-            custom_commands.extend(["python -c 'import clang'"])
+            custom_commands.extend(["python -s -c 'import clang'"])
 
         super().sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
 

--- a/easybuild/easyblocks/c/cplex.py
+++ b/easybuild/easyblocks/c/cplex.py
@@ -173,7 +173,7 @@ class EB_CPLEX(Binary):
         custom_commands = []
 
         if self.with_python:
-            custom_commands.append("python -c 'import cplex'")
-            custom_commands.append("python -c 'import docplex'")
+            custom_commands.append("python -s -c 'import cplex'")
+            custom_commands.append("python -s -c 'import docplex'")
 
         super().sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)

--- a/easybuild/easyblocks/c/cryptography.py
+++ b/easybuild/easyblocks/c/cryptography.py
@@ -57,5 +57,5 @@ class EB_cryptography(PythonPackage):
         if success:
             # Check module added in v0.7 leading to issue #9446 (see above)
             if LooseVersion(self.version) >= LooseVersion("0.7"):
-                run_shell_cmd("python -c 'from cryptography.hazmat.bindings.openssl import binding'")
+                run_shell_cmd("python -s -c 'from cryptography.hazmat.bindings.openssl import binding'")
         return success, fail_msg

--- a/easybuild/easyblocks/e/esmf.py
+++ b/easybuild/easyblocks/e/esmf.py
@@ -176,6 +176,6 @@ class EB_ESMF(ConfigureMake):
 
         custom_commands = []
         if get_software_root('Python'):
-            custom_commands += ["python -c 'import ESMF'"]
+            custom_commands += ["python -s -c 'import ESMF'"]
 
         super().sanity_check_step(custom_commands=custom_commands, custom_paths=custom_paths)

--- a/easybuild/easyblocks/g/gurobi.py
+++ b/easybuild/easyblocks/g/gurobi.py
@@ -101,7 +101,7 @@ class EB_Gurobi(Tarball):
         ]
 
         if get_software_root('Python'):
-            custom_commands.append("python -c 'import gurobipy'")
+            custom_commands.append("python -s -c 'import gurobipy'")
 
         super().sanity_check_step(custom_commands=custom_commands, custom_paths=custom_paths)
 

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -590,7 +590,7 @@ class EB_LAMMPS(CMakeMake):
         python_dir = get_software_root('Python')
         if python_dir:
             # Find the Python .so lib
-            cmd = 'python -c "import sysconfig; print(sysconfig.get_config_var(\'LDLIBRARY\'))"'
+            cmd = 'python -s -c "import sysconfig; print(sysconfig.get_config_var(\'LDLIBRARY\'))"'
             res = run_shell_cmd(cmd, hidden=True)
             if not res.output:
                 raise EasyBuildError("Failed to determine Python .so library: %s", res.output)
@@ -598,7 +598,7 @@ class EB_LAMMPS(CMakeMake):
             if not python_lib_path:
                 raise EasyBuildError("Could not find path to Python .so library: %s", res.output)
             # and the path to the Python include folder
-            cmd = 'python -c "import sysconfig; print(sysconfig.get_config_var(\'INCLUDEPY\'))"'
+            cmd = 'python -s -c "import sysconfig; print(sysconfig.get_config_var(\'INCLUDEPY\'))"'
             res = run_shell_cmd(cmd, hidden=True)
             if not res.output:
                 raise EasyBuildError("Failed to determine Python include dir: %s", res.output)
@@ -773,7 +773,7 @@ class EB_LAMMPS(CMakeMake):
            LooseVersion(self.cur_version) < LooseVersion(translate_lammps_version('22Jul2025')):
             custom_commands = [cmd + '; l.finalize() if l else None' for cmd in custom_commands]
 
-        custom_commands = ["""python -c '%s'""" % cmd for cmd in custom_commands]
+        custom_commands = ["""python -s -c '%s'""" % cmd for cmd in custom_commands]
 
         # Execute sanity check commands within an initialized MPI in MPI enabled toolchains
         if self.toolchain.options.get('usempi', None):
@@ -853,7 +853,7 @@ def get_cpu_arch():
 
     :return: returns detected cpu architecture
     """
-    res = run_shell_cmd("python -c 'from archspec.cpu import host; print(host())'")
+    res = run_shell_cmd("python -s -c 'from archspec.cpu import host; print(host())'")
     if res.exit_code:
         raise EasyBuildError("Failed to determine CPU architecture: %s", res.output)
     return res.output.strip()

--- a/easybuild/easyblocks/m/mrtrix.py
+++ b/easybuild/easyblocks/m/mrtrix.py
@@ -110,6 +110,6 @@ class EB_MRtrix(EasyBlock):
 
         custom_commands = []
         if LooseVersion(self.version) >= LooseVersion('3.0'):
-            custom_commands.append("python -c 'import mrtrix3'")
+            custom_commands.append("python -s -c 'import mrtrix3'")
 
         super().sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)

--- a/easybuild/easyblocks/n/neuron.py
+++ b/easybuild/easyblocks/n/neuron.py
@@ -175,7 +175,7 @@ class EB_NEURON(CMakeMake):
         ]
 
         if self.python_root:
-            custom_commands.append("python -c 'import neuron; neuron.test()'")
+            custom_commands.append("python -s -c 'import neuron; neuron.test()'")
 
         super().sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
 

--- a/easybuild/easyblocks/n/numexpr.py
+++ b/easybuild/easyblocks/n/numexpr.py
@@ -108,10 +108,10 @@ class EB_numexpr(PythonPackage):
 
         # if Intel MKL is available, make sure VML is used
         if self.imkl_root:
-            custom_commands.append("python -c 'import numexpr; assert(numexpr.use_vml)'")
+            custom_commands.append("python -s -c 'import numexpr; assert(numexpr.use_vml)'")
 
             # for sufficiently recent versions of numexpr, also do a more extensive check for VML support
             if LooseVersion(self.version) >= LooseVersion('2.7.3'):
-                custom_commands.append("""python -c "import numexpr; numexpr.set_vml_accuracy_mode('low')" """)
+                custom_commands.append("""python -s -c "import numexpr; numexpr.set_vml_accuracy_mode('low')" """)
 
         return super().sanity_check_step(custom_commands=custom_commands)

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -417,7 +417,7 @@ class EB_numpy(FortranPythonPackage):
                 "blas_found = numpy_build_deps['blas']['found']",
                 "assert blas_found",
             ])
-            custom_commands.append('python -c "%s"' % blas_check_pytxt)
+            custom_commands.append('python -s -c "%s"' % blas_check_pytxt)
 
             # if FlexiBLAS is used, make sure we are linking to it
             # (rather than directly to a backend library like OpenBLAS or Intel MKL)
@@ -429,7 +429,7 @@ class EB_numpy(FortranPythonPackage):
                     "blas_name = numpy_build_deps['blas']['name']",
                     "assert blas_name == 'flexiblas', 'BLAS library should be flexiblas, found %s' % blas_name",
                 ])
-                custom_commands.append('python -c "%s"' % blas_check_pytxt)
+                custom_commands.append('python -s -c "%s"' % blas_check_pytxt)
 
         elif LooseVersion(self.version) >= LooseVersion('1.10'):
             # generic check to see whether numpy v1.10.x and up was built against a CBLAS-enabled library
@@ -440,10 +440,10 @@ class EB_numpy(FortranPythonPackage):
                 "blas_ok = 'HAVE_CBLAS' in dict(numpy.__config__.blas_opt_info['define_macros'])",
                 "sys.exit((1, 0)[blas_ok])",
             ])
-            custom_commands.append('python -c "%s"' % blas_check_pytxt)
+            custom_commands.append('python -s -c "%s"' % blas_check_pytxt)
         else:
             # _dotblas is required for decent performance of numpy.dot(), but only there in numpy 1.9.x and older
-            custom_commands.append("python -c 'import numpy.core._dotblas'")
+            custom_commands.append("python -s -c 'import numpy.core._dotblas'")
 
         return super().sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
 

--- a/easybuild/easyblocks/o/opencv.py
+++ b/easybuild/easyblocks/o/opencv.py
@@ -250,7 +250,7 @@ class EB_OpenCV(CMakeMake):
 
         custom_commands = []
         if get_software_root('Python'):
-            custom_commands.append("python -c 'import cv2'")
+            custom_commands.append("python -s -c 'import cv2'")
 
         super().sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
 

--- a/easybuild/easyblocks/p/petsc.py
+++ b/easybuild/easyblocks/p/petsc.py
@@ -216,12 +216,12 @@ class EB_PETSc(ConfigureMake):
         if self.with_python:
 
             # enable numpy support, but only if numpy is available
-            res = run_shell_cmd("python -c 'import numpy'", fail_on_error=False)
+            res = run_shell_cmd("python -s -c 'import numpy'", fail_on_error=False)
             if res.exit_code == 0:
                 self.cfg.update('configopts', '--with-numpy=1')
 
             # enable mpi4py support, but only if mpi4py is available
-            res = run_shell_cmd("python -c 'import mpi4py'", fail_on_error=False)
+            res = run_shell_cmd("python -s -c 'import mpi4py'", fail_on_error=False)
             if res.exit_code == 0:
                 with_mpi4py_opt = '--with-mpi4py'
                 if self.cfg['shared_libs'] and with_mpi4py_opt not in self.cfg['configopts']:

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -59,7 +59,7 @@ from easybuild.tools.utilities import trace_msg
 import easybuild.tools.toolchain as toolchain
 
 
-EXTS_FILTER_PYTHON_PACKAGES = ('python -c "import %(ext_name)s"', "")
+EXTS_FILTER_PYTHON_PACKAGES = ('python -s -c "import %(ext_name)s"', "")
 EXTS_FILTER_DUMMY_PACKAGES = ("python -m pip show -q '%(ext_name)s'", "")
 
 # magic value for unlimited stack size
@@ -897,7 +897,7 @@ class EB_Python(ConfigureMake):
         temp_prefix = tempfile.mkdtemp(suffix='-tmp-prefix')
         temp_site_packages_path = os.path.join(temp_prefix, self.site_packages_path)
         mkdir(temp_site_packages_path, parents=True)  # Must exist
-        res = run_shell_cmd("%s=%s python -c 'import sys; print(sys.path)'" % (EBPYTHONPREFIXES, temp_prefix))
+        res = run_shell_cmd("%s=%s python -s -c 'import sys; print(sys.path)'" % (EBPYTHONPREFIXES, temp_prefix))
         out = res.output.strip()
         # Output should be a list which we can evaluate directly
         if not out.startswith('[') or not out.endswith(']'):
@@ -955,7 +955,7 @@ class EB_Python(ConfigureMake):
         abiflags = ''
         if LooseVersion(self.version) >= LooseVersion("3"):
             run_shell_cmd("command -v python", hidden=True)
-            cmd = 'python -c "import sysconfig; print(sysconfig.get_config_var(\'abiflags\'));"'
+            cmd = 'python -s -c "import sysconfig; print(sysconfig.get_config_var(\'abiflags\'));"'
             res = run_shell_cmd(cmd, hidden=True)
             abiflags = res.output
             if not abiflags:
@@ -966,7 +966,7 @@ class EB_Python(ConfigureMake):
         # make sure hashlib is installed correctly, there should be no errors/output when 'import hashlib' is run
         # (python will exit with 0 regardless of whether or not errors are printed...)
         # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/6484
-        cmd = "python -c 'import hashlib'"
+        cmd = "python -s -c 'import hashlib'"
         res = run_shell_cmd(cmd)
         out = res.output
         regex = re.compile('error', re.I)
@@ -1002,9 +1002,9 @@ class EB_Python(ConfigureMake):
         custom_commands = [
             "python --version",
             "python-config --help",  # make sure that symlink was created correctly
-            "python -c 'import _ctypes'",  # make sure that foreign function interface (libffi) works
-            "python -c 'import _ssl'",  # make sure SSL support is enabled one way or another
-            "python -c 'import readline'",  # make sure readline support was built correctly
+            "python -s -c 'import _ctypes'",  # make sure that foreign function interface (libffi) works
+            "python -s -c 'import _ssl'",  # make sure SSL support is enabled one way or another
+            "python -s -c 'import readline'",  # make sure readline support was built correctly
         ]
 
         if self.install_pip:
@@ -1014,8 +1014,8 @@ class EB_Python(ConfigureMake):
                 os.path.join('bin', pip) for pip in ('pip', 'pip' + py_maj_version, 'pip' + self.pyshortver)
             ])
             custom_commands.extend([
-                "python -c 'import pip'",
-                "python -c 'import setuptools'",
+                "python -s -c 'import pip'",
+                "python -s -c 'import setuptools'",
             ])
 
         if get_software_root('Tk'):
@@ -1024,7 +1024,7 @@ class EB_Python(ConfigureMake):
                 tkinter = 'tkinter'
             else:
                 tkinter = 'Tkinter'
-            custom_commands.append("python -c 'import %s'" % tkinter)
+            custom_commands.append("python -s -c 'import %s'" % tkinter)
 
             # check whether _tkinter*.so is found, exact filename doesn't matter
             tkinter_so = os.path.join(self.installdir, 'lib', pyver, 'lib-dynload', '_tkinter*.' + shlib_ext)

--- a/easybuild/easyblocks/q/qscintilla.py
+++ b/easybuild/easyblocks/q/qscintilla.py
@@ -197,6 +197,6 @@ class EB_QScintilla(ConfigureMake):
                 os.path.join('qsci', 'api', 'python'),
                 os.path.join('share', 'sip', self.pyqt_pkg_name),
             ])
-            custom_commands.append("python -c 'import %s.Qsci'" % self.pyqt_pkg_name)
+            custom_commands.append("python -s -c 'import %s.Qsci'" % self.pyqt_pkg_name)
 
         super().sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)

--- a/easybuild/easyblocks/r/root.py
+++ b/easybuild/easyblocks/r/root.py
@@ -117,7 +117,7 @@ class EB_ROOT(CMakeMake):
 
         custom_commands = []
         if get_software_root('Python'):
-            custom_commands.append("python -c 'import ROOT'")
+            custom_commands.append("python -s -c 'import ROOT'")
 
         super().sanity_check_step(custom_commands=custom_commands, custom_paths=custom_paths)
 

--- a/easybuild/easyblocks/t/tbb.py
+++ b/easybuild/easyblocks/t/tbb.py
@@ -220,7 +220,7 @@ class EB_tbb(IntelBase, ConfigureMake):
 
         if self.cfg['with_python']:
             custom_paths['dirs'].append(os.path.join(self.tbb_subdir, 'python'))
-            custom_commands.extend(['python -c "import tbb"'])
+            custom_commands.extend(['python -s -c "import tbb"'])
 
         super().sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
 

--- a/easybuild/easyblocks/t/tkinter.py
+++ b/easybuild/easyblocks/t/tkinter.py
@@ -124,7 +124,7 @@ class EB_Tkinter(EB_Python):
             tkinter = 'tkinter'
         else:
             tkinter = 'Tkinter'
-        custom_commands = ["python -c 'import %s'" % tkinter]
+        custom_commands = ["python -s -c 'import %s'" % tkinter]
 
         if not self.tkinter_so_basename:
             self.tkinter_so_basename = self.get_tkinter_so_basename(True)

--- a/easybuild/easyblocks/t/torchvision.py
+++ b/easybuild/easyblocks/t/torchvision.py
@@ -111,7 +111,7 @@ class EB_torchvision(PythonPackage):
                 "    scores = torch.randn(1).to('cuda')",
                 "    print(torchvision.ops.nms(boxes, scores, 0.5))",
             ])
-            custom_commands.append('python -c "%s"' % python_code)
+            custom_commands.append('python -s -c "%s"' % python_code)
 
         if get_software_root('libjpeg-turbo'):
             # check if torchvision was built with libjpeg support
@@ -121,6 +121,6 @@ class EB_torchvision(PythonPackage):
                 "image_tensor = torch.zeros(1, 1, 1, dtype=torch.uint8)",
                 "print(torchvision.io.image.encode_jpeg(image_tensor))",
             ])
-            custom_commands.append('python -c "%s"' % python_code)
+            custom_commands.append('python -s -c "%s"' % python_code)
 
         return super().sanity_check_step(custom_commands=custom_commands, custom_paths=custom_paths)

--- a/easybuild/easyblocks/v/vmd.py
+++ b/easybuild/easyblocks/v/vmd.py
@@ -96,7 +96,8 @@ class EB_VMD(ConfigureMake):
         # Python locations
         pyver = get_software_version('Python')
         pymajver = pyver.split('.')[0]
-        res = run_shell_cmd("python -c 'import sysconfig; print(sysconfig.get_path(\"include\"))'", fail_on_error=False)
+        res = run_shell_cmd("python -s -c 'import sysconfig; print(sysconfig.get_path(\"include\"))'",
+                            fail_on_error=False)
         if res.exit_code:
             raise EasyBuildError("Failed to determine Python include path: %s", res.output)
         else:
@@ -114,7 +115,7 @@ class EB_VMD(ConfigureMake):
             env.setvar('PYTHON_LIBRARIES', res.output.strip())
 
         # numpy include location, easiest way to determine it is via numpy.get_include()
-        res = run_shell_cmd("python -c 'import numpy; print(numpy.get_include())'", fail_on_error=False)
+        res = run_shell_cmd("python -s -c 'import numpy; print(numpy.get_include())'", fail_on_error=False)
         if res.exit_code:
             raise EasyBuildError("Failed to determine numpy include directory: %s", res.output)
         else:


### PR DESCRIPTION
To avoid the user environment (Python packages installed to $HOME/lib/python*) pass `-s` to all invocations of `python -c`.