### PR TITLE
Fix handling of maximum Python version in `pick_python_cmd` function in `PythonPackage` easyblock + require that maximum major Python version is specified if maximum minor Python version is specified

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -194,8 +194,9 @@ def find_python_cmd(log, req_py_majver, req_py_minver, max_py_majver, max_py_min
         # if no Python version requirements are specified,
         # use major/minor version of Python being used in this EasyBuild session
         if req_py_majver is None:
+            if req_py_minver is not None:
+                raise EasyBuildError("'req_py_majver' must be specified when 'req_py_minver' is set!")
             req_py_majver = sys.version_info[0]
-        if req_py_minver is None:
             req_py_minver = sys.version_info[1]
         # if using system Python, go hunting for a 'python' command that satisfies the requirements
         python = pick_python_cmd(req_maj_ver=req_py_majver, req_min_ver=req_py_minver,

--- a/test/easyblocks/module.py
+++ b/test/easyblocks/module.py
@@ -233,12 +233,20 @@ class ModuleOnlyTest(TestCase):
         tmpdir = tempfile.mkdtemp()
         for cmd in ('python2', 'python2.6'):
             install_fake_command(cmd, "#!/bin/bash\n echo 2.6.4", tmpdir)
-        self.assertTrue(pick_python_cmd() is not None)
-        self.assertTrue(pick_python_cmd(3) is not None)
-        self.assertTrue(pick_python_cmd(3, 6) is not None)
-        self.assertTrue(pick_python_cmd(123, 456) is None)
-        self.assertTrue(pick_python_cmd(3, 6, 123, 456) is not None)
-        self.assertTrue(pick_python_cmd(2, 6, 1, 1) is None)
+        self.assertIsNotNone(pick_python_cmd())
+        self.assertIsNotNone(pick_python_cmd(3))
+        self.assertIsNotNone(pick_python_cmd(3, 6))
+        self.assertIsNone(pick_python_cmd(123, 456))
+        self.assertIsNotNone(pick_python_cmd(2, 6, 123, 456))
+        self.assertIsNotNone(pick_python_cmd(2, 6, 2))
+        self.assertIsNone(pick_python_cmd(2, 6, 1, 1))
+        maj_ver, min_ver = sys.version_info[0:2]
+        self.assertIsNotNone(pick_python_cmd(maj_ver, min_ver))
+        self.assertIsNotNone(pick_python_cmd(maj_ver, min_ver, max_py_majver=maj_ver))
+        self.assertIsNotNone(pick_python_cmd(maj_ver, min_ver, max_py_majver=maj_ver, max_py_minver=min_ver))
+        self.assertIsNotNone(pick_python_cmd(maj_ver, min_ver, max_py_majver=maj_ver, max_py_minver=min_ver + 1))
+        self.assertIsNone(pick_python_cmd(maj_ver, min_ver, max_py_majver=maj_ver - 1))
+        self.assertIsNone(pick_python_cmd(maj_ver, min_ver, max_py_majver=maj_ver, max_py_minver=min_ver - 1))
 
 
 def template_module_only_test(self, easyblock, name, version='1.3.2', extra_txt='', tmpdir=None):


### PR DESCRIPTION
When the minor version is unset, only the major version must be checked.
Otherwise patch versions etc. must be ignored.
This allows:
3.7.4 for "max_py_majver=3" and "max_py_majver=3 max_py_minver=7"

However I'd argue that our current approach with `max_py_maj/minver` and `req_py_maj/minver` is error-prone anyway: It does not make sense to only specify a minor version for either. Hence I'd change that easyconfig parameter into a single one: `required_python_version` which is a string like "3.7", same for the max version.   
This can then be converted to a `LooseVersion` and fully avoids the possibility of missing major versions as well as having only a single parameter instead of 2. We can convert the current parameters to the new one automatically and deprecate them for 5.1 or IMO better just remove them for 5.0 as currently ReFrame is the only EC using this and it is trivial to update.

- [x] Requires https://github.com/easybuilders/easybuild-easyblocks/pull/3432