### PR TITLE
fix module load environment in Anaconda and Conda easyblocks

### DIFF
--- a/easybuild/easyblocks/a/anaconda.py
+++ b/easybuild/easyblocks/a/anaconda.py
@@ -40,6 +40,25 @@ from easybuild.tools.run import run_shell_cmd
 class EB_Anaconda(Binary):
     """Support for building/installing Anaconda and Miniconda."""
 
+    def __init__(self, *args, **kwargs):
+        """Initialize class variables."""
+        super().__init__(*args, **kwargs)
+
+        # Do not add installation to search paths for headers or libraries to avoid
+        # that the Anaconda environment is used by other software at building or linking time.
+        # LD_LIBRARY_PATH issue discusses here:
+        # http://superuser.com/questions/980250/environment-module-cannot-initialize-tcl
+        mod_env_headers = self.module_load_environment.alias_vars('HEADERS')
+        mod_env_libs = ['LD_LIBRARY_PATH', 'LIBRARY_PATH']
+        mod_env_cmake = ['CMAKE_LIBRARY_PATH', 'CMAKE_PREFIX_PATH']
+        for disallowed_var in mod_env_headers + mod_env_libs + mod_env_cmake:
+            try:
+                delattr(self.module_load_environment, disallowed_var)
+            except AttributeError:
+                pass
+            else:
+                self.log.debug(f"Purposely not updating ${disallowed_var} in {self.name} module file")
+
     def install_step(self):
         """Copy all files in build directory to the install directory"""
 

--- a/easybuild/easyblocks/a/anaconda.py
+++ b/easybuild/easyblocks/a/anaconda.py
@@ -52,12 +52,8 @@ class EB_Anaconda(Binary):
         mod_env_libs = ['LD_LIBRARY_PATH', 'LIBRARY_PATH']
         mod_env_cmake = ['CMAKE_LIBRARY_PATH', 'CMAKE_PREFIX_PATH']
         for disallowed_var in mod_env_headers + mod_env_libs + mod_env_cmake:
-            try:
-                delattr(self.module_load_environment, disallowed_var)
-            except AttributeError:
-                pass
-            else:
-                self.log.debug(f"Purposely not updating ${disallowed_var} in {self.name} module file")
+            self.module_load_environment.remove(disallowed_var)
+            self.log.debug(f"Purposely not updating ${disallowed_var} in {self.name} module file")
 
     def install_step(self):
         """Copy all files in build directory to the install directory"""

--- a/easybuild/easyblocks/generic/conda.py
+++ b/easybuild/easyblocks/generic/conda.py
@@ -28,9 +28,6 @@ EasyBuild support for installing software using 'conda', implemented as an easyb
 @author: Jillian Rowe (New York University Abu Dhabi)
 @author: Kenneth Hoste (HPC-UGent)
 """
-
-import os
-
 from easybuild.easyblocks.generic.binary import Binary
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.run import run_shell_cmd

--- a/easybuild/easyblocks/generic/conda.py
+++ b/easybuild/easyblocks/generic/conda.py
@@ -65,12 +65,8 @@ class Conda(Binary):
         mod_env_libs = ['LD_LIBRARY_PATH', 'LIBRARY_PATH']
         mod_env_cmake = ['CMAKE_LIBRARY_PATH', 'CMAKE_PREFIX_PATH']
         for disallowed_var in mod_env_headers + mod_env_libs + mod_env_cmake:
-            try:
-                delattr(self.module_load_environment, disallowed_var)
-            except AttributeError:
-                pass
-            else:
-                self.log.debug(f"Purposely not updating ${disallowed_var} in {self.name} module file")
+            self.module_load_environment.remove(disallowed_var)
+            self.log.debug(f"Purposely not updating ${disallowed_var} in {self.name} module file")
 
     def extract_step(self):
         """Copy sources via extract_step of parent, if any are specified."""


### PR DESCRIPTION
I totally misunderstood the purpose of the environment settings in the conda (#3562) and Anaconda (#3577) easyblocks. The goal is not to set some generic paths, but to unset linking paths to libraries in the conda environment.

The actual goal is avoiding that the conda environment is used by any other software external to it, neither at runtime or build time. Hence, this can logically be extended to include paths. 

This PR replaces the default paths set by conda easyblock in `module_load_environment` with the deletion of those variables related to search paths for linking and includes that are unwanted in the conda module environment.

Depends on:
* https://github.com/easybuilders/easybuild-framework/pull/4655