### PR TITLE
add support to OpenFOAM easyblock for custom `sanity_check_motorbike` easyconfig parameter to opt out of running motorBike tutorial example during sanity check

### DIFF
--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -67,7 +67,7 @@ class EB_OpenFOAM(EasyBlock):
             'sanity_check_motorbike': [True, "Should the motorbike sanity check run?", CUSTOM],
         })
         return extra_vars
-    
+
     def __init__(self, *args, **kwargs):
         """Specify that OpenFOAM should be built in install dir."""
 

--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -48,6 +48,7 @@ import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.cmakemake import setup_cmake_env
 from easybuild.framework.easyblock import EasyBlock
+from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import adjust_permissions, apply_regex_substitutions, mkdir, write_file
 from easybuild.tools.modules import get_software_root, get_software_version
@@ -57,7 +58,16 @@ from easybuild.tools.systemtools import get_shared_lib_ext, get_cpu_architecture
 
 class EB_OpenFOAM(EasyBlock):
     """Support for building and installing OpenFOAM."""
-
+    
+    @staticmethod
+    def extra_options():
+        """Custom easyconfig parameter specific to OpenFOAM."""
+        extra_vars = EasyBlock.extra_options()
+        extra_vars.update({
+            'sanity_check_motorbike': [True, "Should the motorbike sanity check run?", CUSTOM],
+        })
+        return extra_vars
+    
     def __init__(self, *args, **kwargs):
         """Specify that OpenFOAM should be built in install dir."""
 
@@ -540,7 +550,8 @@ class EB_OpenFOAM(EasyBlock):
 
         # run motorBike tutorial case to ensure the installation is functional (if it's available);
         # only for recent (>= v6.0) versions of openfoam.org variant
-        if self.is_dot_org and self.looseversion >= LooseVersion('6'):
+        # could be turned off by set 'sanity_check_motorbike' to False (default True)
+        if self.is_dot_org and self.looseversion >= LooseVersion('6') and self.cfg['sanity_check_motorbike']:
             openfoamdir_path = os.path.join(self.installdir, self.openfoamdir)
             if self.looseversion <= LooseVersion('10'):
                 motorbike_path = os.path.join(

--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -58,7 +58,7 @@ from easybuild.tools.systemtools import get_shared_lib_ext, get_cpu_architecture
 
 class EB_OpenFOAM(EasyBlock):
     """Support for building and installing OpenFOAM."""
-    
+
     @staticmethod
     def extra_options():
         """Custom easyconfig parameter specific to OpenFOAM."""


### PR DESCRIPTION
This provide more customizable sanity check for OpenFOAM easyconfig - standard sanity check fails on motorBike tutorial check without ParaView installed. 

resolves https://github.com/vscentrum/vsc-software-stack/issues/481
needed by:
- https://github.com/easybuilders/easybuild-easyconfigs/pull/22303