### PR TITLE
copy `EasyConfig` instance in constructor of `Bundle` and `Cargo` easyblocks before changes to it

### DIFF
--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -85,6 +85,10 @@ class Bundle(EasyBlock):
             if self.cfg['patches']:
                 raise EasyBuildError("List of patches for bundle itself must be empty, found %s", self.cfg['patches'])
 
+        # copy EasyConfig instance before we make changes to it
+        # (like adding component sources to top-level sources easyconfig parameter)
+        self.cfg = self.cfg.copy()
+
         # disable templating to avoid premature resolving of template values
         self.cfg.enable_templating = False
 

--- a/easybuild/easyblocks/generic/cargo.py
+++ b/easybuild/easyblocks/generic/cargo.py
@@ -151,6 +151,9 @@ class Cargo(ExtensionEasyBlock):
                     'filename': self.crate_src_filename(crate, version),
                 })
 
+        # copy EasyConfig instance before we make changes to it
+        self.cfg = self.cfg.copy()
+
         self.cfg.update('sources', sources)
 
     @property


### PR DESCRIPTION
required to make creating multiple `EasyBlock` instances from one `EasyConfig` instance works as intended + fix https://github.com/easybuilders/easybuild-easyconfigs/issues/21393