### PR TITLE
fix `enhance_sanity_check` for `PythonPackage`

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -1012,7 +1012,7 @@ class PythonPackage(ExtensionEasyBlock):
         else:
             self.log.debug("Detection of downloaded dependencies not enabled")
 
-        # Use directory usually containg the python packages by default
+        # Use directory usually containing the python packages by default
         # but only for stand-alone installations, not for extensions;
         # this is relevant for installations of Python packages for multiple Python versions (via multi_deps)
         # (we can not pass this via custom_paths, since then the %(pyshortver)s template value will not be resolved)

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -1012,15 +1012,15 @@ class PythonPackage(ExtensionEasyBlock):
         else:
             self.log.debug("Detection of downloaded dependencies not enabled")
 
-        # inject directory path that uses %(pyshortver)s template into default value for sanity_check_paths,
+        # Use directory usually containg the python packages by default
         # but only for stand-alone installations, not for extensions;
         # this is relevant for installations of Python packages for multiple Python versions (via multi_deps)
         # (we can not pass this via custom_paths, since then the %(pyshortver)s template value will not be resolved)
-        if not self.is_extension and not self.cfg['sanity_check_paths'] and kwargs.get('custom_paths') is None:
-            self.cfg['sanity_check_paths'] = {
+        if not self.is_extension:
+            kwargs.setdefault('custom_paths', {
                 'files': [],
                 'dirs': [os.path.join('lib', 'python%(pyshortver)s', 'site-packages')],
-            }
+            })
 
         # make sure 'exts_filter' is defined, which is used for sanity check
         if self.multi_python:


### PR DESCRIPTION
When trying to add, not replace paths/commands for the sanity check of Python packages the default `lib/python/%(pyshortver)s/site-packages` gets replaced.
This leads to duplicating this in many easyconfigs. Use the `custom_paths` argument for that but still honor if that is given from a child class.

- [x] Requires https://github.com/easybuilders/easybuild-framework/pull/4679