### PR TITLE
Make path to temporary install directory used in test step of `PythonPackage` easyblock available through environment variable so that it may be used in easyconfigs

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -853,7 +853,7 @@ class PythonPackage(ExtensionEasyBlock):
                         actual_installdir = test_installdir
                     # Export the temporary installdir as an environment variable
                     # Some tests (e.g. for astropy) require to be run in the installdir
-                    env.setvar('EB_TEST_INSTALLDIR', actual_installdir)
+                    env.setvar('EB_PYTHONPACKAGE_TEST_INSTALLDIR', actual_installdir)
 
                     self.log.debug("Pre-creating subdirectories in %s: %s", actual_installdir, self.all_pylibdirs)
                     for pylibdir in self.all_pylibdirs:

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -851,6 +851,9 @@ class PythonPackage(ExtensionEasyBlock):
                         actual_installdir = os.path.join(test_installdir, 'local')
                     else:
                         actual_installdir = test_installdir
+                    # Export the temporary installdir as an environment variable
+                    # Some tests (e.g. for astropy) require to be run in the installdir
+                    env.setvar('EB_TEST_INSTALLDIR', actual_installdir)
 
                     self.log.debug("Pre-creating subdirectories in %s: %s", actual_installdir, self.all_pylibdirs)
                     for pylibdir in self.all_pylibdirs:


### PR DESCRIPTION
This is needed by e.g. Astropy (https://github.com/easybuilders/easybuild-easyconfigs/pull/22198), that requires the tests to be ran in the installdir