### PR TITLE
WRF 4.6.1 WPS 4.6.0: Pass NETCDF-Fortran path

### DIFF
--- a/easybuild/easyblocks/w/wps.py
+++ b/easybuild/easyblocks/w/wps.py
@@ -106,6 +106,9 @@ class EB_WPS(EasyBlock):
             wrfdir = os.path.join(wrf, det_wrf_subdir(get_software_version('WRF')))
         else:
             raise EasyBuildError("WRF module not loaded?")
+        netcdf_fortran = get_software_root('NETCDFMINFORTRAN')
+        if netcdf_fortran:
+            env.setvar('NETCDFF_DIR', netcdf_fortran)
 
         self.compile_script = 'compile'
 

--- a/easybuild/easyblocks/w/wrf.py
+++ b/easybuild/easyblocks/w/wrf.py
@@ -95,8 +95,10 @@ class EB_WRF(EasyBlock):
 
         wrfdir = os.path.join(self.builddir, self.wrfsubdir)
 
-        # define $NETCDF* for netCDF dependency (used when creating WRF module file)
-        set_netcdf_env_vars(self.log)
+        set_netcdf_env_vars(self.log)            
+        netcdf_fortran = get_software_root('NETCDFMINFORTRAN')
+        if netcdf_fortran:
+            env.setvar('NETCDFF', netcdf_fortran)
 
         # HDF5 (optional) dependency
         hdf5 = get_software_root('HDF5')


### PR DESCRIPTION
Pass the NETCDF-Fortran path to configure scripts of WRF and WPS if the module is loaded.