### PR TITLE
force use of `bash` for `Allwmake` scripts in OpenFOAM easyblock

### DIFF
--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -372,7 +372,7 @@ class EB_OpenFOAM(EasyBlock):
                 if self.looseversion >= LooseVersion('2406'):
                     # Also build the plugins
                     cmd += ' && %s bash %s -log' % (self.cfg['prebuildopts'],
-                                               os.path.join(self.builddir, self.openfoamdir, 'Allwmake-plugins'))
+                                                    os.path.join(self.builddir, self.openfoamdir, 'Allwmake-plugins'))
 
             run_cmd(cmd_tmpl % cmd, log_all=True, simple=True, log_output=True)
 

--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -340,7 +340,7 @@ class EB_OpenFOAM(EasyBlock):
             cleancmd = "wcleanAll"
 
         # make directly in install directory
-        cmd_tmpl = "%(precmd)s && %(cleancmd)s && %(prebuildopts)s %(makecmd)s" % {
+        cmd_tmpl = "%(precmd)s && %(cleancmd)s && %(prebuildopts)s bash %(makecmd)s" % {
             'precmd': precmd,
             'cleancmd': cleancmd,
             'prebuildopts': self.cfg['prebuildopts'],
@@ -371,7 +371,7 @@ class EB_OpenFOAM(EasyBlock):
 
                 if self.looseversion >= LooseVersion('2406'):
                     # Also build the plugins
-                    cmd += ' && %s %s -log' % (self.cfg['prebuildopts'],
+                    cmd += ' && %s bash %s -log' % (self.cfg['prebuildopts'],
                                                os.path.join(self.builddir, self.openfoamdir, 'Allwmake-plugins'))
 
             run_cmd(cmd_tmpl % cmd, log_all=True, simple=True, log_output=True)


### PR DESCRIPTION
Fixes #3518 by running all `Allwmake` scripts with `bash`. I'm currently running a test build, see https://github.com/EESSI/software-layer/pull/826#issuecomment-2501313733.