### PR TITLE
Avoid failure in Python package installation and sanity check when `$PIP_REQUIRE_VIRTUALENV` is set

### DIFF
--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -159,6 +159,8 @@ class PythonBundle(Bundle):
         # Required here to ensure that it is defined for sanity check commands of the bundle
         # because the environment is reset to the initial environment right before loading the module
         env.setvar('PYTHONNOUSERSITE', '1', verbose=False)
+        # Set (again) in case the module changes it
+        env.setvar('PIP_REQUIRE_VIRTUALENV', 'false', verbose=False)
 
     def sanity_check_step(self, *args, **kwargs):
         """Custom sanity check for bundle of Python package."""

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -30,12 +30,11 @@ EasyBuild support for installing a bundle of Python packages, implemented as a g
 import os
 
 from easybuild.easyblocks.generic.bundle import Bundle
-from easybuild.easyblocks.generic.pythonpackage import EXTS_FILTER_PYTHON_PACKAGES, run_pip_check
+from easybuild.easyblocks.generic.pythonpackage import EXTS_FILTER_PYTHON_PACKAGES, run_pip_check, set_py_env_vars
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage, get_pylibdirs, find_python_cmd_from_ec
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option, PYTHONPATH, EBPYTHONPREFIXES
 from easybuild.tools.modules import get_software_root
-import easybuild.tools.environment as env
 
 
 class PythonBundle(Bundle):
@@ -101,8 +100,7 @@ class PythonBundle(Bundle):
 
     def extensions_step(self, *args, **kwargs):
         """Install extensions (usually PythonPackages)"""
-        # don't add user site directory to sys.path (equivalent to python -s)
-        env.setvar('PYTHONNOUSERSITE', '1', verbose=False)
+        set_py_env_vars(self.log)
         super().extensions_step(*args, **kwargs)
 
     def test_step(self):
@@ -149,18 +147,16 @@ class PythonBundle(Bundle):
         return txt
 
     def load_module(self, *args, **kwargs):
+        """(Re)set environment variables after loading module file.
+
+        Required here to ensure the variables are also defined for stand-alone installations,
+        because the environment is reset to the initial environment right before loading the module.
         """
-        Make sure that $PYTHONNOUSERSITE is defined after loading module file for this software."""
 
         super().load_module(*args, **kwargs)
-
-        # Don't add user site directory to sys.path (equivalent to python -s),
-        # to avoid that any Python packages installed in $HOME/.local/lib affect the sanity check.
         # Required here to ensure that it is defined for sanity check commands of the bundle
         # because the environment is reset to the initial environment right before loading the module
-        env.setvar('PYTHONNOUSERSITE', '1', verbose=False)
-        # Set (again) in case the module changes it
-        env.setvar('PIP_REQUIRE_VIRTUALENV', 'false', verbose=False)
+        set_py_env_vars(self.log)
 
     def sanity_check_step(self, *args, **kwargs):
         """Custom sanity check for bundle of Python package."""

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -494,7 +494,7 @@ class PythonPackage(ExtensionEasyBlock):
         env.setvar('XDG_CACHE_HOME', os.path.join(self.builddir, 'xdg-cache-home'))
         self.log.info("Using %s as pip cache directory", os.environ['XDG_CACHE_HOME'])
         # Users or sites may require using a virtualenv for user installations
-        # We need to disable this to be able to install into the modules
+        # We need to disable this to be able to install into the module
         env.setvar('PIP_REQUIRE_VIRTUALENV', 'false')
         # Don't let pip connect to PYPI to check for a new version
         env.setvar('PIP_DISABLE_PIP_VERSION_CHECK', 'true')
@@ -974,6 +974,7 @@ class PythonPackage(ExtensionEasyBlock):
         # required here to ensure that it is defined for stand-alone installations,
         # because the environment is reset to the initial environment right before loading the module
         env.setvar('PYTHONNOUSERSITE', '1', verbose=False)
+        env.setvar('PIP_REQUIRE_VIRTUALENV', 'false', verbose=False)
 
     def sanity_check_step(self, *args, **kwargs):
         """
@@ -997,6 +998,7 @@ class PythonPackage(ExtensionEasyBlock):
         # to avoid that any Python packages installed in $HOME/.local/lib affect the sanity check;
         # see also https://github.com/easybuilders/easybuild-easyblocks/issues/1877
         env.setvar('PYTHONNOUSERSITE', '1', verbose=False)
+        env.setvar('PIP_REQUIRE_VIRTUALENV', 'false', verbose=False)
 
         if self.cfg.get('download_dep_fail', True):
             self.log.info("Detection of downloaded depdenencies enabled, checking output of installation command...")

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -62,6 +62,17 @@ EXTS_FILTER_PYTHON_PACKAGES = ('python -c "import %(ext_name)s"', "")
 # magic value for unlimited stack size
 UNLIMITED = 'unlimited'
 
