### PR TITLE
pass the preferred host compiler to the CUDA compiler in the CMakeMake easyblock

### DIFF
--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -332,7 +332,7 @@ class CMakeMake(ConfigureMake):
         cuda_root = get_software_root('CUDA')
         if cuda_root:
             options['CMAKE_CUDA_HOST_COMPILER'] = which(os.getenv('CXX', 'g++'))
-            options['CMAKE_CUDA_COMPILER'] = 'nvcc'
+            options['CMAKE_CUDA_COMPILER'] = which('nvcc')
             cuda_cc = build_option('cuda_compute_capabilities') or self.cfg['cuda_compute_capabilities']
             if cuda_cc:
                 options['CMAKE_CUDA_ARCHITECTURES'] = '"%s"' % ';'.join([cc.replace('.', '') for cc in cuda_cc])

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -328,6 +328,11 @@ class CMakeMake(ConfigureMake):
         # ensure CMake uses EB python, not system or virtualenv python
         options.update(get_cmake_python_config_dict())
 
+        # pass the preferred host compiler to the CUDA compiler
+        cuda_root = get_software_root('CUDA')
+        if cuda_root:
+            self.cfg.update('preconfigopts', 'CUDAHOSTCXX=%s' % which(os.getenv('CXX', 'g++')))
+
         if not self.cfg.get('allow_system_boost', False):
             boost_root = get_software_root('Boost')
             if boost_root:

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -328,10 +328,18 @@ class CMakeMake(ConfigureMake):
         # ensure CMake uses EB python, not system or virtualenv python
         options.update(get_cmake_python_config_dict())
 
-        # pass the preferred host compiler to the CUDA compiler
+        # pass the preferred host compiler, CUDA compiler, and CUDA architectures to the CUDA compiler
         cuda_root = get_software_root('CUDA')
         if cuda_root:
-            self.cfg.update('preconfigopts', 'CUDAHOSTCXX=%s' % which(os.getenv('CXX', 'g++')))
+            options['CMAKE_CUDA_HOST_COMPILER'] = which(os.getenv('CXX', 'g++'))
+            options['CMAKE_CUDA_COMPILER'] = 'nvcc'
+            cuda_cc = build_option('cuda_compute_capabilities') or self.cfg['cuda_compute_capabilities']
+            if cuda_cc:
+                options['CMAKE_CUDA_ARCHITECTURES'] = '"%s"' % ';'.join([cc.replace('.', '') for cc in cuda_cc])
+            else:
+                raise EasyBuildError('List of CUDA compute capabilities must be specified, either via '
+                                     'cuda_compute_capabilities easyconfig parameter or via '
+                                     '--cuda-compute-capabilities')
 
         if not self.cfg.get('allow_system_boost', False):
             boost_root = get_software_root('Boost')


### PR DESCRIPTION
When compiling a CUDA version of GROMACS in EESSI we noticed that `nvcc` would pick up the `g++` from the compat layer sysroot as host compiler (instead of the GCC from the EB stack), leading to weird issues/errors:

