### PR TITLE
Update VTune EasyBlock to work with v2024 and newer

### DIFF
--- a/easybuild/easyblocks/v/vtune.py
+++ b/easybuild/easyblocks/v/vtune.py
@@ -46,7 +46,9 @@ class EB_VTune(IntelBase):
         # recent versions of VTune are installed to a subdirectory
         self.subdir = ''
         loosever = LooseVersion(self.version)
-        if loosever >= LooseVersion('2021'):
+        if loosever >= LooseVersion('2024'):
+            self.subdir = os.path.join('vtune', '.'.join([str(loosever.version[0]), str(loosever.version[1])]))
+        elif loosever >= LooseVersion('2021'):
             self.subdir = os.path.join('vtune', self.version)
         elif loosever >= LooseVersion('2020'):
             self.subdir = 'vtune_profiler'


### PR DESCRIPTION
In the latest VTune, the path name was changed from `major.minor.patch` to `major.minor`