### PR TITLE
tweak libpaths by adding directory containing libnccl.so.2

### DIFF
--- a/easybuild/easyblocks/t/tensorflow.py
+++ b/easybuild/easyblocks/t/tensorflow.py
@@ -562,6 +562,13 @@ class EB_TensorFlow(PythonPackage):
         tensorrt_root = get_software_root('TensorRT')
         nccl_root = get_software_root('NCCL')
 
+        # add path to libnccl.so.2 directory provided by NCCL when both sysroot
+        # and RPATH are used (such as in EESSI)
+        if build_option('sysroot') and self.toolchain.use_rpath:
+            libpaths = self.system_libs_info[2]
+            libpaths.append(os.path.join(nccl_root, 'lib'))
+            self.system_libs_info[2] = libpaths
+
         self._with_cuda = bool(cuda_root)
 
         config_env_vars = {


### PR DESCRIPTION
When building `TensorFlow-2.15.1-foss-2023a-CUDA-12.1.1.eb` for EESSI we hit an error that `libnccl.so.2` wasn't found in 533 test cases. In the backtrace we saw the following (# number of occurrences):

```python
    from tensorflow.python.platform import _pywrap_cpu_feature_guard # 515
    from tensorflow.python import _pywrap_py_exception_registry # 16
    from tensorflow.python.framework import _errors_test_helper # 2
```
The corresponding shared libraries for the imports are
- `_pywrap_cpu_feature_guard.so`,
- `_pywrap_py_exception_registry.so`, and
- `_errors_test_helper.so`.

While `_pywrap_py_exception_registry.so` depends on `libnccl.so.2` directly, the other two depend on `_pywrap_tensorflow_internal.so` which depends on `libnccl.so.2` directly. Regardless of these dependency graph differences, the underlying issue causing the import error seems to be the same.

The problem seems to be caused by a combination of factors (below the list we illustrate the issue):
- The RPATH section of `_pywrap_tensorflow_internal.so` or `_pywrap_py_exception_registry.so` contains a _relative_ path to a location that contains `libnccl.so.2` (via something like `$ORIGIN/../...`)
- However, it seems that this relative path is applied to the wrong base directory. In that base directory, the shared library `_pywrap_tensorflow_internal.so` or `_pywrap_py_exception_registry.so` is actually a symbolic link to another directory.
- Following the relative path (e.g., some `$ORIGIN/../...` in the RPATH header) from that other directory, the shared library `libnccl.so.2` is found.
- The easyblock implemented by `tensorflow.py` does not add the absolute directory that contains `libnccl.so.2` and which is provided by EESSI (e.g., `/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/accel/nvidia/cc80/software/NCCL/2.18.3-GCCcore-12.3.0-CUDA-12.1.1/lib`) to `system_libs_info[2]` and thus this absolute location doesn't get added to `LIBRARY_PATH` which is then used by the RPATH wrapper linker script. The absolute location to the NCCL installation is derived in the `tensorflow.py` easyblock (see variable `nccl_root`) and stored in some `NCCL_INSTALL_PATH` variable in many/all command invocations. The directory containing `libnccl.so.2` could easily be obtained as `os.path.join(nccl_root, 'lib')`.
- The installation procedure for TensorFlow knows the location of `libnccl.so.2` and seems to copy the file to some "internal" location and then uses that location to add some relative paths to the RPATH section in libraries that depend on it. However, since the absolute location is fixed for EESSI (for specific architecture), this absolute location could be used.

This PR does the latter, it adds the known absolute location to `libnccl.so.2` to the RPATH section of shared libraries (via the RPATH linker wrappers).

Maybe there are other/better ways to do this - using the known absolute path to `libnccl.so.2` and make the RPATH linker wrapper aware of it.

Illustrating the issue (via the import error for `_pywrap_py_exception_registry`):
- Error
```
FAIL: //tensorflow/python/kernel_tests/sparse_ops:sparse_slice_op_test (see /dev/shm/tmp/easybuild/build/TensorFlow/2.15.1/foss-2023a-CUDA-12.1.1/TensorFlow/bazel-root/118f384e922c3d547bdefb95531c44fe/execroot/org_tensorflow/bazel-out/k8-opt/testlogs/tensorflow/python/kernel_tests/sparse_ops/sparse_slice_op_test/test.log)
INFO: From Testing //tensorflow/python/kernel_tests/sparse_ops:sparse_slice_op_test:
==================== Test output for //tensorflow/python/kernel_tests/sparse_ops:sparse_slice_op_test:
Traceback (most recent call last):
  File "/dev/shm/tmp/easybuild/build/TensorFlow/2.15.1/foss-2023a-CUDA-12.1.1/TensorFlow/bazel-root/118f384e922c3d547bdefb95531c44fe/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/sparse_ops/sparse_slice_op_test.runfiles/org_tensorflow/tensorflow/python/kernel_tests/sparse_ops/sparse_slice_op_test.py", line 19, in <module>
    from tensorflow.python.framework import errors
  File "/dev/shm/tmp/easybuild/build/TensorFlow/2.15.1/foss-2023a-CUDA-12.1.1/TensorFlow/bazel-root/118f384e922c3d547bdefb95531c44fe/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/sparse_ops/sparse_slice_op_test.runfiles/org_tensorflow/tensorflow/python/framework/errors.py", line 21, in <module>
    from tensorflow.python.framework import errors_impl as _impl
  File "/dev/shm/tmp/easybuild/build/TensorFlow/2.15.1/foss-2023a-CUDA-12.1.1/TensorFlow/bazel-root/118f384e922c3d547bdefb95531c44fe/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/sparse_ops/sparse_slice_op_test.runfiles/org_tensorflow/tensorflow/python/framework/errors_impl.py", line 21, in <module>
    from tensorflow.python import _pywrap_py_exception_registry
ImportError: libnccl.so.2: cannot open shared object file: No such file or directory
```
- Checking `ldd` on the imported shared library
```
cd /dev/shm/tmp/easybuild/build/TensorFlow/2.15.1/foss-2023a-CUDA-12.1.1/TensorFlow/bazel-root/118f384e922c3d547bdefb95531c44fe/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/sparse_ops/sparse_slice_op_test.runfiles/org_tensorflow/tensorflow/python; ldd _pywrap_py_exception_registry.so | grep libnccl.so.2
        libnccl.so.2 => not found
        libnccl.so.2 => not found
        libnccl.so.2 => not found
```
- Determining target of symlink
```
cd /dev/shm/tmp/easybuild/build/TensorFlow/2.15.1/foss-2023a-CUDA-12.1.1/TensorFlow/bazel-root/118f384e922c3d547bdefb95531c44fe/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/sparse_ops/sparse_slice_op_test.runfiles/org_tensorflow/tensorflow/python; realpath _pywrap_py_exception_registry.so
/dev/shm/tmp/easybuild/build/TensorFlow/2.15.1/foss-2023a-CUDA-12.1.1/TensorFlow/bazel-root/118f384e922c3d547bdefb95531c44fe/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/_pywrap_py_exception_registry.so
```
- Checking `ldd` from the directory for the target of the symlink
```
cd /dev/shm/tmp/easybuild/build/TensorFlow/2.15.1/foss-2023a-CUDA-12.1.1/TensorFlow/bazel-root/118f384e922c3d547bdefb95531c44fe/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python; ldd _pywrap_py_exception_registry.so | grep libnccl.so.2
        libnccl.so.2 => /dev/shm/tmp/easybuild/build/TensorFlow/2.15.1/foss-2023a-CUDA-12.1.1/TensorFlow/bazel-root/118f384e922c3d547bdefb95531c44fe/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/./../../_solib_local/_U@local_Uconfig_Unccl_S_S_Cnccl___Uexternal_Slocal_Uconfig_Unccl/libnccl.so.2 (0x00007eff6832c000)
```