### PR TITLE
fix Molpro easyblock in module-only mode

### DIFF
--- a/easybuild/easyblocks/m/molpro.py
+++ b/easybuild/easyblocks/m/molpro.py
@@ -67,6 +67,14 @@ class EB_Molpro(ConfigureMake, Binary):
         self.cleanup_token_symlink = False
         self.license_token = os.path.join(os.path.expanduser('~'), '.molpro', 'token')
 
+        # custom paths in module load environment
+        # add glob patterns for all possible locations of executables, non-existent ones will be ignored
+        self.module_load_environment.PATH = [
+            'bin',
+            '*/bin',
+            '*/utilities',
+        ]
+
     def extract_step(self):
         """Extract Molpro source files, or just copy in case of binary install."""
         if self.cfg['precompiled_binaries']:
@@ -233,14 +241,6 @@ class EB_Molpro(ConfigureMake, Binary):
                 self.log.debug("Symlink to license token %s removed", self.license_token)
             except OSError as err:
                 raise EasyBuildError("Failed to remove %s: %s", self.license_token, err)
-
-    def make_module_req_guess(self):
-        """Customize $PATH guesses for Molpro module."""
-        guesses = super(EB_Molpro, self).make_module_req_guess()
-        guesses.update({
-            'PATH': [os.path.join(os.path.basename(self.full_prefix), x) for x in ['bin', 'utilities']],
-        })
-        return guesses
 
     def sanity_check_step(self):
         """Custom sanity check for Molpro."""


### PR DESCRIPTION
Fixes #3614 and updates for https://github.com/easybuilders/easybuild-easyblocks/issues/3527

Molpro easyblock heavily relies on `self.full_prefix` which is defined from a `CONFIG` file that only exists in the build directory.

* replace `make_module_req_guess` with `module_load_environment` and define glob patterns for `PATH` to possible locations of executables. This avoids needing `self.full_prefix`.
* add extra guess to sanity check whenever `self.full_prefix` is empty. In such a case, try to also determine installation prefix based on a simple glob pattern.
