### PR TITLE
let `CMakeMake` easyblock also set `Python_EXECUTABLE` option, as well as `Python3_EXECUTABLE` and `Python2_EXECUTABLE` derivatives (when appropriate)

### DIFF
--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -105,8 +105,8 @@ def setup_cmake_env_python_hints(cmake_version):
             setvar('Python2_ROOT_DIR', python_root)
 
 
-def _get_cmake_python_config():
-    """Get the CMake configuration options for Python hints."""
+def get_cmake_python_config_dict():
+    """Get a dictionary with the CMake configuration options for Python hints."""
     options = {}
     python_root = get_software_root('Python')
     if python_root:
@@ -123,14 +123,9 @@ def _get_cmake_python_config():
     return options
 
 
-def get_cmake_python_config_dict():
-    """Get a dictionary with the CMake configuration options for Python hints."""
-    return _get_cmake_python_config()
-
-
 def get_cmake_python_config_str():
     """Get a string with the CMake configuration options for Python hints."""
-    options = _get_cmake_python_config()
+    options = get_cmake_python_config_dict()
     return ' '.join(['-D%s=%s' % (key, value) for key, value in options.items()])
 
 
@@ -327,7 +322,7 @@ class CMakeMake(ConfigureMake):
         options['CMAKE_FIND_USE_PACKAGE_REGISTRY'] = 'OFF'
 
         # ensure CMake uses EB python, not system or virtualenv python
-        options.update(self._get_cmake_python_config())
+        options.update(get_cmake_python_config_dict())
 
         if not self.cfg.get('allow_system_boost', False):
             boost_root = get_software_root('Boost')

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -86,6 +86,7 @@ def setup_cmake_env(tc):
     setvar("CMAKE_INCLUDE_PATH", include_paths)
     setvar("CMAKE_LIBRARY_PATH", library_paths)
 
+
 def setup_cmake_env_python_hints(cmake_version):
     """Convenience function to set CMake hints for FindPython[_2/3] as environment variables.
     Needed to avoid wrong Python being picked up by CMake when not called directly by EasyBuild but as step in a
@@ -102,6 +103,7 @@ def setup_cmake_env_python_hints(cmake_version):
             setvar('Python3_ROOT_DIR', python_root)
         else:
             setvar('Python2_ROOT_DIR', python_root)
+
 
 def _get_cmake_python_config():
     """Get the CMake configuration options for Python hints."""
@@ -120,9 +122,11 @@ def _get_cmake_python_config():
             options['Python2_EXECUTABLE'] = python_exe
     return options
 
+
 def get_cmake_python_config_dict():
     """Get a dictionary with the CMake configuration options for Python hints."""
     return _get_cmake_python_config()
+
 
 def get_cmake_python_config_str():
     """Get a string with the CMake configuration options for Python hints."""

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -284,6 +284,10 @@ class CMakeMake(ConfigureMake):
         # disable CMake user package repository
         options['CMAKE_FIND_USE_PACKAGE_REGISTRY'] = 'OFF'
 
+        # ensure CMake uses PATH to determine python without prioritizing a virtualenv
+        # necessary to pick up on the correct python version when `eb` is run from a virtualenv
+        options['Python3_FIND_VIRTUALENV'] = 'STANDARD'
+
         if not self.cfg.get('allow_system_boost', False):
             boost_root = get_software_root('Boost')
             if boost_root:

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -92,7 +92,8 @@ def setup_cmake_env_python_hints(cmake_version):
     Needed to avoid wrong Python being picked up by CMake when not called directly by EasyBuild but as step in a
     build and no option is provided to set custom CMake variables.
     """
-    cmake_version = det_cmake_version()
+    if cmake_version is None:
+        cmake_version = det_cmake_version()
     if LooseVersion(cmake_version) < '3.12':
         raise EasyBuildError("Setting Python hints for CMake requires CMake version 3.12 or newer")
     python_root = get_software_root('Python')

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -88,9 +88,10 @@ def setup_cmake_env(tc):
 
 
 def setup_cmake_env_python_hints(cmake_version=None):
