### PR TITLE
Adding RISCV support to build Qt5

### DIFF
--- a/easybuild/easyblocks/q/qt.py
+++ b/easybuild/easyblocks/q/qt.py
@@ -39,7 +39,7 @@ from easybuild.tools.filetools import apply_regex_substitutions
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd_qa
 from easybuild.tools.systemtools import get_cpu_architecture, get_glibc_version, get_shared_lib_ext
-from easybuild.tools.systemtools import AARCH64, POWER
+from easybuild.tools.systemtools import AARCH64, POWER, RISCV64
 
 
 class EB_Qt(ConfigureMake):
@@ -73,7 +73,7 @@ class EB_Qt(ConfigureMake):
         # if no platform is specified, try to derive it based on compiler in toolchain
         elif comp_fam in [toolchain.GCC]:  # @UndefinedVariable
             myarch = get_cpu_architecture()
-            if myarch == AARCH64:
+            if myarch in [AARCH64, RISCV64]:
                 platform = 'linux-g++'
             else:
                 platform = 'linux-g++-64'


### PR DESCRIPTION
If RISCV64 is not explicitly considered, build of Qt5-5.15.13-GCCcore-13.2.0.eb fails with:
`g++: error: unrecognized command-line option -m64`
in RISCV platforms.