### PR TITLE
Fix building PyTorch when using `setup.py` as the build command

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -474,7 +474,6 @@ class PythonPackage(ExtensionEasyBlock):
         self.pylibdir = UNKNOWN
         self.all_pylibdirs = [UNKNOWN]
 
-        self.py_installopts = []
         self.install_cmd_output = ''
 
         # make sure there's no site.cfg in $HOME, because setup.py will find it and use it
@@ -499,8 +498,6 @@ class PythonPackage(ExtensionEasyBlock):
         # figure out whether this Python package is being installed for multiple Python versions
         self.multi_python = 'Python' in self.cfg['multi_deps']
 
-        # determine install command
-        self.use_setup_py = False
         self.determine_install_command()
 
         # avoid that pip (ab)uses $HOME/.cache/pip
@@ -517,7 +514,9 @@ class PythonPackage(ExtensionEasyBlock):
         """
         Determine install command to use.
         """
+        self.py_installopts = []
         if self.cfg.get('use_pip', True) or self.cfg.get('use_pip_editable', False):
+            self.use_setup_py = False
             self.install_cmd = PIP_INSTALL_CMD
 
             pip_verbose = self.cfg.get('pip_verbose', None)
@@ -546,8 +545,8 @@ class PythonPackage(ExtensionEasyBlock):
         else:
             self.use_setup_py = True
             self.install_cmd = SETUP_PY_INSTALL_CMD
-            install_target = self.cfg.get_ref('install_target')
 
+            install_target = self.cfg.get_ref('install_target')
             if install_target == EASY_INSTALL_TARGET:
                 self.install_cmd += " %(loc)s"
                 self.py_installopts.append('--no-deps')

--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -240,6 +240,7 @@ class EB_PyTorch(PythonPackage):
         if self.cfg['use_pip'] is None and pytorch_version >= '2.0':
             self.log.info("Auto-enabling use of pip to install PyTorch >= 2.0, since 'use_pip' is not set")
             self.cfg['use_pip'] = True
+            self.determine_install_command()
 
     def fetch_step(self, skip_checksums=False):
         """Fetch sources for installing PyTorch, including those for tests."""


### PR DESCRIPTION
When changing `use_pip` after `PythonPackage.__init__` called `determine_install_command` the change is not honored. Call it again after the change.

This also requires to make it idempotent so all member variables changed in that function need to be set in all cases.

Fixes #3570