### PR TITLE
set minimum supported version of PETSc to v3.9 and adopt `module_load_environment`

### DIFF
--- a/easybuild/easyblocks/p/petsc.py
+++ b/easybuild/easyblocks/p/petsc.py
@@ -37,7 +37,7 @@ from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import BUILD, CUSTOM
 from easybuild.tools import LooseVersion
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import symlink, apply_regex_substitutions
+from easybuild.tools.filetools import apply_regex_substitutions
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext

--- a/easybuild/easyblocks/p/petsc.py
+++ b/easybuild/easyblocks/p/petsc.py
@@ -47,24 +47,6 @@ NO_MPI_CXX_EXT_FLAGS = '-DOMPI_SKIP_MPICXX -DMPICH_SKIP_MPICXX'
 class EB_PETSc(ConfigureMake):
     """Support for building and installing PETSc"""
 
-    def __init__(self, *args, **kwargs):
-        """Initialize PETSc specific variables."""
-        super(EB_PETSc, self).__init__(*args, **kwargs)
-
-        self.petsc_arch = self.cfg['petsc_arch']
-        self.petsc_subdir = ""
-        self.prefix_inc = ''
-        self.prefix_lib = ''
-        self.prefix_bin = ''
-
-        self.with_python = False
-
-        if self.cfg['sourceinstall']:
-            self.build_in_installdir = True
-
-        if LooseVersion(self.version) >= LooseVersion("3.9"):
-            self.prefix_bin = os.path.join(self.prefix_inc, 'lib', 'petsc')
-
     @staticmethod
     def extra_options():
         """Add extra config options specific to PETSc."""
@@ -87,6 +69,26 @@ class EB_PETSc(ConfigureMake):
         }
         return ConfigureMake.extra_options(extra_vars)
 
+    def __init__(self, *args, **kwargs):
+        """Initialize PETSc specific variables."""
+        super(EB_PETSc, self).__init__(*args, **kwargs)
+
+        if LooseVersion(self.version) < LooseVersion("3.9"):
+            raise EasyBuildError(
+                f"Version {self.version} of {self.name} is unsupported. Mininum supported version is 3.9"
+            )
+
+        self.petsc_arch = self.cfg['petsc_arch']
+        self.petsc_subdir = ""
+        self.prefix_inc = ''
+        self.prefix_lib = ''
+        self.prefix_bin = os.path.join(self.prefix_inc, 'lib', 'petsc')
+
+        self.with_python = False
+
+        if self.cfg['sourceinstall']:
+            self.build_in_installdir = True
+
     def prepare_step(self, *args, **kwargs):
         """Prepare build environment."""
 
