### PR TITLE
add support for Sapphire Rapids in LAMMPS easyblock

### DIFF
--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -126,6 +126,7 @@ KOKKOS_CPU_MAPPING = {
     'skylake_avx512': 'SKX',
     'cascadelake': 'SKX',
     'icelake': 'SKX',
+    'sapphirerapids': 'SKX',
     'knights-landing': 'KNL',
     'zen': 'ZEN',
     'zen2': 'ZEN2',
@@ -242,6 +243,7 @@ class EB_LAMMPS(CMakeMake):
 
         if LooseVersion(self.cur_version) >= LooseVersion(translate_lammps_version('2Aug2023')):
             self.kokkos_cpu_mapping['icelake'] = 'ICX'
+            self.kokkos_cpu_mapping['sapphirerapids'] = 'SPR'
 
     def prepare_step(self, *args, **kwargs):
         """Custom prepare step for LAMMPS."""


### PR DESCRIPTION
I used the same approach as for Icelake, support for Sapphire Rapids was also added in version 2Aug2023, see https://github.com/lammps/lammps/blob/stable_2Aug2023/lib/kokkos/cmake/kokkos_arch.cmake#L62.

Do note that the 2Aug2023 has a dependency on a too old archspec version which detects Sapphire Rapids as Icelake, so we may want to have another fix for that (e.g. modify the archspec version in the easyconfig?).