### PR TITLE
remove hardcoded CPLUS_INCLUDE_PATH in favor of module-search-path-headers in custom easyblock for Eigen

### DIFF
--- a/easybuild/easyblocks/e/eigen.py
+++ b/easybuild/easyblocks/e/eigen.py
@@ -98,12 +98,3 @@ class EB_Eigen(CMakeMake):
                                    % os.path.join(self.installdir, cmake_config_dir))
 
         super(EB_Eigen, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
-
-    def make_module_req_guess(self):
-        """
-        A dictionary of possible directories to look for.
-        Include CPLUS_INCLUDE_PATH as an addition to default ones
-        """
-        guesses = super(EB_Eigen, self).make_module_req_guess()
-        guesses.update({'CPLUS_INCLUDE_PATH': ['include']})
-        return guesses


### PR DESCRIPTION
`CPATH` has precedence over `C_INCLUDE_PATH` and `CPLUS_INCLUDE_PATH`. So this is effectively not doing anything. If `CPLUS_INCLUDE_PATH` is really needed, this should be set through `module-search-path-headers`.