+# Environment variables and values to avoid common issues during Python package installations and usage in EasyBuild
+PY_ENV_VARS = {
+    # don't add user site directory to sys.path (equivalent to python -s), see https://www.python.org/dev/peps/pep-0370
+    'PYTHONNOUSERSITE': '1',
+    # Users or sites may require using a virtualenv for user installations
+    # We need to disable this to be able to install into modules
+    'PIP_REQUIRE_VIRTUALENV': 'false',
+    # Don't let pip connect to PYPI to check for a new version
+    'PIP_DISABLE_PIP_VERSION_CHECK': 'true',
+}
+
 # We want the following import order:
 # 1. Packages installed into VirtualEnv
 # 2. Packages installed into $EBPYTHONPREFIXES (e.g. our modules)
@@ -235,6 +246,22 @@ def run_pip_check(python_cmd=None, unversioned_packages=None):
 
     if pip_check_errors:
         raise EasyBuildError('\n'.join(pip_check_errors))
+
+
+def set_py_env_vars(log, verbose=False):
+    """Set environment variables required/useful for installing or using Python packages"""
+
+    py_vars = PY_ENV_VARS.copy()
+    # avoid that pip (ab)uses $HOME/.cache/pip
+    # cfr. https://pip.pypa.io/en/stable/reference/pip_install/#caching
+    py_vars['XDG_CACHE_HOME'] = os.path.join(tempfile.gettempdir(), 'xdg-cache-home')
+    # Only set (all) environment variables if any has a different value to
+    # avoid (non)changes (and log messages) for each package in a bundle
+    set_required = any(os.environ.get(name, None) != value for name, value in py_vars.items())
+    if set_required:
+        for name, value in py_vars.items():
+            env.setvar(name, value, verbose=verbose)
+        log.info("Using %s as pip cache directory", os.environ['XDG_CACHE_HOME'])
 
 
 class EB_Python(ConfigureMake):
@@ -423,8 +450,7 @@ class EB_Python(ConfigureMake):
         self.cfg['exts_defaultclass'] = "PythonPackage"
         self.cfg['exts_filter'] = EXTS_FILTER_PYTHON_PACKAGES
 
-        # don't add user site directory to sys.path (equivalent to python -s)
-        env.setvar('PYTHONNOUSERSITE', '1')
+        set_py_env_vars(self.log)
 
         # don't pass down any build/install options that may have been specified
         # 'make' options do not make sense for when building/installing Python libraries (usually via 'python setup.py')
@@ -560,9 +586,8 @@ class EB_Python(ConfigureMake):
                 env.setvar('TCLTK_CFLAGS', '-I%s/include -I%s/include' % (tcl, tk))
                 env.setvar('TCLTK_LIBS', tcltk_libs)
 
-        # don't add user site directory to sys.path (equivalent to python -s)
         # This matters e.g. when python installs the bundled pip & setuptools (for >= 3.4)
-        env.setvar('PYTHONNOUSERSITE', '1')
+        set_py_env_vars(self.log)
 
         super().configure_step()
 

--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -41,7 +41,7 @@ from itertools import chain
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage, det_python_version
-from easybuild.easyblocks.python import EXTS_FILTER_PYTHON_PACKAGES
+from easybuild.easyblocks.python import EXTS_FILTER_PYTHON_PACKAGES, PY_ENV_VARS
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools import LooseVersion
 from easybuild.tools.build_log import EasyBuildError, print_warning
@@ -907,7 +907,7 @@ class EB_TensorFlow(PythonPackage):
             action_env['EBPYTHONPREFIXES'] = INHERIT
 
         # Ignore user environment for Python
-        action_env['PYTHONNOUSERSITE'] = '1'
+        action_env.update(PY_ENV_VARS)
 
         # TF 2 (final) sets this in configure
         if (LooseVersion(self.version) < LooseVersion('2.0')) and self._with_cuda:

--- a/easybuild/easyblocks/t/tensorflow_compression.py
+++ b/easybuild/easyblocks/t/tensorflow_compression.py
@@ -32,6 +32,7 @@ import os
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage
+from easybuild.easyblocks.python import PY_ENV_VARS
 from easybuild.tools import LooseVersion
 from easybuild.tools.modules import get_software_version
 from easybuild.tools.run import run_shell_cmd
@@ -104,7 +105,7 @@ class EB_tensorflow_minus_compression(PythonPackage):
             action_env['EBPYTHONPREFIXES'] = INHERIT
 
         # Ignore user environment for Python
-        action_env['PYTHONNOUSERSITE'] = '1'
+        action_env.update(PY_ENV_VARS)
 
         # Use the same configuration (i.e. environment) for compiling and using host tools
         # This means that our action_envs are (almost) always passed


### PR DESCRIPTION
We already have it for the installation if set by users but if a module sets it (e.g Python) the sanity check will fail