### PR TITLE
Bugfix for MetalWalls easyblock 

### DIFF
--- a/easybuild/easyblocks/m/metalwalls.py
+++ b/easybuild/easyblocks/m/metalwalls.py
@@ -78,11 +78,12 @@ class EB_MetalWalls(MakeCp):
         # https://gitlab.com/ampere2/metalwalls/-/wikis/install#plumed
         plumed = get_software_root('PLUMED')
         f90wrap = get_software_root('f90wrap')
-        f90wrap_version = get_software_version('f90wrap')
 
         if LooseVersion(self.version) <= LooseVersion('21.06.1'):
-            if LooseVersion(f90wrap_version) > LooseVersion('0.2.13'):
-                raise EasyBuildError('MetalWalls version %s requires f90wrap <= 0.2.13' % self.version)
+            if f90wrap:
+                f90wrap_version = get_software_version('f90wrap')
+                if LooseVersion(f90wrap_version) > LooseVersion('0.2.13'):
+                    raise EasyBuildError('MetalWalls version %s requires f90wrap <= 0.2.13' % self.version)
 
         tpl_rgx = 'alltests\\.append(suite_%s)'
         if plumed:


### PR DESCRIPTION
Fix exception caused by calling `LoosVersion` on `f90wrap_version` even when it is None