### PR TITLE
disable CPU-specific optimizations for generic builds (by using a custom `processor_arch`) in LAMMPS easyblock

### DIFF
--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -590,10 +590,11 @@ def get_kokkos_arch(kokkos_cpu_mapping, cuda_cc, kokkos_arch, cuda=None):
         else:
             processor_arch = 'EASYBUILD_GENERIC'
 
-        warning_msg = "Generic build requested, setting CPU ARCH to %s." % processor_arch
+        self.log.info("Generic build requested, setting CPU ARCH to %s." % processor_arch)
         if kokkos_arch:
-            warning_msg += " The specified kokkos_arch (%s) will be ignored." % kokkos_arch
-        print_warning(warning_msg)
+            msg = "The specified kokkos_arch (%s) will be ignored " % kokkos_arch
+            msg += "because a generic build was requested (via --optarch=GENERIC)"
+            print_warning(msg)
     elif kokkos_arch:
         if kokkos_arch not in KOKKOS_CPU_ARCH_LIST:
             warning_msg = "Specified CPU ARCH (%s) " % kokkos_arch

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -34,7 +34,6 @@ import glob
 import os
 import re
 import tempfile
-import textwrap
 import copy
 from easybuild.tools import LooseVersion
 

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -45,7 +45,7 @@ from easybuild.tools.config import build_option
 from easybuild.tools.filetools import copy_dir, mkdir
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
-from easybuild.tools.systemtools import get_cpu_architecture, get_shared_lib_ext
+from easybuild.tools.systemtools import AARCH64, get_cpu_architecture, get_shared_lib_ext
 from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
 
 from easybuild.easyblocks.generic.cmakemake import CMakeMake

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -34,6 +34,7 @@ import glob
 import os
 import re
 import tempfile
+import textwrap
 import copy
 from easybuild.tools import LooseVersion
 
@@ -46,6 +47,7 @@ from easybuild.tools.filetools import copy_dir, mkdir
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
+from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
 
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 
@@ -579,7 +581,14 @@ def get_kokkos_arch(kokkos_cpu_mapping, cuda_cc, kokkos_arch, cuda=None):
 
     processor_arch = None
 
-    if kokkos_arch:
+    if build_option('optarch') == OPTARCH_GENERIC:
+        processor_arch = 'EASYBUILD_GENERIC'
+        warning_msg = "Generic build requested, so setting CPU ARCH to "
+        warning_msg += "custom value EASYBUILD_GENERIC to prevent CPU optimizations."
+        if kokkos_arch:
+            warning_msg += " The specified kokkos_arch (%s) will be ignored." % kokkos_arch
+        print_warning(warning_msg)
+    elif kokkos_arch:
         if kokkos_arch not in KOKKOS_CPU_ARCH_LIST:
             warning_msg = "Specified CPU ARCH (%s) " % kokkos_arch
             warning_msg += "was not found in listed options [%s]." % KOKKOS_CPU_ARCH_LIST

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -39,6 +39,7 @@ from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain
+from easybuild.base import fancylogger
 from easybuild.framework.easyconfig import CUSTOM, MANDATORY
 from easybuild.tools.build_log import EasyBuildError, print_warning, print_msg
 from easybuild.tools.config import build_option
@@ -153,6 +154,8 @@ KOKKOS_GPU_ARCH_TABLE = {
 
 # lammps version, which caused the most changes. This may not be precise, but it does work with existing easyconfigs
 ref_version = '29Sep2021'
+
+_log = fancylogger.getLogger('easyblocks.lammps')
 
 
 def translate_lammps_version(version):
@@ -590,7 +593,7 @@ def get_kokkos_arch(kokkos_cpu_mapping, cuda_cc, kokkos_arch, cuda=None):
         else:
             processor_arch = 'EASYBUILD_GENERIC'
 
-        self.log.info("Generic build requested, setting CPU ARCH to %s." % processor_arch)
+        _log.info("Generic build requested, setting CPU ARCH to %s." % processor_arch)
         if kokkos_arch:
             msg = "The specified kokkos_arch (%s) will be ignored " % kokkos_arch
             msg += "because a generic build was requested (via --optarch=GENERIC)"

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -38,7 +38,6 @@ import copy
 from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
-import easybuild.tools.systemtools as systemtools
 import easybuild.tools.toolchain as toolchain
 from easybuild.framework.easyconfig import CUSTOM, MANDATORY
 from easybuild.tools.build_log import EasyBuildError, print_warning, print_msg

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -586,7 +586,7 @@ def get_kokkos_arch(kokkos_cpu_mapping, cuda_cc, kokkos_arch, cuda=None):
         # this ensures that KOKKOS_ARCH_ARM_NEON is enabled (Neon is required for armv8-a).
         # For other architectures we set a custom/non-existent type, which will disable all optimizations,
         # and it should use the compiler (optimization) flags set by EasyBuild for this architecture.
-        if get_cpu_architecture() == systemtools.AARCH64:
+        if get_cpu_architecture() == AARCH64:
             processor_arch = 'ARMV80'
         else:
             processor_arch = 'EASYBUILD_GENERIC'


### PR DESCRIPTION
LAMMPS uses archspec to determine the CPU type and it will enable optimizations for this CPU accordingly, even if `optarch` is set to `GENERIC`. See for instance this EESSI issue which demonstrates/explains it in some more detail:
https://github.com/EESSI/software-layer/issues/545

This PR tries to solve that by overriding the CPU mapping for generic builds and using a custom CPU target `EASYBUILD_GENERIC` for these builds. By using a non-existent CPU type, all CPU-specific optimizations in these `IF(KOKKOS_ARCH_*)` statements in https://github.com/lammps/lammps/blob/stable_29Aug2024/lib/kokkos/cmake/kokkos_arch.cmake will be skipped, and hence no compiler optimization should be enabled. By default, they're all disabled. Furthermore, the compiler flags set by Easybuild, including the optimization flags for generic builds defined at https://github.com/easybuilders/easybuild-framework/blob/develop/easybuild/toolchains/compiler/gcc.py#L101, should be forwarded to the build step, which should result in properly built generic binaries.

I had to make one exception here for Arm, since Neon seems to be (sort of?) required for armv8-a,  see https://developer.arm.com/documentation/ka005463/latest/. If we would use `EASYBUILD_GENERIC` for Arm as  well, LAMMPS would automatically set `KOKKOS_ARCH_ARM_NEON=OFF`, which will disable Neon include statements. By using the existing `ARMV80` target (which is basically a generic Arm build anyway), this feature is enabled, see https://github.com/lammps/lammps/blob/stable_29Aug2024/lib/kokkos/cmake/kokkos_arch.cmake#L246.

Note: I have only tested this with the latest LAMMPS version on `x86_64` and `riscv64` so far (and will upload test reports), but I'll try to do some additional tests builds on at least Arm as well.