### PR TITLE
fix error reporting for unknown value of `unrecognized_configure_options` in `ConfigureMake`

### DIFF
--- a/easybuild/easyblocks/generic/configuremake.py
+++ b/easybuild/easyblocks/generic/configuremake.py
@@ -335,7 +335,7 @@ class ConfigureMake(EasyBlock):
         valid_actions = (ERROR, WARN, IGNORE)
         # Always verify the EC param
         if action not in valid_actions:
-            raise EasyBuildError('Invalid value for `unrecognized_configure_options`: %s. Must be one of: ',
+            raise EasyBuildError("Invalid value for 'unrecognized_configure_options': %s. Must be one of: %s",
                                  action, ', '.join(valid_actions))
         if action != IGNORE:
             unrecognized_options_str = 'configure: WARNING: unrecognized options:'


### PR DESCRIPTION
fix for crash if `unrecognized_configure_options` is set to a bogus value

<details>

```
EasyBuild crashed! Please consider reporting a bug, this should not happen...

Traceback (most recent call last):
  File "/usr/lib64/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib64/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/p/home/jusers/hoste1/jureca/venv-eb5/lib64/python3.9/site-packages/easybuild/main.py", line 801, in <module>
    main_with_hooks()
  File "/p/home/jusers/hoste1/jureca/venv-eb5/lib64/python3.9/site-packages/easybuild/main.py", line 787, in main_with_hooks
    main(args=args, prepared_cfg_data=(init_session_state, eb_go, cfg_settings))
  File "/p/home/jusers/hoste1/jureca/venv-eb5/lib64/python3.9/site-packages/easybuild/main.py", line 742, in main
    do_cleanup = process_eb_args(orig_paths, eb_go, cfg_settings, modtool, testing, init_session_state,
  File "/p/home/jusers/hoste1/jureca/venv-eb5/lib64/python3.9/site-packages/easybuild/main.py", line 566, in process_eb_args
    ecs_with_res = build_and_install_software(ordered_ecs, init_session_state,
  File "/p/home/jusers/hoste1/jureca/venv-eb5/lib64/python3.9/site-packages/easybuild/main.py", line 175, in build_and_install_software
    raise ec_res['err']
  File "/p/home/jusers/hoste1/jureca/venv-eb5/lib64/python3.9/site-packages/easybuild/main.py", line 136, in build_and_install_software
    (ec_res['success'], app_log, err_msg, err_code) = build_and_install_one(ec, init_env)
  File "/p/home/jusers/hoste1/jureca/venv-eb5/lib64/python3.9/site-packages/easybuild/framework/easyblock.py", line 4462, in build_and_install_one
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/p/home/jusers/hoste1/jureca/venv-eb5/lib64/python3.9/site-packages/easybuild/easyblocks/f/fftw.py", line 230, in run_all_steps
    return super(EB_FFTW, self).run_all_steps(*args, **kwargs)
  File "/p/home/jusers/hoste1/jureca/venv-eb5/lib64/python3.9/site-packages/easybuild/framework/easyblock.py", line 4330, in run_all_steps
    self.run_step(step_name, step_methods)
  File "/p/home/jusers/hoste1/jureca/venv-eb5/lib64/python3.9/site-packages/easybuild/framework/easyblock.py", line 4172, in run_step
    step_method(self)()
  File "/p/home/jusers/hoste1/jureca/venv-eb5/lib64/python3.9/site-packages/easybuild/easyblocks/generic/configuremake.py", line 338, in configure_step
    raise EasyBuildError('Invalid value for `unrecognized_configure_options`: %s. Must be one of: ',
  File "/p/home/jusers/hoste1/jureca/venv-eb5/lib64/python3.9/site-packages/easybuild/tools/build_log.py", line 135, in __init__
    msg = msg % args
TypeError: not all arguments converted during string formatting
```

</details>