### PR TITLE
add missing `return` for customised `install_extension_async` methods in Rserve and Rmpi easyblocks

### DIFF
--- a/easybuild/easyblocks/r/rmpi.py
+++ b/easybuild/easyblocks/r/rmpi.py
@@ -80,4 +80,4 @@ class EB_Rmpi(RPackage):
         """
         self.prepare_rmpi_configureargs()
         # it might be needed to get the R cmd and run it with mympirun...
-        super(EB_Rmpi, self).install_extension_async(*args, **kwargs)
+        return super(EB_Rmpi, self).install_extension_async(*args, **kwargs)

--- a/easybuild/easyblocks/r/rserve.py
+++ b/easybuild/easyblocks/r/rserve.py
@@ -45,4 +45,4 @@ class EB_Rserve(RPackage):
     def install_extension_async(self, *args, **kwargs):
         """Set LIBS environment variable correctly prior to building."""
         self.configurevars = ['LIBS="$LIBS -lpthread"']
-        super(EB_Rserve, self).install_extension_async(*args, **kwargs)
+        return super(EB_Rserve, self).install_extension_async(*args, **kwargs)


### PR DESCRIPTION
This is requires in order to be able to use `--parallel-extensions-install` on `R-bundle-CRAN-2024.06-foss-2023b.eb`, without it we get a hard crash:

```
Traceback (most recent call last):
  File "/usr/lib64/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib64/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/tmp/vsc40023/easybuild-framework/easybuild/main.py", line 801, in <module>
    main_with_hooks()
  File "/tmp/vsc40023/easybuild-framework/easybuild/main.py", line 787, in main_with_hooks
    main(args=args, prepared_cfg_data=(init_session_state, eb_go, cfg_settings))
  File "/tmp/vsc40023/easybuild-framework/easybuild/main.py", line 743, in main
    hooks, do_build)
  File "/tmp/vsc40023/easybuild-framework/easybuild/main.py", line 567, in process_eb_args
    exit_on_failure=exit_on_failure)
  File "/tmp/vsc40023/easybuild-framework/easybuild/main.py", line 175, in build_and_install_software
    raise ec_res['err']
  File "/tmp/vsc40023/easybuild-framework/easybuild/main.py", line 136, in build_and_install_software
    (ec_res['success'], app_log, err_msg, err_code) = build_and_install_one(ec, init_env)
  File "/tmp/vsc40023/easybuild-framework/easybuild/framework/easyblock.py", line 4373, in build_and_install_one
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/tmp/vsc40023/easybuild-framework/easybuild/framework/easyblock.py", line 4241, in run_all_steps
    self.run_step(step_name, step_methods)
  File "/tmp/vsc40023/easybuild-framework/easybuild/framework/easyblock.py", line 4084, in run_step
    step_method(self)()
  File "/tmp/vsc40023/easybuild-framework/easybuild/framework/easyblock.py", line 2973, in extensions_step
    self.install_all_extensions(install=install)
  File "/tmp/vsc40023/easybuild-framework/easybuild/framework/easyblock.py", line 1939, in install_all_extensions
    self.install_extensions_parallel(install=install)
  File "/tmp/vsc40023/easybuild-framework/easybuild/framework/easyblock.py", line 2059, in install_extensions_parallel
    if self.dry_run or ext.async_cmd_task.done():
AttributeError: 'NoneType' object has no attribute 'done'
```