### PR TITLE
imports without the single folder letter

### DIFF
--- a/easybuild/easyblocks/i/icc.py
+++ b/easybuild/easyblocks/i/icc.py
@@ -40,7 +40,7 @@ from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.intelbase import IntelBase, ACTIVATION_NAME_2012, COMP_ALL
 from easybuild.easyblocks.generic.intelbase import LICENSE_FILE_NAME_2012
-from easybuild.easyblocks.t.tbb import get_tbb_gccprefix
+from easybuild.easyblocks.tbb import get_tbb_gccprefix
 from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
 

--- a/easybuild/easyblocks/i/intel_compilers.py
+++ b/easybuild/easyblocks/i/intel_compilers.py
@@ -31,7 +31,7 @@ import os
 from easybuild.tools import LooseVersion
 
 from easybuild.easyblocks.generic.intelbase import IntelBase
-from easybuild.easyblocks.t.tbb import get_tbb_gccprefix
+from easybuild.easyblocks.tbb import get_tbb_gccprefix
 from easybuild.tools.build_log import EasyBuildError, print_msg
 from easybuild.tools.run import run_shell_cmd
 

--- a/easybuild/easyblocks/m/mamba.py
+++ b/easybuild/easyblocks/m/mamba.py
@@ -31,7 +31,7 @@ EasyBuild support for building and installing Mamba, implemented as an easyblock
 
 import os
 
-from easybuild.easyblocks.a.anaconda import EB_Anaconda
+from easybuild.easyblocks.anaconda import EB_Anaconda
 
 
 class EB_Mamba(EB_Anaconda):


### PR DESCRIPTION
noticed while testing in #3533

------------------------------

We **must** not change the one in `r/init.py`
```
from easybuild.easyblocks.r.r import *
```
to be
```
from easybuild.easyblocks.r import *
```
else we get
```
$ eb R-4.4.2-gfbf-2024a.eb -D
== Temporary log file in case of crash /tmp/eb-jcktr5ls/easybuild-58_vio1o.log
ERROR: Failed to process easyconfig /home/simon/work/easybuild-easyconfigs/easybuild/easyconfigs/r/R/R-4.4.2-gfbf-2024a.eb: Failed to import EB_R easyblock: Failed to import EB_R from easybuild.easyblocks.r: module 'easybuild.easyblocks.r' has no attribute 'EB_R'
```