### PR TITLE
let internal easyblock not create a log file in QuantumESPRESSO easyblock

### DIFF
--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -28,6 +28,7 @@ EasyBuild support for Quantum ESPRESSO, implemented as an easyblock
 @author: Kenneth Hoste (Ghent University)
 @author: Ake Sandgren (HPC2N, Umea University)
 @author: Davide Grassano (CECAM, EPFL)
+@author: Jan Reuter (Juelich Supercomputing Centre)
 """
 
 import fileinput
@@ -84,6 +85,8 @@ class EB_QuantumESPRESSO(EasyBlock):
 
         # Required to avoid CMakeMake default extra_opts to override the ConfigMake ones
         new_ec = EasyConfig(ec.path, extra_options=eb.extra_options())
+        # Disable log file for nested EasyBlock
+        kwargs['logfile'] = self.logfile
         self.ebclass = eb(new_ec, *args, **kwargs)
 
     class EB_QuantumESPRESSOcmake(CMakeMake):


### PR DESCRIPTION
This fixes the increased disk usage when running the EasyConfig test suite as log files would stay open.
See https://github.com/easybuilders/easybuild-easyconfigs/issues/21841 for more information.

Requires:
- [x] https://github.com/easybuilders/easybuild-framework/pull/4707

Fixes:
- https://github.com/easybuilders/easybuild-easyconfigs/issues/21841

---

**Old Notes:**
- During the EasyConfig test suite, some log files will be left over until the suite has finished. However, these files are now only ~1.1KB in size instead of steadily increasing in size.
- It's hard to test the changes in the CI.
- We need to check if these changes affect normal installation logs. Until then, marked as draft.

