### PR TITLE
add custom easyconfig parameter `with_cxx_backtrace` to GCC easyblock to enable the build of the libstdcxx-backtrace library

### DIFF
--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -156,7 +156,7 @@ class EB_GCC(ConfigureMake):
             'withppl': [False, "Build GCC with PPL support", CUSTOM],
             'withnvptx': [False, "Build GCC with NVPTX offload support", CUSTOM],
             'withamdgcn': [False, "Build GCC with AMD GCN offload support", CUSTOM],
-            'with_cxx_backtrace': [False, "Build GCC with enabled stack trace for C++23", CUSTOM],
+            'with_cxx_backtrace': [None, "Build GCC with enabled stack trace for C++23", CUSTOM],
         }
         return ConfigureMake.extra_options(extra_vars)
 
@@ -644,9 +644,12 @@ class EB_GCC(ConfigureMake):
         else:
             self.configopts += " --disable-lto"
 
-        # enable builind of libstdc++_libbacktrace
-        if self.cfg['with_cxx_backtrace']:
-            self.configopts += " --enable-libstdcxx-backtrace"
+        # enable building of libstdc++_libbacktrace
+        if self.cfg['with_cxx_backtrace'] is not None:
+            if self.cfg['with_cxx_backtrace']:
+                # '--enable-libstdcxx-backtrace' is undefined by default. No need to explicitly 
+                # disable it if 'with_cxx_backtrace' is set to False
+                self.configopts += " --enable-libstdcxx-backtrace"
 
         # configure for a release build
         self.configopts += " --enable-checking=release "

--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -156,6 +156,7 @@ class EB_GCC(ConfigureMake):
             'withppl': [False, "Build GCC with PPL support", CUSTOM],
             'withnvptx': [False, "Build GCC with NVPTX offload support", CUSTOM],
             'withamdgcn': [False, "Build GCC with AMD GCN offload support", CUSTOM],
+            'with_cxx_backtrace': [False, "Build GCC with enabled stack trace for C++23", CUSTOM],
         }
         return ConfigureMake.extra_options(extra_vars)
 
@@ -642,6 +643,10 @@ class EB_GCC(ConfigureMake):
             self.configopts += " --enable-lto"
         else:
             self.configopts += " --disable-lto"
+
+        # enable builind of libstdc++_libbacktrace 
+        if self.cfg['with_cxx_backtrace']:
+            self.configopts += " --enable-libstdcxx-backtrace"
 
         # configure for a release build
         self.configopts += " --enable-checking=release "

--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -647,7 +647,7 @@ class EB_GCC(ConfigureMake):
         # enable building of libstdc++_libbacktrace
         if self.cfg['with_cxx_backtrace'] is not None:
             if self.cfg['with_cxx_backtrace']:
-                # '--enable-libstdcxx-backtrace' is undefined by default. No need to explicitly 
+                # '--enable-libstdcxx-backtrace' is undefined by default. No need to explicitly
                 # disable it if 'with_cxx_backtrace' is set to False
                 self.configopts += " --enable-libstdcxx-backtrace"
 

--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -644,7 +644,7 @@ class EB_GCC(ConfigureMake):
         else:
             self.configopts += " --disable-lto"
 
-        # enable builind of libstdc++_libbacktrace 
+        # enable builind of libstdc++_libbacktrace
         if self.cfg['with_cxx_backtrace']:
             self.configopts += " --enable-libstdcxx-backtrace"
 


### PR DESCRIPTION
Add an option to build a static library for the stack trace support in C++23.