### PR TITLE
enhance generic `Bundle` easyblock to transfer module requirements of components, but do not create logfile in components

### DIFF
--- a/easybuild/easyblocks/c/clang_aomp.py
+++ b/easybuild/easyblocks/c/clang_aomp.py
@@ -145,7 +145,7 @@ class EB_Clang_minus_AOMP(Bundle):
             raise EasyBuildError("Could not find 'ROCm-Device-Libs' source directory in %s", self.builddir)
 
         num_comps = len(self.cfg['components'])
-        for idx, comp in enumerate(self.comp_cfgs):
+        for idx, (comp, _) in enumerate(self.comp_instances):
             name = comp['name']
             msg = "configuring bundle component %s %s (%d/%d)..." % (name, comp['version'], idx + 1, num_comps)
             print_msg(msg)

--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -340,6 +340,9 @@ class Bundle(EasyBlock):
             self.log.info("Gathering module paths for component %s v%s", cfg['name'], cfg['version'])
             reqs = comp.make_module_req_guess()
 
+            # Try-except block to fail with an easily understandable error message.
+            # This should only trigger when an EasyBlock returns non-dict module requirements
+            # for make_module_req_guess() which should then be fixed in the components EasyBlock.
             try:
                 for key, value in sorted(reqs.items()):
                     if isinstance(value, string_type):

--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -348,7 +348,7 @@ class Bundle(EasyBlock):
                     if isinstance(value, string_type):
                         value = [value]
                     final_reqs.setdefault(key, [])
-                    final_reqs[key].append(value)
+                    final_reqs[key].extend(value)
             except AttributeError:
                 raise EasyBuildError("Cannot process module requirements of bundle component %s v%s",
                                      cfg['name'], cfg['version'])

--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -199,7 +199,7 @@ class Bundle(EasyBlock):
             if comp_cfg['patches']:
                 self.cfg.update('patches', comp_cfg['patches'])
 
-            self.comp_instances.append((comp_cfg, comp_cfg.easyblock(comp_cfg)))
+            self.comp_instances.append((comp_cfg, comp_cfg.easyblock(comp_cfg, logfile=self.logfile)))
 
         self.cfg.update('checksums', checksums_patches)
 
@@ -319,9 +319,6 @@ class Bundle(EasyBlock):
                         else:
                             new_val = path
                         env.setvar(envvar, new_val)
-
-            # close log for this component
-            comp.close_log()
 
     def make_module_req_guess(self):
         """

--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -322,15 +322,15 @@ class Bundle(EasyBlock):
 
     def make_module_req_guess(self):
         """
-        Set module requirements from all comppnents, e.g. $PATH, etc.
+        Set module requirements from all components, e.g. $PATH, etc.
         During the install step, we only set these requirements temporarily.
         Later on when building the module, those paths are not considered.
         Therefore, iterate through all the components again and gather
         the requirements.
 
-        Do not remove duplicates or check for existance of folders,
+        Do not remove duplicates or check for existence of folders,
         as this is done in the generic EasyBlock while creating
-        the modulefile already.
+        the module file already.
         """
         # Start with the paths from the generic EasyBlock.
         # If not added here, they might be missing entirely and fail sanity checks.
@@ -342,10 +342,10 @@ class Bundle(EasyBlock):
 
             try:
                 for key, value in sorted(reqs.items()):
-                    if isinstance(reqs, string_type):
+                    if isinstance(value, string_type):
                         value = [value]
                     final_reqs.setdefault(key, [])
-                    final_reqs[key] += value
+                    final_reqs[key].append(value)
             except AttributeError:
                 raise EasyBuildError("Cannot process module requirements of bundle component %s v%s",
                                      cfg['name'], cfg['version'])


### PR DESCRIPTION
This fixes the increased disk usage when running the EasyConfig test suite as log files would stay open.
See https://github.com/easybuilders/easybuild-easyconfigs/issues/21841 for more information.

Requires:
- [x] https://github.com/easybuilders/easybuild-framework/pull/4707

Related:
- https://github.com/easybuilders/easybuild-easyconfigs/issues/21841

See #3472 for the initial review and #3504 for the occurring issue, causing a revert of the PR.