### PR TITLE
Remove X11 flag fro GROMACS 2023+

### DIFF
--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -354,8 +354,9 @@ class EB_GROMACS(CMakeMake):
             # always specify to use external BLAS/LAPACK
             self.cfg.update('configopts', "-DGMX_EXTERNAL_BLAS=ON -DGMX_EXTERNAL_LAPACK=ON")
 
-            # disable GUI tools
-            self.cfg.update('configopts', "-DGMX_X11=OFF")
+            if gromacs_version < '2023':
+                # disable GUI tools, removed in v2023
+                self.cfg.update('configopts', "-DGMX_X11=OFF")
 
             # convince to build for an older architecture than present on the build node by setting GMX_SIMD CMake flag
             # it does not make sense for Cray, because OPTARCH is defined by the Cray Toolchain


### PR DESCRIPTION
The support for `gmx view` was [removed in version 2023 ](https://github.com/gromacs/gromacs/commit/130cd361333b66dc4d2c51fd406badca73bdf6a8)so X11 is no longer a (optional) dependency.
Don't pass the flag to avoid warnings from CMake about unused params.

I.e.:
```
CMake Warning:
  Manually-specified variables were not used by the project:

    GMX_X11
```
