### PR TITLE
Fix bug in FlexiBLAS easyblock to allow AOCL-BLAS to be default

### DIFF
--- a/easybuild/easyblocks/f/flexiblas.py
+++ b/easybuild/easyblocks/f/flexiblas.py
@@ -109,8 +109,11 @@ class EB_FlexiBLAS(CMakeMake):
         unsupported_libs = [x for x in self.blas_libs if x not in supported_blas_libs]
         if unsupported_libs:
             raise EasyBuildError("One or more unsupported libraries used: %s", ', '.join(unsupported_libs))
+        # need to use CMake naming convention
         if 'AOCL-BLAS' in self.blas_libs:
             self.blas_libs[self.blas_libs.index('AOCL-BLAS')] = 'AOCL_mt'
+        if configopts['FLEXIBLAS_DEFAULT'] == 'AOCL-BLAS':
+            configopts['FLEXIBLAS_DEFAULT'] = 'AOCL_mt'
         # list of BLAS libraries to use is specified via -DEXTRA=...
         configopts['EXTRA'] = ';'.join(self.blas_libs)
 


### PR DESCRIPTION
In the current version, if one sets AOCL-BLAS as the default, it will be (silently) ignored and FlexiBLAS will use NETLIB instead, since the eventual name of the AOCL-BLAS backend will be the CMake name, AOCL_MT. This PR fixes this by substituting the name in `configopts['FLEXIBLAS_DEFAULT']`, just like how it's handled in the backends variable.