@@ -104,246 +106,210 @@ class EB_PETSc(ConfigureMake):
 
         Configure procedure is much more concise for older versions (< v3).
         """
-        if LooseVersion(self.version) >= LooseVersion("3"):
-            # make the install dir first if we are doing a download install, then keep it for the rest of the way
-            deps = self.cfg["download_deps"] + self.cfg["download_deps_static"] + self.cfg["download_deps_shared"]
-            if deps:
-                self.log.info("Creating the installation directory before the configure.")
-                self.make_installdir()
-                self.cfg["keeppreviousinstall"] = True
-                for dep in set(deps):
-                    self.cfg.update('configopts', '--download-%s=1' % dep)
-                for dep in self.cfg["download_deps_static"]:
-                    self.cfg.update('configopts', '--download-%s-shared=0' % dep)
-                for dep in self.cfg["download_deps_shared"]:
-                    self.cfg.update('configopts', '--download-%s-shared=1' % dep)
+        # make the install dir first if we are doing a download install, then keep it for the rest of the way
+        deps = self.cfg["download_deps"] + self.cfg["download_deps_static"] + self.cfg["download_deps_shared"]
+        if deps:
+            self.log.info("Creating the installation directory before the configure.")
+            self.make_installdir()
+            self.cfg["keeppreviousinstall"] = True
+            for dep in set(deps):
+                self.cfg.update('configopts', '--download-%s=1' % dep)
+            for dep in self.cfg["download_deps_static"]:
+                self.cfg.update('configopts', '--download-%s-shared=0' % dep)
+            for dep in self.cfg["download_deps_shared"]:
+                self.cfg.update('configopts', '--download-%s-shared=1' % dep)
 
-            # compilers
-            self.cfg.update('configopts', '--with-cc="%s"' % os.getenv('CC'))
-            self.cfg.update('configopts', '--with-cxx="%s" --with-c++-support' % os.getenv('CXX'))
-            self.cfg.update('configopts', '--with-fc="%s"' % os.getenv('F90'))
+        # compilers
+        self.cfg.update('configopts', '--with-cc="%s"' % os.getenv('CC'))
+        self.cfg.update('configopts', '--with-cxx="%s" --with-c++-support' % os.getenv('CXX'))
+        self.cfg.update('configopts', '--with-fc="%s"' % os.getenv('F90'))
 
-            # compiler flags
-            # Don't build with MPI c++ bindings as this leads to a hard dependency
-            # on libmpi and libmpi_cxx even for C code and non-MPI code
-            cxxflags = os.getenv('CXXFLAGS') + ' ' + NO_MPI_CXX_EXT_FLAGS
-            if LooseVersion(self.version) >= LooseVersion("3.5"):
-                self.cfg.update('configopts', '--CFLAGS="%s"' % os.getenv('CFLAGS'))
-                self.cfg.update('configopts', '--CXXFLAGS="%s"' % cxxflags)
-                self.cfg.update('configopts', '--FFLAGS="%s"' % os.getenv('F90FLAGS'))
+        # compiler flags
+        # Don't build with MPI c++ bindings as this leads to a hard dependency
+        # on libmpi and libmpi_cxx even for C code and non-MPI code
+        cxxflags = os.getenv('CXXFLAGS') + ' ' + NO_MPI_CXX_EXT_FLAGS
+        self.cfg.update('configopts', '--CFLAGS="%s"' % os.getenv('CFLAGS'))
+        self.cfg.update('configopts', '--CXXFLAGS="%s"' % cxxflags)
+        self.cfg.update('configopts', '--FFLAGS="%s"' % os.getenv('F90FLAGS'))
+
+        if not self.toolchain.comp_family() == toolchain.GCC:  # @UndefinedVariable
+            self.cfg.update('configopts', '--with-gnu-compilers=0')
+
+        # MPI
+        if self.toolchain.options.get('usempi', None):
+            self.cfg.update('configopts', '--with-mpi=1')
+
+        # build options
+        self.cfg.update('configopts', '--with-build-step-np=%s' % self.cfg['parallel'])
+        self.cfg.update('configopts', '--with-shared-libraries=%d' % self.cfg['shared_libs'])
+        self.cfg.update('configopts', '--with-debugging=%d' % self.toolchain.options['debug'])
+        self.cfg.update('configopts', '--with-pic=%d' % self.toolchain.options['pic'])
+        self.cfg.update('configopts', '--with-x=0 --with-windows-graphics=0')
+
+        # PAPI support
+        if self.cfg['with_papi']:
+            papi_inc = self.cfg['papi_inc']
+            papi_inc_file = os.path.join(papi_inc, "papi.h")
+            papi_lib = self.cfg['papi_lib']
+            if os.path.isfile(papi_inc_file) and os.path.isfile(papi_lib):
+                self.cfg.update('configopts', '--with-papi=1')
+                self.cfg.update('configopts', '--with-papi-include=%s' % papi_inc)
+                self.cfg.update('configopts', '--with-papi-lib=%s' % papi_lib)
             else:
-                self.cfg.update('configopts', '--with-cflags="%s"' % os.getenv('CFLAGS'))
-                self.cfg.update('configopts', '--with-cxxflags="%s"' % cxxflags)
-                self.cfg.update('configopts', '--with-fcflags="%s"' % os.getenv('F90FLAGS'))
+                raise EasyBuildError("PAPI header (%s) and/or lib (%s) not found, can not enable PAPI support?",
+                                     papi_inc_file, papi_lib)
 
-            if not self.toolchain.comp_family() == toolchain.GCC:  # @UndefinedVariable
-                self.cfg.update('configopts', '--with-gnu-compilers=0')
+        # Python extensions_step
+        if self.with_python:
 
-            # MPI
-            if self.toolchain.options.get('usempi', None):
-                self.cfg.update('configopts', '--with-mpi=1')
+            # enable numpy support, but only if numpy is available
+            res = run_shell_cmd("python -c 'import numpy'", fail_on_error=False)
+            if res.exit_code == 0:
+                self.cfg.update('configopts', '--with-numpy=1')
 
-            # build options
-            self.cfg.update('configopts', '--with-build-step-np=%s' % self.cfg['parallel'])
-            self.cfg.update('configopts', '--with-shared-libraries=%d' % self.cfg['shared_libs'])
-            self.cfg.update('configopts', '--with-debugging=%d' % self.toolchain.options['debug'])
-            self.cfg.update('configopts', '--with-pic=%d' % self.toolchain.options['pic'])
-            self.cfg.update('configopts', '--with-x=0 --with-windows-graphics=0')
+            # enable mpi4py support, but only if mpi4py is available
+            res = run_shell_cmd("python -c 'import mpi4py'", fail_on_error=False)
+            if res.exit_code == 0:
+                with_mpi4py_opt = '--with-mpi4py'
+                if self.cfg['shared_libs'] and with_mpi4py_opt not in self.cfg['configopts']:
+                    self.cfg.update('configopts', '%s=1' % with_mpi4py_opt)
 
-            # PAPI support
-            if self.cfg['with_papi']:
-                papi_inc = self.cfg['papi_inc']
-                papi_inc_file = os.path.join(papi_inc, "papi.h")
-                papi_lib = self.cfg['papi_lib']
-                if os.path.isfile(papi_inc_file) and os.path.isfile(papi_lib):
-                    self.cfg.update('configopts', '--with-papi=1')
-                    self.cfg.update('configopts', '--with-papi-include=%s' % papi_inc)
-                    self.cfg.update('configopts', '--with-papi-lib=%s' % papi_lib)
-                else:
-                    raise EasyBuildError("PAPI header (%s) and/or lib (%s) not found, can not enable PAPI support?",
-                                         papi_inc_file, papi_lib)
+        # FFTW, ScaLAPACK
+        deps = ["FFTW", "ScaLAPACK"]
+        for dep in deps:
+            libdir = os.getenv('%s_LIB_DIR' % dep.upper())
+            libs = os.getenv('%s_STATIC_LIBS' % dep.upper())
+            if libdir and libs:
+                with_arg = "--with-%s" % dep.lower()
+                self.cfg.update('configopts', '%s=1' % with_arg)
+                self.cfg.update('configopts', '%s-lib=[%s/%s]' % (with_arg, libdir, libs))
 
-            # Python extensions_step
-            if self.with_python:
-
-                # enable numpy support, but only if numpy is available
-                res = run_shell_cmd("python -c 'import numpy'", fail_on_error=False)
-                if res.exit_code == 0:
-                    self.cfg.update('configopts', '--with-numpy=1')
-
-                # enable mpi4py support, but only if mpi4py is available
-                res = run_shell_cmd("python -c 'import mpi4py'", fail_on_error=False)
-                if res.exit_code == 0:
-                    with_mpi4py_opt = '--with-mpi4py'
-                    if self.cfg['shared_libs'] and with_mpi4py_opt not in self.cfg['configopts']:
-                        self.cfg.update('configopts', '%s=1' % with_mpi4py_opt)
-
-            # FFTW, ScaLAPACK (and BLACS for older PETSc versions)
-            deps = ["FFTW", "ScaLAPACK"]
-            if LooseVersion(self.version) < LooseVersion("3.5"):
-                deps.append("BLACS")
-            for dep in deps:
-                libdir = os.getenv('%s_LIB_DIR' % dep.upper())
-                libs = os.getenv('%s_STATIC_LIBS' % dep.upper())
-                if libdir and libs:
-                    with_arg = "--with-%s" % dep.lower()
-                    self.cfg.update('configopts', '%s=1' % with_arg)
-                    self.cfg.update('configopts', '%s-lib=[%s/%s]' % (with_arg, libdir, libs))
-
-                    inc = os.getenv('%s_INC_DIR' % dep.upper())
-                    if inc:
-                        self.cfg.update('configopts', '%s-include=%s' % (with_arg, inc))
-                else:
-                    self.log.info("Missing inc/lib info, so not enabling %s support." % dep)
-
-            # BLAS, LAPACK libraries
-            bl_libdir = os.getenv('BLAS_LAPACK_LIB_DIR')
-            bl_libs = os.getenv('BLAS_LAPACK_STATIC_LIBS')
-            if bl_libdir and bl_libs:
-                self.cfg.update('configopts', '--with-blas-lapack-lib=[%s/%s]' % (bl_libdir, bl_libs))
+                inc = os.getenv('%s_INC_DIR' % dep.upper())
+                if inc:
+                    self.cfg.update('configopts', '%s-include=%s' % (with_arg, inc))
             else:
-                raise EasyBuildError("One or more environment variables for BLAS/LAPACK not defined?")
+                self.log.info("Missing inc/lib info, so not enabling %s support." % dep)
 
-            # additional dependencies
-            # filter out deps handled seperately
-            sep_deps = ['BLACS', 'BLAS', 'CMake', 'FFTW', 'LAPACK', 'numpy',
-                        'mpi4py', 'papi', 'ScaLAPACK', 'SciPy-bundle', 'SuiteSparse']
-            # SCOTCH has to be treated separately since they add weird postfixes
-            # to library names from SCOTCH 7.0.1 or PETSc version 3.17.
-            if (LooseVersion(self.version) >= LooseVersion("3.17")):
-                sep_deps.append('SCOTCH')
-            depfilter = [d['name'] for d in self.cfg.builddependencies()] + sep_deps
+        # BLAS, LAPACK libraries
+        bl_libdir = os.getenv('BLAS_LAPACK_LIB_DIR')
+        bl_libs = os.getenv('BLAS_LAPACK_STATIC_LIBS')
+        if bl_libdir and bl_libs:
+            self.cfg.update('configopts', '--with-blas-lapack-lib=[%s/%s]' % (bl_libdir, bl_libs))
+        else:
+            raise EasyBuildError("One or more environment variables for BLAS/LAPACK not defined?")
 
-            deps = [dep['name'] for dep in self.cfg.dependencies() if not dep['name'] in depfilter]
-            for dep in deps:
-                if isinstance(dep, str):
-                    dep = (dep, dep)
-                deproot = get_software_root(dep[0])
-                if deproot:
-                    if (LooseVersion(self.version) >= LooseVersion("3.5")) and (dep[1] == "SCOTCH"):
-                        withdep = "--with-pt%s" % dep[1].lower()  # --with-ptscotch is the configopt PETSc >= 3.5
-                    else:
-                        withdep = "--with-%s" % dep[1].lower()
-                    self.cfg.update('configopts', '%s=1 %s-dir=%s' % (withdep, withdep, deproot))
+        # additional dependencies
+        # filter out deps handled seperately
+        sep_deps = ['BLACS', 'BLAS', 'CMake', 'FFTW', 'LAPACK', 'numpy',
+                    'mpi4py', 'papi', 'ScaLAPACK', 'SciPy-bundle', 'SuiteSparse']
+        # SCOTCH has to be treated separately since they add weird postfixes
+        # to library names from SCOTCH 7.0.1 or PETSc version 3.17.
+        if (LooseVersion(self.version) >= LooseVersion("3.17")):
+            sep_deps.append('SCOTCH')
+        depfilter = [d['name'] for d in self.cfg.builddependencies()] + sep_deps
 
-            # SCOTCH has to be treated separately since they add weird postfixes
-            # to library names from SCOTCH 7.0.1 or PETSc version 3.17.
-            scotch = get_software_root('SCOTCH')
-            scotch_ver = get_software_version('SCOTCH')
-            if (scotch and LooseVersion(scotch_ver) >= LooseVersion("7.0")):
-                withdep = "--with-ptscotch"
-                scotch_inc = [os.path.join(scotch, "include")]
-                inc_spec = "-include=[%s]" % ','.join(scotch_inc)
+        deps = [dep['name'] for dep in self.cfg.dependencies() if not dep['name'] in depfilter]
+        for dep in deps:
+            if isinstance(dep, str):
+                dep = (dep, dep)
+            deproot = get_software_root(dep[0])
+            if deproot and dep[1] == "SCOTCH":
+                withdep = "--with-pt%s" % dep[1].lower()  # --with-ptscotch
+                self.cfg.update('configopts', '%s=1 %s-dir=%s' % (withdep, withdep, deproot))
 
-                # For some reason there is a v3 suffix added to libptscotchparmetis
-                # which is the reason for this new code;
-                # note: order matters here, don't sort these alphabetically!
-                req_scotch_libs = ['libptesmumps.a', 'libptscotchparmetisv3.a', 'libptscotch.a',
-                                   'libptscotcherr.a', 'libesmumps.a', 'libscotch.a', 'libscotcherr.a']
-                scotch_libs = [os.path.join(scotch, "lib", x) for x in req_scotch_libs]
-                lib_spec = "-lib=[%s]" % ','.join(scotch_libs)
-                self.cfg.update('configopts', ' '.join([withdep + spec for spec in ['=1', inc_spec, lib_spec]]))
+        # SCOTCH has to be treated separately since they add weird postfixes
+        # to library names from SCOTCH 7.0.1 or PETSc version 3.17.
+        scotch = get_software_root('SCOTCH')
+        scotch_ver = get_software_version('SCOTCH')
+        if (scotch and LooseVersion(scotch_ver) >= LooseVersion("7.0")):
+            withdep = "--with-ptscotch"
+            scotch_inc = [os.path.join(scotch, "include")]
+            inc_spec = "-include=[%s]" % ','.join(scotch_inc)
 
-            # SuiteSparse options changed in PETSc 3.5,
-            suitesparse = get_software_root('SuiteSparse')
-            if suitesparse:
-                if LooseVersion(self.version) >= LooseVersion("3.5"):
-                    withdep = "--with-suitesparse"
-                    # specified order of libs matters!
-                    ss_libs = ["UMFPACK", "KLU", "CHOLMOD", "BTF", "CCOLAMD", "COLAMD", "CAMD", "AMD"]
-                    # More libraries added after version 3.17
-                    if LooseVersion(self.version) >= LooseVersion("3.17"):
-                        ss_libs = ["UMFPACK", "KLU", "SPQR", "CHOLMOD", "BTF", "CCOLAMD",
-                                   "COLAMD", "CXSparse", "LDL", "RBio", "SLIP_LU", "CAMD", "AMD"]
+            # For some reason there is a v3 suffix added to libptscotchparmetis
+            # which is the reason for this new code;
+            # note: order matters here, don't sort these alphabetically!
+            req_scotch_libs = ['libptesmumps.a', 'libptscotchparmetisv3.a', 'libptscotch.a',
+                               'libptscotcherr.a', 'libesmumps.a', 'libscotch.a', 'libscotcherr.a']
+            scotch_libs = [os.path.join(scotch, "lib", x) for x in req_scotch_libs]
+            lib_spec = "-lib=[%s]" % ','.join(scotch_libs)
+            self.cfg.update('configopts', ' '.join([withdep + spec for spec in ['=1', inc_spec, lib_spec]]))
 
-                    # SLIP_LU was replaced by SPEX in SuiteSparse >= 6.0
-                    if LooseVersion(get_software_version('SuiteSparse')) >= LooseVersion("6.0"):
-                        ss_libs = [x if x != "SLIP_LU" else "SPEX" for x in ss_libs]
+        # SuiteSparse options
+        suitesparse = get_software_root('SuiteSparse')
+        if suitesparse:
+            withdep = "--with-suitesparse"
+            # specified order of libs matters!
+            ss_libs = ["UMFPACK", "KLU", "CHOLMOD", "BTF", "CCOLAMD", "COLAMD", "CAMD", "AMD"]
+            # More libraries added after version 3.17
+            if LooseVersion(self.version) >= LooseVersion("3.17"):
+                ss_libs = ["UMFPACK", "KLU", "SPQR", "CHOLMOD", "BTF", "CCOLAMD",
+                           "COLAMD", "CXSparse", "LDL", "RBio", "SLIP_LU", "CAMD", "AMD"]
 
-                    suitesparse_inc = os.path.join(suitesparse, "include")
-                    suitesparse_incs = [suitesparse_inc]
-                    # SuiteSparse can install its headers into a subdirectory of the include directory instead.
-                    suitesparse_inc_subdir = os.path.join(suitesparse_inc, 'suitesparse')
-                    if os.path.exists(suitesparse_inc_subdir):
-                        suitesparse_incs.append(suitesparse_inc_subdir)
-                    inc_spec = "-include=[%s]" % ','.join(suitesparse_incs)
+            # SLIP_LU was replaced by SPEX in SuiteSparse >= 6.0
+            if LooseVersion(get_software_version('SuiteSparse')) >= LooseVersion("6.0"):
+                ss_libs = [x if x != "SLIP_LU" else "SPEX" for x in ss_libs]
 
-                    suitesparse_libs = [os.path.join(suitesparse, "lib", "lib%s.so" % x.replace("_", "").lower())
-                                        for x in ss_libs]
-                    lib_spec = "-lib=[%s]" % ','.join(suitesparse_libs)
-                else:
-                    # CHOLMOD and UMFPACK are part of SuiteSparse (PETSc < 3.5)
-                    withdep = "--with-umfpack"
-                    inc_spec = "-include=%s" % os.path.join(suitesparse, "include")
-                    # specified order of libs matters!
-                    umfpack_libs = [os.path.join(suitesparse, "lib", "lib%s.a" % x.lower())
-                                    for x in ["UMFPACK", "CHOLMOD", "COLAMD", "AMD"]]
-                    lib_spec = "-lib=[%s]" % ','.join(umfpack_libs)
+            suitesparse_inc = os.path.join(suitesparse, "include")
+            suitesparse_incs = [suitesparse_inc]
+            # SuiteSparse can install its headers into a subdirectory of the include directory instead.
+            suitesparse_inc_subdir = os.path.join(suitesparse_inc, 'suitesparse')
+            if os.path.exists(suitesparse_inc_subdir):
+                suitesparse_incs.append(suitesparse_inc_subdir)
+            inc_spec = "-include=[%s]" % ','.join(suitesparse_incs)
 
-                self.cfg.update('configopts', ' '.join([withdep + spec for spec in ['=1', inc_spec, lib_spec]]))
+            suitesparse_libs = [os.path.join(suitesparse, "lib", "lib%s.so" % x.replace("_", "").lower())
+                                for x in ss_libs]
+            lib_spec = "-lib=[%s]" % ','.join(suitesparse_libs)
 
-            # set PETSC_DIR for configure (env) and build_step
-            petsc_dir = self.cfg['start_dir'].rstrip(os.path.sep)
-            env.setvar('PETSC_DIR', petsc_dir)
-            self.cfg.update('buildopts', 'PETSC_DIR=%s' % petsc_dir)
+            self.cfg.update('configopts', ' '.join([withdep + spec for spec in ['=1', inc_spec, lib_spec]]))
 
-            if self.cfg['sourceinstall']:
-                if self.petsc_arch:
-                    env.setvar('PETSC_ARCH', self.cfg['petsc_arch'])
+        # set PETSC_DIR for configure (env) and build_step
+        petsc_dir = self.cfg['start_dir'].rstrip(os.path.sep)
+        env.setvar('PETSC_DIR', petsc_dir)
+        self.cfg.update('buildopts', 'PETSC_DIR=%s' % petsc_dir)
 
-                # run configure without --prefix (required)
-                cmd = "%s ./configure %s" % (self.cfg['preconfigopts'], self.cfg['configopts'])
-                res = run_shell_cmd(cmd)
-                out = res.output
+        if self.cfg['sourceinstall']:
+            if self.petsc_arch:
+                env.setvar('PETSC_ARCH', self.cfg['petsc_arch'])
+
+            # run configure without --prefix (required)
+            cmd = "%s ./configure %s" % (self.cfg['preconfigopts'], self.cfg['configopts'])
+            res = run_shell_cmd(cmd)
+            out = res.output
+        else:
+            out = super(EB_PETSc, self).configure_step()
+
+        # check for errors in configure
+        error_regexp = re.compile("ERROR")
+        if error_regexp.search(out):
+            raise EasyBuildError("Error(s) detected in configure output!")
+
+        if self.cfg['sourceinstall']:
+            # figure out PETSC_ARCH setting
+            petsc_arch_regex = re.compile(r"^\s*PETSC_ARCH:\s*(\S+)$", re.M)
+            res = petsc_arch_regex.search(out)
+            if res:
+                self.petsc_arch = res.group(1)
+                self.cfg.update('buildopts', 'PETSC_ARCH=%s' % self.petsc_arch)
             else:
-                out = super(EB_PETSc, self).configure_step()
+                raise EasyBuildError("Failed to determine PETSC_ARCH setting.")
 
-            # check for errors in configure
-            error_regexp = re.compile("ERROR")
-            if error_regexp.search(out):
-                raise EasyBuildError("Error(s) detected in configure output!")
-
-            if self.cfg['sourceinstall']:
-                # figure out PETSC_ARCH setting
-                petsc_arch_regex = re.compile(r"^\s*PETSC_ARCH:\s*(\S+)$", re.M)
-                res = petsc_arch_regex.search(out)
-                if res:
-                    self.petsc_arch = res.group(1)
-                    self.cfg.update('buildopts', 'PETSC_ARCH=%s' % self.petsc_arch)
-                else:
-                    raise EasyBuildError("Failed to determine PETSC_ARCH setting.")
-
-                self.petsc_subdir = self.name.lower()
-                self.prefix_lib = os.path.join(self.petsc_subdir, self.petsc_arch)
-                self.prefix_inc = os.path.join(self.petsc_subdir, self.petsc_arch)
-                self.prefix_bin = os.path.join(self.petsc_subdir, self.petsc_arch)
-            else:
-                self.petsc_subdir = '%s-%s' % (self.name.lower(), self.version)
-
-        else:  # old versions (< 3.x)
-
-            self.cfg.update('configopts', '--prefix=%s' % self.installdir)
-            self.cfg.update('configopts', '--with-shared=1')
-
-            # additional dependencies
-            for dep in ["SCOTCH"]:
-                deproot = get_software_root(dep)
-                if deproot:
-                    withdep = "--with-%s" % dep.lower()
-                    self.cfg.update('configopts', '%s=1 %s-dir=%s' % (withdep, withdep, deproot))
-
-            cmd = "./config/configure.py %s" % self.get_cfg('configopts')
-            run_shell_cmd(cmd)
+            self.petsc_subdir = self.name.lower()
+            self.prefix_lib = os.path.join(self.petsc_subdir, self.petsc_arch)
+            self.prefix_inc = os.path.join(self.petsc_subdir, self.petsc_arch)
+            self.prefix_bin = os.path.join(self.petsc_subdir, self.petsc_arch)
+        else:
+            self.petsc_subdir = '%s-%s' % (self.name.lower(), self.version)
 
         # Make sure to set test_parallel before self.cfg['parallel'] is set to None
         if self.cfg['test_parallel'] is None and self.cfg['parallel']:
             self.cfg['test_parallel'] = self.cfg['parallel']
 
-        # PETSc > 3.5, make does not accept -j
+        # PETSc make does not accept -j
         # to control parallel build, we need to specify MAKE_NP=... as argument to 'make' command
-        if LooseVersion(self.version) >= LooseVersion("3.5"):
-            self.cfg.update('buildopts', "MAKE_NP=%s" % self.cfg['parallel'])
-            self.cfg['parallel'] = None
+        self.cfg.update('buildopts', "MAKE_NP=%s" % self.cfg['parallel'])
+        self.cfg['parallel'] = None
 
     # default make should be fine
 
@@ -372,25 +338,17 @@ class EB_PETSc(ConfigureMake):
         Install using make install (for non-source installations),
         or by symlinking files (old versions, < 3).
         """
