### PR TITLE
Add support for detecting external MAGMA library for ELSI

### DIFF
--- a/easybuild/easyblocks/e/elsi.py
+++ b/easybuild/easyblocks/e/elsi.py
@@ -131,6 +131,12 @@ class EB_ELSI(CMakeMake):
             self.cfg.update('configopts', "-DENABLE_BSEPACK=ON -DUSE_EXTERNAL_BSEPACK=ON")
             external_libs.extend(['bsepack', 'sseig'])
 
+        magma = get_software_root('magma')
+        if magma:
+            self.log.info("Using external MAGMA.")
+            self.cfg.update('configopts', "-DENABLE_MAGMA=ON")
+            external_libs.append('magma')
+
         if get_software_root('imkl') or get_software_root('ScaLAPACK'):
             external_libs.extend(re.findall(r'lib(.*?)\.a', os.environ['SCALAPACK%s_STATIC_LIBS' % self.env_suff]))
         else:


### PR DESCRIPTION
Adds an if branch to the ELSI easyblock to automatically detect the external MAGMA solver if it is installed on the system, similarly as is done for the other solvers that ELSI can link to.

For the flags that have to be set for MAGMA see https://gitlab.com/elsi_project/elsi_interface/-/blob/master/INSTALL.md?ref_type=heads .

A similar thing can probably be added for other solvers that are still missing from the easyblock like eigenexa, but I haven't tried/tested yet if that would work.