### PR TITLE
adopt `module_load_environment`: GCC

### DIFF
--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -203,6 +203,13 @@ class EB_GCC(ConfigureMake):
             self.log.warning('Setting withnvptx to False, since we are building on a RISC-V system')
             self.cfg['withnvptx'] = False
 
+        # define list of subdirectories in search paths of module load environment
+        self.module_load_environment.PATH = ['bin']
+        self.module_load_environment.LD_LIBRARY_PATH = ['lib', 'lib64']
+        # GCC can find its own headers and libraries but the .so's need to be in LD_LIBRARY_PATH
+        self.module_load_environment.CPATH = []
+        self.module_load_environment.LIBRARY_PATH = ['lib', 'lib64'] if get_cpu_family() == RISCV else []
+
     def create_dir(self, dirname):
         """
         Create a dir to build in.
@@ -1194,17 +1201,3 @@ class EB_GCC(ConfigureMake):
 
         super(EB_GCC, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands,
                                               extra_modules=extra_modules)
-
-    def make_module_req_guess(self):
-        """
-        GCC can find its own headers and libraries but the .so's need to be in LD_LIBRARY_PATH
-        """
-        guesses = super(EB_GCC, self).make_module_req_guess()
-        guesses.update({
-            'PATH': ['bin'],
-            'CPATH': [],
-            'LIBRARY_PATH': ['lib', 'lib64'] if get_cpu_family() == RISCV else [],
-            'LD_LIBRARY_PATH': ['lib', 'lib64'],
-            'MANPATH': ['man', 'share/man']
-        })
-        return guesses


### PR DESCRIPTION
Update of GCC easyblock for https://github.com/easybuilders/easybuild-easyblocks/issues/3527

Note: `PATH` and `LD_LIBRARY_PATH` are default and could be removed