### PR TITLE
strip leading `local/` from pylibdir where appropriate

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -207,6 +207,15 @@ def det_pylibdir(plat_specific=False, python_cmd=None):
                              cmd, prefix, out, ec)
 
     pylibdir = txt[len(prefix):]
+
+    # Ubuntu 24.04: the pylibdir has a leading local/, which causes issues later
+    # e.g. when symlinking <installdir>/local/* to <installdir>/*
+    # we can safely strip this to get a working installation
+    local = 'local/'
+    if pylibdir.startswith(local):
+        log.info("Removing leading /local from determined pylibdir: %s" % pylibdir)
+        pylibdir = pylibdir[len(local):]
+
     log.debug("Determined pylibdir using '%s': %s", cmd, pylibdir)
     return pylibdir
 


### PR DESCRIPTION
Without this, when trying to use EB to install EasyBuild as a module, I get the following error:
```
== 2024-09-26 13:59:47,138 pythonpackage.py:283 INFO Active Python installation scheme: posix_local
== 2024-09-26 13:59:47,140 pythonpackage.py:302 INFO Found 'local' subdirectory in installation prefix /home/userfs/c/csrv944/.local/easybuild/software/EasyBuild/4.9.4: ['local']
== 2024-09-26 13:59:47,141 pythonpackage.py:305 INFO Subdirectories of /home/userfs/c/csrv944/.local/easybuild/software/EasyBuild/4.9.4/local: ['local', 'lib', 'contrib', 'easybuild', 'etc', 'bin']
== 2024-09-26 13:59:47,404 build_log.py:171 ERROR EasyBuild crashed with an error (at easybuild/tools/build_log.py:111 in caller_info): Failed to install EasyBuild packages: [Errno 22] Invalid argument: '/home/userfs/c/csrv944/.local/easybuild/software/EasyBuild/4.9.4/local' (at easybuild/easyblocks/e/easybuildmeta.py:158 in install_step)
```

the `[Errno 22] Invalid argument` is due to trying to symlink `<installdir>/local/local -> <installdir>/local` which obviously won't work