### PR TITLE
flesh out logic to determine location to binutils commands into a standalone function `det_binutils_bin_path` in TensorFlow easyblock, and leverage it from jaxlib easyblock

### DIFF
--- a/easybuild/easyblocks/j/jaxlib.py
+++ b/easybuild/easyblocks/j/jaxlib.py
@@ -37,6 +37,7 @@ from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage
+from easybuild.easyblocks.tensorflow import det_binutils_bin_path
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import apply_regex_substitutions, which
@@ -68,12 +69,9 @@ class EB_jaxlib(PythonPackage):
 
         super(EB_jaxlib, self).configure_step()
 
-        binutils_root = get_software_root('binutils')
-        if not binutils_root:
-            raise EasyBuildError("Failed to determine installation prefix for binutils")
         config_env_vars = {
             # This is the binutils bin folder: https://github.com/tensorflow/tensorflow/issues/39263
-            'GCC_HOST_COMPILER_PREFIX': os.path.join(binutils_root, 'bin'),
+            'GCC_HOST_COMPILER_PREFIX': det_binutils_bin_path(),
         }
 
         # Collect options for the build script


### PR DESCRIPTION
This is required to be able to install `jaxlib` extension of `jax` when using RPATH + alternate sysroot (like we do in EESSI)