-        if LooseVersion(self.version) >= LooseVersion("3"):
-            if not self.cfg['sourceinstall']:
-                super(EB_PETSc, self).install_step()
-                petsc_root = self.installdir
-            else:
-                petsc_root = os.path.join(self.installdir, self.petsc_subdir)
-            # Remove MPI-CXX flags added during configure to prevent them from being passed to consumers of PETsc
-            petsc_variables_path = os.path.join(petsc_root, 'lib', 'petsc', 'conf', 'petscvariables')
-            if os.path.isfile(petsc_variables_path):
-                fix = (r'^(CXX_FLAGS|CXX_LINKER_FLAGS|CONFIGURE_OPTIONS)( = .*)%s(.*)$' % NO_MPI_CXX_EXT_FLAGS,
-                       r'\1\2\3')
-                apply_regex_substitutions(petsc_variables_path, [fix])
-
-        else:  # old versions (< 3.x)
-
-            for fn in ['petscconf.h', 'petscconfiginfo.h', 'petscfix.h', 'petscmachineinfo.h']:
-                includedir = os.path.join(self.installdir, 'include')
-                bmakedir = os.path.join(self.installdir, 'bmake', 'linux-gnu-c-opt')
-                symlink(os.path.join(bmakedir, fn), os.path.join(includedir, fn))
+        if not self.cfg['sourceinstall']:
+            super(EB_PETSc, self).install_step()
+            petsc_root = self.installdir
+        else:
+            petsc_root = os.path.join(self.installdir, self.petsc_subdir)
+        # Remove MPI-CXX flags added during configure to prevent them from being passed to consumers of PETsc
+        petsc_variables_path = os.path.join(petsc_root, 'lib', 'petsc', 'conf', 'petscvariables')
+        if os.path.isfile(petsc_variables_path):
+            fix = (r'^(CXX_FLAGS|CXX_LINKER_FLAGS|CONFIGURE_OPTIONS)( = .*)%s(.*)$' % NO_MPI_CXX_EXT_FLAGS,
+                   r'\1\2\3')
+            apply_regex_substitutions(petsc_variables_path, [fix])
 
     def make_module_req_guess(self):
         """Specify PETSc custom values for PATH, CPATH and LD_LIBRARY_PATH."""
