### PR TITLE
Adapt cp2k regtest argument

### DIFF
--- a/easybuild/easyblocks/c/cp2k.py
+++ b/easybuild/easyblocks/c/cp2k.py
@@ -787,7 +787,11 @@ class EB_CP2K(EasyBlock):
             cfg_fn = 'cp2k_regtest.cfg'
 
             regtest_script = os.path.join(self.cfg['start_dir'], 'tests', 'do_regtest.py')
-            regtest_cmd = [regtest_script, self.typearch, self.cfg['type']]
+            if LooseVersion(self.version) >= LooseVersion('2025'):
+                exedir = os.path.join(self.cfg['start_dir'], 'exe', self.typearch)
+            else:
+                exedir = self.typearch
+            regtest_cmd = [regtest_script, exedir, self.cfg['type']]
             if LooseVersion(self.version) < LooseVersion('7.1'):
                 # -nosvn option was removed in CP2K 7.1
                 regtest_cmd.insert(1, '-nosvn')


### PR DESCRIPTION
This builds upon https://github.com/easybuilders/easybuild-easyblocks/pull/3433. For CP2K >= 2025.1, the `do_regtest.py` script expects a full path instead of just `self.typearch` as first argument (see https://github.com/cp2k/cp2k/pull/3640)