-    """Convenience function to set CMake hints for FindPython[_2/3] as environment variables.
-    Needed to avoid wrong Python being picked up by CMake when not called directly by EasyBuild but as step in a
-    build and no option is provided to set custom CMake variables.
+    """Set environment variables as hints for CMake to prefer the Python module, if loaded.
+    Useful when there is no way to specify arguments for CMake directly,
+    e.g. when CMake is called from within another build system.
+    Otherwise get_cmake_python_config_[str/dict] should be used instead.
     """
     if cmake_version is None:
         cmake_version = det_cmake_version()
@@ -107,7 +108,7 @@ def setup_cmake_env_python_hints(cmake_version=None):
 
 
 def get_cmake_python_config_dict():
-    """Get a dictionary with the CMake configuration options for Python hints."""
+    """Get a dictionary with CMake configuration options for finding Python if loaded as a module."""
     options = {}
     python_root = get_software_root('Python')
     if python_root:
@@ -125,9 +126,11 @@ def get_cmake_python_config_dict():
 
 
 def get_cmake_python_config_str():
-    """Get a string with the CMake configuration options for Python hints."""
+    """Get CMake configuration arguments for finding Python if loaded as a module.
+    This string is intended to be passed to the invocation of `cmake`.
+    """
     options = get_cmake_python_config_dict()
-    return ' '.join(['-D%s=%s' % (key, value) for key, value in options.items()])
+    return ' '.join('-D%s=%s' % (key, value) for key, value in options.items())
 
 
 class CMakeMake(ConfigureMake):

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -289,10 +289,10 @@ class CMakeMake(ConfigureMake):
         if python_root:
             python_version = LooseVersion(get_software_version('Python'))
             python_exe = os.path.join(python_root, 'bin', 'python')
-            options['Python_EXECUTABLE'] = python_exe
-            # This is needed if someone is still using `find_package(PythonInterp ...)` in their CMakeLists.txt
+            # This is required for (deprecated) `find_package(PythonInterp ...)`
             options['PYTHON_EXECUTABLE'] = python_exe
             # Ensure that both `find_package(Python) and find_package(Python2/3)` work as intended
+            options['Python_EXECUTABLE'] = python_exe
             if python_version >= "3":
                 options['Python3_EXECUTABLE'] = python_exe
             else:

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -87,7 +87,7 @@ def setup_cmake_env(tc):
     setvar("CMAKE_LIBRARY_PATH", library_paths)
 
 
-def setup_cmake_env_python_hints(cmake_version):
+def setup_cmake_env_python_hints(cmake_version=None):
     """Convenience function to set CMake hints for FindPython[_2/3] as environment variables.
     Needed to avoid wrong Python being picked up by CMake when not called directly by EasyBuild but as step in a
     build and no option is provided to set custom CMake variables.

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -336,6 +336,22 @@ class CMakeMake(ConfigureMake):
 
         return out
 
+    def set_cmake_env_vars_python(self):
+        """Convenience function to set CMake hints for FindPython[_2/3] as environment variables.
+        Needed to avoid wrong Python being picked up by CMake when not called directly by EasyBuild but as step in a
+        build and no option is provided to set custom CMake variables.
+        """
+        if LooseVersion(self.cmake_version) < '3.12':
+            raise EasyBuildError("Setting Python hints for CMake requires CMake version 3.12 or newer")
+        python_root = get_software_root('Python')
+        if python_root:
+            python_version = LooseVersion(get_software_version('Python'))
+            setvar('Python_ROOT_DIR', python_root)
+            if python_version >= "3":
+                setvar('Python3_ROOT_DIR', python_root)
+            else:
+                setvar('Python2_ROOT_DIR', python_root)
+
     def test_step(self):
         """CMake specific test setup"""
         # When using ctest for tests (default) then show verbose output if a test fails

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -284,9 +284,19 @@ class CMakeMake(ConfigureMake):
         # disable CMake user package repository
         options['CMAKE_FIND_USE_PACKAGE_REGISTRY'] = 'OFF'
 
-        # ensure CMake uses PATH to determine python without prioritizing a virtualenv
-        # necessary to pick up on the correct python version when `eb` is run from a virtualenv
-        options['Python3_FIND_VIRTUALENV'] = 'STANDARD'
+        # ensure CMake uses EB python, not system or virtualenv python
+        python_root = get_software_root('Python')
+        if python_root:
+            python_version = LooseVersion(get_software_version('Python'))
+            python_exe = os.path.join(python_root, 'bin', 'python')
+            options['Python_EXECUTABLE'] = python_exe
+            # This is needed if someone is still using `find_package(PythonInterp ...)` in their CMakeLists.txt
+            options['PYTHON_EXECUTABLE'] = python_exe
+            # Ensure that both `find_package(Python) and find_package(Python2/3)` work as intended
+            if python_version >= "3":
+                options['Python3_EXECUTABLE'] = python_exe
+            else:
+                options['Python2_EXECUTABLE'] = python_exe
 
         if not self.cfg.get('allow_system_boost', False):
             boost_root = get_software_root('Boost')

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -316,6 +316,8 @@ class CMakeMake(ConfigureMake):
                 options['BOOST_ROOT'] = boost_root
                 options['Boost_NO_SYSTEM_PATHS'] = 'ON'
 
+        self.cmake_options = options
+
         if self.cfg.get('configure_cmd') == DEFAULT_CONFIGURE_CMD:
             self.prepend_config_opts(options)
             command = ' '.join([


### PR DESCRIPTION
## EDIT
Following the thread discussion this has changed from setting `Python3_FIND_VIRTUALENV` to setting `Python_EXECUTABLE` and all its variants in order to force the CMakeMake easyblock to pick up the correct python when loaded as a module.

This would replace:

- #3282

## OLD

This is related to:

- https://github.com/easybuilders/easybuild-easyblocks/pull/3283
- https://github.com/easybuilders/easybuild-easyblocks/pull/3373
- Possibly any CMake build that is invoking `FindPython3` via `find_package(Python3)`

`Python3_FIND_VIRTUALENV` controls how CMake finds the python3 interpreter in case a `virtualenv` or `conda` environment is activated, by default prioritizing the virtual environment.
Setting it to `STANDARD` switch the behavior to looking for python3 in `PATH` which allows the correct python to be found when invoking `eb` from within a virtual environment

No version check has been added as the flag is supported since CMake 3.15 which now is tied to an archived toolchain (GCC 8.3.0 https://docs.easybuild.io/policies/toolchains/)

I think this should always be on by default.
Even if a build process tries to work with virtual environments (eg creating a venv, activating it and tha running cmake trying to use the python from the venv) i think that activating the virtualenv inside the build process would prepend to the PATH and still allow finding the correct python