### PR TITLE
Make `MesonNinja` respect the toolchainopts with buildtype as well as `--debug` and `--optimization` flags

### DIFF
--- a/easybuild/easyblocks/generic/mesonninja.py
+++ b/easybuild/easyblocks/generic/mesonninja.py
@@ -128,7 +128,7 @@ class MesonNinja(EasyBlock):
             'preconfigopts': self.cfg['preconfigopts'],
             'source_dir': build_dir,
             'buildtype': self.build_type(),
-            'optimization': self.optimizatoin(),
+            'optimization': self.optimization(),
             'debug': self.toolchain.options.get('debug', False),
         }
         res = run_shell_cmd(cmd)

--- a/easybuild/easyblocks/generic/mesonninja.py
+++ b/easybuild/easyblocks/generic/mesonninja.py
@@ -127,8 +127,8 @@ class MesonNinja(EasyBlock):
             'installdir': self.installdir,
             'preconfigopts': self.cfg['preconfigopts'],
             'source_dir': build_dir,
-            'buildtype': self.build_type(),
-            'optimization': self.optimization(),
+            'buildtype': self.build_type,
+            'optimization': self.optimization,
             'debug': self.toolchain.options.get('debug', False),
         }
         res = run_shell_cmd(cmd)

--- a/easybuild/easyblocks/generic/mesonninja.py
+++ b/easybuild/easyblocks/generic/mesonninja.py
@@ -121,7 +121,7 @@ class MesonNinja(EasyBlock):
         build_dir = self.cfg.get('build_dir') or self.start_dir
 
         cmd = ("%(preconfigopts)s %(configure_cmd)s --prefix %(installdir)s --buildtype %(buildtype)s %(configopts)s "
-               "--optimization %(optimization)s --debug %(debug)s %(source_dir)s") % {
+               "--optimization %(optimization)s %(debug)s %(source_dir)s") % {
             'configopts': self.cfg['configopts'],
             'configure_cmd': configure_cmd,
             'installdir': self.installdir,
@@ -129,7 +129,7 @@ class MesonNinja(EasyBlock):
             'source_dir': build_dir,
             'buildtype': self.build_type,
             'optimization': self.optimization,
-            'debug': self.toolchain.options.get('debug', False),
+            'debug': '--debug' if self.toolchain.options.get('debug', False) else '',
         }
         res = run_shell_cmd(cmd)
         return res.output

--- a/easybuild/easyblocks/generic/mesonninja.py
+++ b/easybuild/easyblocks/generic/mesonninja.py
@@ -54,7 +54,7 @@ class MesonNinja(EasyBlock):
             'build_dir': [None, "build_dir to pass to meson", CUSTOM],
             'build_cmd': [DEFAULT_BUILD_CMD, "Build command to use", CUSTOM],
             'build_type': [None, "Build type for meson, e.g. release."
-                                 "Replaces use of toolchain options debug, noopt, lowopt", CUSTOM],
+                                 "Replaces use of toolchain options debug, noopt, lowopt, opt", CUSTOM],
             'ndebug': [True, "Sets -Db_ndebug which in turn defines NDEBUG for C/C++ builds."
                              "This disabled costly asserts in code, typical for production.", CUSTOM],
             'configure_cmd': [DEFAULT_CONFIGURE_CMD, "Configure command to use", CUSTOM],
@@ -70,6 +70,8 @@ class MesonNinja(EasyBlock):
             return 0
         elif self.toolchain.options.get('lowopt', False):
             return 1
+        elif self.toolchain.options.get('opt', False):
+            return 3
         else:
             return 2
 


### PR DESCRIPTION
Fixes #3280 

Should also merge https://github.com/easybuilders/easybuild-easyconfigs/pull/21619 once this is merged.

In this version, i double up on both buildtype as well as --optimizationand --debug flags to respect the toolchainopts. I think this will be the better approach, but i haven't tested anything yet.