### PR TITLE
GCC: Fix NVPTX mapping error when with no CC

### DIFF
--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -383,7 +383,7 @@ class EB_GCC(ConfigureMake):
         architecture_mappings_replacement = "misa=,"
 
         # Determine which compute capabilities are configured. If there are none, return immediately.
-        if cuda_cc_list is None:
+        if not cuda_cc_list:
             return None
         cuda_sm_list = [f"sm_{cc.replace('.', '')}" for cc in cuda_cc_list]
 


### PR DESCRIPTION
When no compute capability is set but NVPTX is enabled, trying to figure out the NVPTX architecture fails with the error:

```
File "easybuild/easyblocks/g/gcc.py", line 431, in map_nvptx_capability
  return sorted_gcc_cc[0]
IndexError: list index out of range
```

The error occurs because of an insufficient check for an unset CUDA compute capability. This commit changes the checked conditions, so that empty lists are also correctly handled.