### PR TITLE
enhance handling of `PETSC_ARCH` and adopt `module_load_environment` in SLEPc easyblock

### DIFF
--- a/easybuild/easyblocks/s/slepc.py
+++ b/easybuild/easyblocks/s/slepc.py
@@ -117,6 +117,13 @@ class EB_SLEPc(ConfigureMake):
         if LooseVersion(self.version) >= LooseVersion("3.5"):
             self.cfg['parallel'] = None
 
+    def install_step(self):
+        """
+        Install using make install (for non-source installations)
+        """
+        if not self.cfg['sourceinstall']:
+            super(EB_SLEPc, self).install_step()
+
     def make_module_extra(self):
         """Set SLEPc specific environment variables (SLEPC_DIR)."""
         txt = super(EB_SLEPc, self).make_module_extra()

--- a/easybuild/easyblocks/s/slepc.py
+++ b/easybuild/easyblocks/s/slepc.py
@@ -61,6 +61,9 @@ class EB_SLEPc(ConfigureMake):
         if self.cfg['petsc_arch'] is None:
             self.petsc_arch = 'arch-installed-petsc'
 
+        # define $PETSC_ARCH in build environment
+        env.setvar('PETSC_ARCH', self.petsc_arch)
+
         self.slepc_subdir = ''
 
         if self.cfg['sourceinstall']:
@@ -109,9 +112,6 @@ class EB_SLEPc(ConfigureMake):
         error_regexp = re.compile("ERROR")
         if error_regexp.search(out):
             raise EasyBuildError("Error(s) detected in configure output!")
-
-        # define $PETSC_ARCH
-        env.setvar('PETSC_ARCH', self.petsc_arch)
 
         # SLEPc > 3.5, make does not accept -j
         if LooseVersion(self.version) >= LooseVersion("3.5"):


### PR DESCRIPTION
Update of SLEPc easyblock for https://github.com/easybuilders/easybuild-easyblocks/issues/3527

This PR for SLEPc is much simpler than its counterpart for PETSc (#3627) because `$PETSC_ARCH` is known early in the installation:
* if PETSc (dependency) defines `$PETSC_ARCH`, SLEPc will not change it (even with a custom `petsc_arch` parameter)
* if PETSc (dependency) does not define `$PETSC_ARCH`, SLEPc can define a custom `petsc_arch` for installations with `sourceinstall` enabled

This PR moves some assignments into the prepare step, where `petsc_arch` and `slepc_subdir` become defined.

This PR also replaces `module_make_req_guess` with `module_load_environment`  in the prepare step.