@@ -432,10 +390,7 @@ class EB_PETSc(ConfigureMake):
             'dirs': [os.path.join(self.prefix_bin, 'bin'), os.path.join(self.prefix_inc, 'include'),
                      os.path.join(self.prefix_lib, 'include')]
         }
-        if LooseVersion(self.version) < LooseVersion('3.6'):
-            custom_paths['dirs'].append(os.path.join(self.prefix_lib, 'conf'))
-        else:
-            custom_paths['dirs'].append(os.path.join(self.prefix_lib, 'lib', 'petsc', 'conf'))
+        custom_paths['dirs'].append(os.path.join(self.prefix_lib, 'lib', 'petsc', 'conf'))
 
         custom_commands = []
         if self.with_python:

--- a/easybuild/easyblocks/p/petsc.py
+++ b/easybuild/easyblocks/p/petsc.py
@@ -380,8 +380,7 @@ class EB_PETSc(ConfigureMake):
 
     def install_step(self):
         """
-        Install using make install (for non-source installations),
-        or by symlinking files (old versions, < 3).
+        Install using make install (for non-source installations)
         """
         if not self.cfg['sourceinstall']:
             super(EB_PETSc, self).install_step()

--- a/easybuild/easyblocks/p/petsc.py
+++ b/easybuild/easyblocks/p/petsc.py
@@ -109,22 +109,30 @@ class EB_PETSc(ConfigureMake):
 
     @property
     def bin_dir(self):
