### PR TITLE
be more careful when getting value of particular easyconfig parameter in `PythonBundle` and `PythonPackage` easyblock, to avoid trouble with unresolved template values

### DIFF
--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -164,24 +164,26 @@ class Bundle(EasyBlock):
             comp_cfg.enable_templating = True
 
             # 'sources' is strictly required
-            if comp_cfg['sources']:
+            comp_sources = comp_cfg.get_ref('sources')
+            if comp_sources:
                 # If per-component source URLs are provided, attach them directly to the relevant sources
-                if comp_cfg['source_urls']:
-                    for source in comp_cfg['sources']:
+                comp_source_urls = comp_cfg.get_ref('source_urls')
+                if comp_source_urls:
+                    for source in comp_sources:
                         if isinstance(source, str):
-                            self.cfg.update('sources', [{'filename': source, 'source_urls': comp_cfg['source_urls']}])
+                            self.cfg.update('sources', [{'filename': source, 'source_urls': comp_source_urls[:]}])
                         elif isinstance(source, dict):
                             # Update source_urls in the 'source' dict to use the one for the components
                             # (if it doesn't already exist)
                             if 'source_urls' not in source:
-                                source['source_urls'] = comp_cfg['source_urls']
+                                source['source_urls'] = comp_source_urls[:]
                             self.cfg.update('sources', [source])
                         else:
                             raise EasyBuildError("Source %s for component %s is neither a string nor a dict, cannot "
                                                  "process it.", source, comp_cfg['name'])
                 else:
                     # add component sources to list of sources
-                    self.cfg.update('sources', comp_cfg['sources'])
+                    self.cfg.update('sources', comp_sources)
             else:
                 raise EasyBuildError("No sources specification for component %s v%s", comp_name, comp_version)
 

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -546,12 +546,13 @@ class PythonPackage(ExtensionEasyBlock):
         else:
             self.use_setup_py = True
             self.install_cmd = SETUP_PY_INSTALL_CMD
+            install_target = self.cfg.get_ref('install_target')
 
-            if self.cfg['install_target'] == EASY_INSTALL_TARGET:
+            if install_target == EASY_INSTALL_TARGET:
                 self.install_cmd += " %(loc)s"
                 self.py_installopts.append('--no-deps')
             if self.cfg.get('zipped_egg', False):
-                if self.cfg['install_target'] == EASY_INSTALL_TARGET:
+                if install_target == EASY_INSTALL_TARGET:
                     self.py_installopts.append('--zip-ok')
                 else:
                     raise EasyBuildError("Installing zipped eggs requires using easy_install or pip")

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -818,7 +818,7 @@ class PythonPackage(ExtensionEasyBlock):
 
     def build_step(self):
         """Build Python package using setup.py"""
-        build_cmd = self.cfg['buildcmd']
+        build_cmd = self.cfg.get_ref('buildcmd')
         if self.use_setup_py:
 
             if get_software_root('CMake'):


### PR DESCRIPTION
fixes the following failures in easyconfigs test suite:

* for `PySide2-5.14.2.3-GCCcore-10.2.0.eb`:
```
Failed to resolve all templates in "install --parallel=%(parallel)s" using template dictionary: ...
```

* for `jax-0.4.25-gfbf-2023a.eb` and `jax-0.4.25-gfbf-2023a-CUDA-12.1.1.eb`:
```
Failed to resolve all templates in "mkdir -p %(builddir)s/archives && cp %%s %(builddir)s/archives" using template dictionary: ...
```


edit: requires:
* https://github.com/easybuilders/easybuild-framework/pull/4726