### PR TITLE
Make `CmdCp` easier to use

### DIFF
--- a/easybuild/easyblocks/generic/cmdcp.py
+++ b/easybuild/easyblocks/generic/cmdcp.py
@@ -67,9 +67,7 @@ class CmdCp(MakeCp):
             # determine command to use
             # find (first) regex match, then complete matching command template
             cmd = None
-            for pattern, regex_cmd in self.cfg.get_ref('cmds_map'):
-                pattern = pattern % self.cfg.template_values
-                regex_cmd = regex_cmd % self.cfg.template_values
+            for pattern, regex_cmd in self.cfg['cmds_map']:
                 try:
                     regex = re.compile(pattern)
                 except re.error as err:
@@ -80,6 +78,6 @@ class CmdCp(MakeCp):
                     break
             if cmd is None:
                 raise EasyBuildError("No match for %s in %s, don't know which command to use.",
-                                     src, self.cfg.get_ref('cmds_map'))
+                                     src, self.cfg['cmds_map'])
 
             run_shell_cmd(cmd)


### PR DESCRIPTION
The name suggest running a command and copy files. However the commands need to be specified as a regex-map list which might be executed for every source instead of once. Often a workflow might be just `./custom_configure && ./custom_build.sh` which is not easy to map to this.
Instead allow non-tuples which are considered as commands to be run. When mixing tuples and non-tuples the plain commands are run last.

This was always a concern of mine that a workflow consisting of running only a command that involves some custom install procedure was less obvious than it might be. It came up [recently](https://github.com/easybuilders/easybuild-framework/pull/4580#issuecomment-2585204615) where an EC uses `MakeCp` requiring `parallel = False` as it replaces the `make` cmd by a single command. In that case it is `./configure --options` and `./coconut` which isn't easily applicable using `CmdCp`

With this change it can be:
```
cmds_map = [
    "./configure --option1 --option2",
    "./coconut --flag 1 --flag 2",
]
```

I'd say this is easier to read and understand than:
```
cmds_map = [
   (".*", "./configure --option1 --option2 && ./coconut --flag 1 --flag 2"),
]
```

Also error reporting would be more focused, i.e. either "./configure failed" or "./coconut failed"

I can port a couple easyconfigs to the new syntax in a PR to the easyconfig repo for test reports and usage examples.