-        """Return relative path to directory with executables of PETSc"""
+        """Relative path to directory with executables of PETSc"""
+        # default: "lib/petsc/bin"
+        # sourceinstall: "petsc-{version}/lib/petsc/bin"
         return os.path.join(self.petsc_subdir, 'lib', 'petsc', 'bin')
 
     @property
     def cnf_dir(self):
-        """Return relative path to directory with configuration executables of PETSc"""
+        """Relative path to directory with configuration executables of PETSc"""
+        # default: "lib/petsc/conf"
+        # sourceinstall: "petsc-{version}/{arch}/lib/petsc/conf"
         return os.path.join(self.petsc_subdir, self.arch_subdir, 'lib', 'petsc', 'conf')
 
     @property
     def lib_dir(self):
-        """Return relative path to directory with libraries of PETSc"""
+        """Relative path to directory with libraries of PETSc"""
+        # default: "lib"
+        # sourceinstall: "petsc-{version}/{arch}/lib"
         return os.path.join(self.petsc_subdir, self.arch_subdir, 'lib')
 
     @property
     def inc_dirs(self):
-        """Return relative path to directory with headers of PETSc"""
+        """Relative path to directory with headers of PETSc"""
+        # default: "include"
+        # sourceinstall: "petsc-{version}/include" and "petsc-{version}/{arch}/include"
         if self.cfg['sourceinstall']:
             return [
                 os.path.join(self.petsc_subdir, 'include'),

--- a/test/easyblocks/init_easyblocks.py
+++ b/test/easyblocks/init_easyblocks.py
@@ -247,6 +247,9 @@ def suite():
         elif easyblock_fn == 'paraver.py':
             # custom easyblock for Paraver requires version >= 4.7
             innertest = make_inner_test(easyblock, version='4.8')
+        elif easyblock_fn == 'petsc.py':
+            # custom easyblock for PETSc has a minimum version requirement
+            innertest = make_inner_test(easyblock, version='99.9')
         elif easyblock_fn in ['python.py', 'tkinter.py']:
             # custom easyblock for Python (ensurepip) requires version >= 3.4.0
             innertest = make_inner_test(easyblock, version='3.4.0')

--- a/test/easyblocks/module.py
+++ b/test/easyblocks/module.py
@@ -479,6 +479,9 @@ def suite():
         elif eb_fn == 'paraver.py':
             # custom easyblock for Paraver requires version >= 4.7
             innertest = make_inner_test(easyblock, name='Paraver', version='4.8')
+        elif eb_fn == 'petsc.py':
+            # custom easyblock for PETSc has a minimum required version
+            innertest = make_inner_test(easyblock, name='PETSc', version='99.9')
         elif eb_fn in ['python.py', 'tkinter.py']:
             # custom easyblock for Python (ensurepip) requires version >= 3.4.0
             innertest = make_inner_test(easyblock, name=eb_fn.replace('_', '-')[:-3], version='3.4.0')


### PR DESCRIPTION
This one became bigger than expected:
* remove code for versions of PETSc prior to v3.9 (2018a)
* set version 3.9 as minimum supported version (error on lower versions)
* replace `make_module_req_guess` with `module_load_environment` on init (for [#3527](https://github.com/easybuilders/easybuild-easyblocks/issues/3527))
* replace attributes `prefix_bin`, `prefix_lib` and `prefix_inc` with properties `bin_dir`, `lib_dir` and `inc_dirs` to more clearly define the location of files depending on the type of install (regular installs and `sourceinstall` installs have quite different topologies)
* fix installations with `sourceinstall` enabled in `module-only` mode by adding an extra check on PETSC_ARCH in the sanity check step