```
-- Check for working CUDA compiler: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/accel/nvidia/cc80/software/CUDA/12.4.0/bin/nvcc
-- Check for working CUDA compiler: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/accel/nvidia/cc80/software/CUDA/12.4.0/bin/nvcc - broken
CMake Error at /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/software/CMake/3.27.6-GCCcore-13.2.0/share/cmake-3.27/Modules/CMakeTestCUDACompiler.cmake:100 (message):
  The CUDA compiler

    "/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/accel/nvidia/cc80/software/CUDA/12.4.0/bin/nvcc"

  is not able to compile a simple test program.

  It fails with the following output:

    Change Dir: '/tmp/bot/easybuild/build/GROMACS/2024.4/foss-2023b-CUDA-12.4.0/easybuild_obj/CMakeFiles/CMakeScratch/TryCompile-JFpCnw'
    
    Run Build Command(s): /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/software/CMake/3.27.6-GCCcore-13.2.0/bin/cmake -E env VERBOSE=1 /cvmfs/software.eessi.io/versions/2023.06/compat/linux/x86_64/usr/bin/gmake -f Makefile cmTC_b4aca/fast
    /cvmfs/software.eessi.io/versions/2023.06/compat/linux/x86_64/usr/bin/gmake  -f CMakeFiles/cmTC_b4aca.dir/build.make CMakeFiles/cmTC_b4aca.dir/build
    gmake[1]: Entering directory '/tmp/bot/easybuild/build/GROMACS/2024.4/foss-2023b-CUDA-12.4.0/easybuild_obj/CMakeFiles/CMakeScratch/TryCompile-JFpCnw'
    Building CUDA object CMakeFiles/cmTC_b4aca.dir/main.cu.o
    /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/accel/nvidia/cc80/software/CUDA/12.4.0/bin/nvcc -forward-unknown-to-host-compiler   -std=c++17 "--generate-code=arch=compute_52,code=[compute_52,sm_52]" -MD -MT CMakeFiles/cmTC_b4aca.dir/main.cu.o -MF CMakeFiles/cmTC_b4aca.dir/main.cu.o.d -x cu -c /tmp/bot/easybuild/build/GROMACS/2024.4/foss-2023b-CUDA-12.4.0/easybuild_obj/CMakeFiles/CMakeScratch/TryCompile-JFpCnw/main.cu -o CMakeFiles/cmTC_b4aca.dir/main.cu.o
    Linking CUDA executable cmTC_b4aca
    /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/software/CMake/3.27.6-GCCcore-13.2.0/bin/cmake -E cmake_link_script CMakeFiles/cmTC_b4aca.dir/link.txt --verbose=1
    /cvmfs/software.eessi.io/versions/2023.06/compat/linux/x86_64/usr/bin/g++ -L/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/software/mpi4py/3.1.5-gompi-2023b/lib64 -L/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/software/mpi4py/3.1.5-gompi-2023b/lib -L/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/software/networkx/3.2.1-gfbf-2023b/lib64 -L/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/software/networkx/3.2.1-gfbf-2023b/lib -L/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/software/SciPy-bundle/2023.11-gfbf-2023b/lib64 -L/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/software/SciPy-bundle/2023.11-gfbf-2023b/lib -L/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/software/Python/3.11.5-GCCcore-13.2.0/lib64 -L/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/software/Python/3.11.5-GCCcore-13.2.0/lib -L/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/accel/nvidia/cc80/software/CUDA/12.4.0/lib64 -L/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/accel/nvidia/cc80/software/CUDA/12.4.0/lib -L/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/software/scikit-build-core/0.9.3-GCCcore-13.2.0/lib64 -L/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/software/scikit-build-core/0.9.3-GCCcore-13.2.0/lib -L/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/software/FFTW.MPI/3.3.10-gompi-2023b/lib64 -L/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/software/FFTW.MPI/3.3.10-gompi-2023b/lib -L/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/software/ScaLAPACK/2.2.0-gompi-2023b-fb/lib64 -L/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/software/ScaLAPACK/2.2.0-gompi-2023b-fb/lib -L/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/software/FlexiBLAS/3.3.1-GCC-13.2.0/lib64 -L/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/software/FlexiBLAS/3.3.1-GCC-13.2.0/lib -L/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/software/GCCcore/13.2.0/lib64 -L/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/software/GCCcore/13.2.0/lib  @CMakeFiles/cmTC_b4aca.dir/objects1.rsp -o cmTC_b4aca @CMakeFiles/cmTC_b4aca.dir/linkLibs.rsp -L"/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/accel/nvidia/cc80/software/CUDA/12.4.0/targets/x86_64-linux/lib/stubs" -L"/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/accel/nvidia/cc80/software/CUDA/12.4.0/targets/x86_64-linux/lib"
    /cvmfs/software.eessi.io/versions/2023.06/compat/linux/x86_64/usr/lib/gcc/x86_64-pc-linux-gnu/10/../../../../x86_64-pc-linux-gnu/bin/ld: CMakeFiles/cmTC_b4aca.dir/main.cu.o: relocation R_X86_64_32 against `.bss' can not be used when making a PIE object; recompile with -fPIE
    /cvmfs/software.eessi.io/versions/2023.06/compat/linux/x86_64/usr/lib/gcc/x86_64-pc-linux-gnu/10/../../../../x86_64-pc-linux-gnu/bin/ld: failed to set dynamic section sizes: bad value
    collect2: error: ld returned 1 exit status
    gmake[1]: *** [CMakeFiles/cmTC_b4aca.dir/build.make:102: cmTC_b4aca] Error 1
    gmake[1]: Leaving directory '/tmp/bot/easybuild/build/GROMACS/2024.4/foss-2023b-CUDA-12.4.0/easybuild_obj/CMakeFiles/CMakeScratch/TryCompile-JFpCnw'
    gmake: *** [Makefile:127: cmTC_b4aca/fast] Error 2
```

The right host compiler can be set using the `$CUDAHOSTCXX` environment variable, which is preferred over `CMAKE_CUDA_HOST_COMPILER` according to https://cmake.org/cmake/help/latest/envvar/CUDAHOSTCXX.html (though that may change in the future, see https://gitlab.kitware.com/cmake/cmake/-/issues/23160).

edit: for consistency reasons, I did switch to the `CMAKE_CUDA_HOST_COMPILER`, see https://github.com/easybuilders/easybuild-easyblocks/pull/3523#discussion_r1865838299.