### PR TITLE
adopt `module_load_environment`: IntelBase, Advisor, Inspector, VTune

### DIFF
--- a/easybuild/easyblocks/a/advisor.py
+++ b/easybuild/easyblocks/a/advisor.py
@@ -57,14 +57,13 @@ class EB_Advisor(IntelBase):
         else:
             self.subdir = os.path.join('advisor', 'latest')
 
+        # prepare module load environment
+        self.prepare_intel_tools_env()
+
     def prepare_step(self, *args, **kwargs):
         """Since 2019u3 there is no license required."""
         kwargs['requires_runtime_license'] = False
         super(EB_Advisor, self).prepare_step(*args, **kwargs)
-
-    def make_module_req_guess(self):
-        """Find reasonable paths for Advisor"""
-        return self.get_guesses_tools()
 
     def sanity_check_step(self):
         """Custom sanity check paths for Advisor"""

--- a/easybuild/easyblocks/i/inspector.py
+++ b/easybuild/easyblocks/i/inspector.py
@@ -58,13 +58,12 @@ class EB_Inspector(IntelBase):
         elif loosever >= LooseVersion('2021'):
             self.subdir = os.path.join('inspector', 'latest')
 
+        # prepare module load environment
+        self.prepare_intel_tools_env()
+
     def make_installdir(self):
         """Do not create installation directory, install script handles that already."""
         super(EB_Inspector, self).make_installdir(dontcreate=True)
-
-    def make_module_req_guess(self):
-        """Find reasonable paths for Inspector"""
-        return self.get_guesses_tools()
 
     def sanity_check_step(self):
         """Custom sanity check paths for Intel Inspector."""

--- a/easybuild/easyblocks/v/vtune.py
+++ b/easybuild/easyblocks/v/vtune.py
@@ -60,6 +60,9 @@ class EB_VTune(IntelBase):
         elif loosever >= LooseVersion('2020'):
             self.subdir = 'vtune_profiler'
 
+        # prepare module load environment
+        self.prepare_intel_tools_env()
+
     def prepare_step(self, *args, **kwargs):
         """Since 2019u3 there is no license required."""
         kwargs['requires_runtime_license'] = False
@@ -68,10 +71,6 @@ class EB_VTune(IntelBase):
     def make_installdir(self):
         """Do not create installation directory, install script handles that already."""
         super(EB_VTune, self).make_installdir(dontcreate=True)
-
-    def make_module_req_guess(self):
-        """Find reasonable paths for VTune"""
-        return self.get_guesses_tools()
 
     def sanity_check_step(self):
         """Custom sanity check paths for VTune."""


### PR DESCRIPTION
and deprecate `get_guesses_tools` with `prepare_intel_tools_env`.

Update of IntelBase, Advisor, Inspector and VTune easyblock for https://github.com/easybuilders/easybuild-easyblocks/issues/3527