### PR TITLE
Modularized getting of CMake options

### DIFF
--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -347,7 +347,6 @@ class CMakeMake(ConfigureMake):
 
         return options
 
-
     def configure_step(self, srcdir=None, builddir=None):
         """Configure build using cmake"""
 
@@ -387,7 +386,7 @@ class CMakeMake(ConfigureMake):
             if '-DBUILD_SHARED_LIBS=' in self.cfg['configopts']:
                 print_warning('Ignoring BUILD_SHARED_LIBS is set in configopts because build_shared_libs is set')
             self.cfg.update('configopts', '-DBUILD_SHARED_LIBS=%s' % ('ON' if build_shared_libs else 'OFF'))
-            
+
         # If the cache does not exist CMake reads the environment variables
         cache_exists = os.path.exists('CMakeCache.txt')
 

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -282,11 +282,6 @@ class CMakeMake(ConfigureMake):
                 'CXX': 'CMAKE_CXX_COMPILER',
                 'F90': 'CMAKE_Fortran_COMPILER',
             })
-        else:
-            # Set the variable which CMake uses to init the compiler using F90 for backward compatibility
-            fc = os.getenv('F90')
-            if fc:
-                setvar('FC', fc)
 
         # Flags are read from environment variables already since at least CMake 2.8.0
         if LooseVersion(self.cmake_version) < LooseVersion('2.8.0') or cache_exists:


### PR DESCRIPTION
This PR aims to be a followup of:

- https://github.com/easybuilders/easybuild-easyblocks/pull/3463

by modularizing not only the getting of the CMake options for Python but all of them.
The idea is to allow other easyblocks inheriting from CMakeMake to get the same options as in the base easyblock without having to call the `configure` method first.

An example usecase where this would be useful is the new LLVM easyblock:

- https://github.com/easybuilders/easybuild-easyblocks/pull/3373

where due to the complex logic across stages of compilation it is handy to have all the options in a `dict` instead of working with `self.cfg` and `configopts`.
This still cannot be achieved by just storing the options in a class variable as in #3463 as other options needs to be set beside the base one before running CMake

The only minor distinction in the new function is the setting of `BUILD_SHARED_LIBS` which should not alter the behavior of CMakeMake as options already set in `configopts` will take precedence over those in `options` (https://github.com/easybuilders/easybuild-easyblocks/blob/3a6cb1a4c968d39a49dbd73de660514d69061e29/easybuild/easyblocks/generic/cmakemake.py#L205-L206)

Manually tested with:

- GROMACS-2023.3-foss-2023a.eb
- btllib-1.7.0-GCC-12.3.0.eb
- CVXPY-1.4.2-foss-2023a.eb
- FlexiBLAS-3.3.1-GCC-12.3.0.eb 
- fmt-10.0.0-GCCcore-12.3.0.eb
- googletest-1.13.0-GCCcore-12.3.0.eb