### PR TITLE
fix check in Score-P's configure scripts that may fail if the path to certain dependencies include `yes` or `no`

### DIFF
--- a/easybuild/easyblocks/s/score_p.py
+++ b/easybuild/easyblocks/s/score_p.py
@@ -61,6 +61,7 @@ class EB_Score_minus_P(ConfigureMake):
                 (r'_lib}\${with_', '_lib},${with_'),
             ]
             configure_scripts = [
+                os.path.join(self.start_dir, 'build-backend', 'configure'),
                 os.path.join(self.start_dir, 'build-mpi', 'configure'),
                 os.path.join(self.start_dir, 'build-shmem', 'configure'),
             ]

--- a/easybuild/easyblocks/s/score_p.py
+++ b/easybuild/easyblocks/s/score_p.py
@@ -57,10 +57,13 @@ class EB_Score_minus_P(ConfigureMake):
             # Let configure scripts specifically check for yes|no instead of *yes*|*no*,
             # to prevent errors for certain dependencies installed in a path that includes "yes" or "no"
             # see https://gitlab.com/score-p/scorep/-/issues/1008
-            yes_no_regex = (r'\*yes\*\|\*no\*', r'yes,\*\|no,\*\|\*,yes\|\*,no')
+            yes_no_regex = [
+                (r'\*yes\*\|\*no\*', 'yes,*|no,*|*,yes|*,no'),
+                (r'_lib}\${with_', '_lib},${with_'),
+            ]
             configure_scripts = glob.glob(os.path.join(self.start_dir, 'build-*', 'configure'))
             for configure_script in configure_scripts:
-                apply_regex_substitutions(configure_script, [yes_no_regex])
+                apply_regex_substitutions(configure_script, yes_no_regex)
 
         # Remove some settings from the environment, as they interfere with
         # Score-P's configure magic...

--- a/easybuild/easyblocks/s/score_p.py
+++ b/easybuild/easyblocks/s/score_p.py
@@ -53,9 +53,8 @@ class EB_Score_minus_P(ConfigureMake):
         """Configure the build, set configure options for compiler, MPI and dependencies."""
 
         if LooseVersion(self.version) >= LooseVersion('8.0') and LooseVersion(self.version) < LooseVersion('8.5'):
-            # Let configure scripts specifically check for yes|no instead of *yes*|*no*,
-            # to prevent errors for certain dependencies installed in a path that includes "yes" or "no"
-            # see https://gitlab.com/score-p/scorep/-/issues/1008
+            # Fix an issue where the configure script would fail if certain dependencies are installed in a path
+            # that includes "yes" or "no", see https://gitlab.com/score-p/scorep/-/issues/1008.
             yes_no_regex = [
                 (r'\*yes\*\|\*no\*', 'yes,*|no,*|*,yes|*,no'),
                 (r'_lib}\${with_', '_lib},${with_'),

--- a/easybuild/easyblocks/s/score_p.py
+++ b/easybuild/easyblocks/s/score_p.py
@@ -57,7 +57,7 @@ class EB_Score_minus_P(ConfigureMake):
             # Let configure scripts specifically check for yes|no instead of *yes*|*no*,
             # to prevent errors for certain dependencies installed in a path that includes "yes" or "no"
             # see https://gitlab.com/score-p/scorep/-/issues/1008
-            yes_no_regex = (r'\*yes\*\|\*no\*', r'yes|no')
+            yes_no_regex = (r'\*yes\*\|\*no\*', r'yes,\*\|no,\*\|\*,yes\|\*,no')
             configure_scripts = glob.glob(os.path.join(self.start_dir, 'build-*', 'configure'))
             for configure_script in configure_scripts:
                 apply_regex_substitutions(configure_script, [yes_no_regex])

--- a/easybuild/easyblocks/s/score_p.py
+++ b/easybuild/easyblocks/s/score_p.py
@@ -32,7 +32,6 @@ implemented as an easyblock.
 @author: Alexander Grund (TU Dresden)
 @author: Christian Feld (Juelich Supercomputing Centre)
 """
-import glob
 import os
 
 import easybuild.tools.toolchain as toolchain
@@ -61,7 +60,10 @@ class EB_Score_minus_P(ConfigureMake):
                 (r'\*yes\*\|\*no\*', 'yes,*|no,*|*,yes|*,no'),
                 (r'_lib}\${with_', '_lib},${with_'),
             ]
-            configure_scripts = glob.glob(os.path.join(self.start_dir, 'build-*', 'configure'))
+            configure_scripts = [
+                os.path.join(self.start_dir, 'build-mpi', 'configure'),
+                os.path.join(self.start_dir, 'build-shmem', 'configure'),
+            ]
             for configure_script in configure_scripts:
                 apply_regex_substitutions(configure_script, yes_no_regex)
 

--- a/easybuild/easyblocks/s/score_p.py
+++ b/easybuild/easyblocks/s/score_p.py
@@ -35,8 +35,6 @@ implemented as an easyblock.
 import glob
 import os
 
-from easybuild.tools import LooseVersion
-
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools import LooseVersion


### PR DESCRIPTION
This prevents issues with dependencies located in paths containing `yes` or `no`, see:
https://gitlab.com/score-p/scorep/-/issues/1008

I'm restricting this to versions 8.0-8.4, as @Thyre mentioned that it will probably be fixed soon, and version 7 doesn't seem to have this check.