### PR TITLE
inject custom '`%(python)s`' template value before getting value of '`buildcmd`' custom easyconfig parameter in `PythonPackage` easyblock

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -833,7 +833,7 @@ class PythonPackage(ExtensionEasyBlock):
 
             if not build_cmd:
                 build_cmd = 'build'  # Default value for setup.py
-            build_cmd = self.python_cmd + ' setup.py ' + build_cmd
+            build_cmd = f"{self.python_cmd} setup.py {build_cmd}"
 
         if build_cmd:
             cmd = ' '.join([self.cfg['prebuildopts'], build_cmd, self.cfg['buildopts']])

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -818,7 +818,11 @@ class PythonPackage(ExtensionEasyBlock):
 
     def build_step(self):
         """Build Python package using setup.py"""
-        build_cmd = self.cfg.get_ref('buildcmd')
+
+        # inject extra '%(python)s' template value before getting value of 'buildcmd' custom easyconfig parameter
+        self.cfg.template_values['python'] = self.python_cmd
+        build_cmd = self.cfg['buildcmd']
+
         if self.use_setup_py:
 
             if get_software_root('CMake'):
@@ -829,10 +833,9 @@ class PythonPackage(ExtensionEasyBlock):
 
             if not build_cmd:
                 build_cmd = 'build'  # Default value for setup.py
-            build_cmd = '%(python)s setup.py ' + build_cmd
+            build_cmd = self.python_cmd + ' setup.py ' + build_cmd
 
         if build_cmd:
-            build_cmd = build_cmd % {'python': self.python_cmd}
             cmd = ' '.join([self.cfg['prebuildopts'], build_cmd, self.cfg['buildopts']])
             res = run_shell_cmd(cmd)
 


### PR DESCRIPTION
Fix for crash when installing `PySide2-5.14.2.3-GCCcore-10.2.0.eb`:
```
Traceback (most recent call last):
  File "/usr/lib64/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib64/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/user/gent/400/vsc40023/easybuild/eb5/easybuild-framework/easybuild/main.py", line 801, in <module>
    main_with_hooks()
  File "/user/gent/400/vsc40023/easybuild/eb5/easybuild-framework/easybuild/main.py", line 787, in main_with_hooks
    main(args=args, prepared_cfg_data=(init_session_state, eb_go, cfg_settings))
  File "/user/gent/400/vsc40023/easybuild/eb5/easybuild-framework/easybuild/main.py", line 743, in main
    hooks, do_build)
  File "/user/gent/400/vsc40023/easybuild/eb5/easybuild-framework/easybuild/main.py", line 567, in process_eb_args
    exit_on_failure=exit_on_failure)
  File "/user/gent/400/vsc40023/easybuild/eb5/easybuild-framework/easybuild/main.py", line 175, in build_and_install_software
    raise ec_res['err']
  File "/user/gent/400/vsc40023/easybuild/eb5/easybuild-framework/easybuild/main.py", line 136, in build_and_install_software
    (ec_res['success'], app_log, err_msg, err_code) = build_and_install_one(ec, init_env)
  File "/user/gent/400/vsc40023/easybuild/eb5/easybuild-framework/easybuild/framework/easyblock.py", line 4461, in build_and_install_one
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/user/gent/400/vsc40023/easybuild/eb5/easybuild-framework/easybuild/framework/easyblock.py", line 4329, in run_all_steps
    self.run_step(step_name, step_methods)
  File "/user/gent/400/vsc40023/easybuild/eb5/easybuild-framework/easybuild/framework/easyblock.py", line 4172, in run_step
    step_method(self)()
  File "/user/gent/400/vsc40023/easybuild/eb5/easybuild-easyblocks/easybuild/easyblocks/generic/pythonpackage.py", line 835, in build_step
    build_cmd = build_cmd % {'python': self.python_cmd}
KeyError: 'parallel'
```

The tricky thing here is that while the `buildcmd` value may contain general template values (like `%(parallel)s`), there's also this custom `%(python)s` that is used locally here in `PythonPackage.build_step`.
The only proper way of correctly handling any possible combination of these cases at this point is by injecting the value for the `%(python)s` template in the dictionary of template values (which shouldn't cause trouble anywhere).