### PR TITLE
generate version from the source files when using `software-commit`

### DIFF
--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -265,10 +265,6 @@ class EB_LAMMPS(CMakeMake):
     def configure_step(self, **kwargs):
         """Custom configuration procedure for LAMMPS."""
 
-        # DEBUG
-        print("Is there anything more here in the configure step: ", dir(self))
-        # DEBUG
-
         if not get_software_root('VTK'):
             if self.cfg['user_packages']:
                 self.cfg['user_packages'] = [x for x in self.cfg['user_packages'] if x != 'VTK']

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -154,11 +154,6 @@ KOKKOS_GPU_ARCH_TABLE = {
 ref_version = '29Sep2021'
 
 
-def generate_cur_version(items):
-    """Generate computer readable version"""
-    
-
-
 def translate_lammps_version(version, path=""):
     """Translate the LAMMPS version into something that can be used in a comparison"""
     month_map = {
@@ -166,6 +161,8 @@ def translate_lammps_version(version, path=""):
        "FEB": '02',
        "MAR": '03',
        "APR": '04',
+       "MAY": '05',
+       "JUN": '06',
        "JUL": '07',
        "AUG": '08',
        "SEP": '09',
@@ -173,10 +170,6 @@ def translate_lammps_version(version, path=""):
        "NOV": '11',
        "DEC": '12'
     }
-    # create a function that does the split and returns cur_version
-    # Than this can simply be tried once if the first one fails than it goes looking in the lammps file
-    # If I just do a try and except than I also get rit of the stupid len check 
-    # because this one is already not doing a very good check since a previous update of the EasyBlock
     items = [x for x in re.split('(\\d+)', version) if x]
     if len(items) < 3:
         raise ValueError("Version %s does not have (at least) 3 elements" % version)

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -199,10 +199,6 @@ class EB_LAMMPS(CMakeMake):
         """LAMMPS easyblock constructor: determine whether we should build with CUDA support enabled."""
         super(EB_LAMMPS, self).__init__(*args, **kwargs)
 
-        # DEBUG
-        print("I don't know if this exhists: ", dir(self.start_dir))
-        # DEBUG
-
         cuda_dep = 'cuda' in [dep['name'].lower() for dep in self.cfg.dependencies()]
         cuda_toolchain = hasattr(self.toolchain, 'COMPILER_CUDA_FAMILY')
         self.cuda = cuda_dep or cuda_toolchain
@@ -238,9 +234,6 @@ class EB_LAMMPS(CMakeMake):
         """Custom prepare step for LAMMPS."""
         super(EB_LAMMPS, self).prepare_step(*args, **kwargs)
 
-        # DEBUG
-        print("Is there anything more here in the prepare step: ", self.start_dir)
-
         # version 1.3.2 is used in the test suite to check easyblock can be initialised
         if self.version != '1.3.2':
             self.cur_version = translate_lammps_version(self.version, path=self.start_dir)
@@ -263,7 +256,6 @@ class EB_LAMMPS(CMakeMake):
 
         self.kokkos_cpu_mapping = copy.deepcopy(KOKKOS_CPU_MAPPING)
         self.update_kokkos_cpu_mapping()
-        # DEBUG
 
         # Unset LIBS when using both KOKKOS and CUDA - it will mix lib paths otherwise
         if self.cfg['kokkos'] and self.cuda:
@@ -709,4 +701,3 @@ def get_cpu_arch():
     if ec:
         raise EasyBuildError("Failed to determine CPU architecture: %s", out)
     return out.strip()
-

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -261,15 +261,6 @@ class EB_LAMMPS(CMakeMake):
         if self.cfg['kokkos'] and self.cuda:
             env.unset_env_vars(['LIBS'])
 
-    def update_kokkos_cpu_mapping(self):
-
-        if LooseVersion(self.cur_version) >= LooseVersion(translate_lammps_version('31Mar2017')):
-            self.kokkos_cpu_mapping['neoverse_n1'] = 'ARMV81'
-            self.kokkos_cpu_mapping['neoverse_v1'] = 'ARMV81'
-
-        if LooseVersion(self.cur_version) >= LooseVersion(translate_lammps_version('21sep2021')):
-            self.kokkos_cpu_mapping['a64fx'] = 'A64FX'
-            self.kokkos_cpu_mapping['zen4'] = 'ZEN3'
 
     def configure_step(self, **kwargs):
         """Custom configuration procedure for LAMMPS."""


### PR DESCRIPTION
Please do not merge this one untill these two are merged I will update the easyBlock as they are. the new additions is so that LAMMPS can be used with --software-commit for https://github.com/EESSI/dev.eessi.io-example.
- [ ] https://github.com/easybuilders/easybuild-easyblocks/pull/3484
- [ ] https://github.com/easybuilders/easybuild-easyblocks/pull/3321

Currently `--module-only` does not work when the correct version is not specified.