### PR TITLE
recursive glob expansion of library files in GROMACS and convert `lib_subdirs` into a property

### DIFF
--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -571,7 +571,7 @@ class EB_GROMACS(CMakeMake):
 
         lib_subdirs = []
         real_installdir = os.path.realpath(self.installdir)
-        for lib_path in glob.glob(os.path.join(real_installdir, '**', libname)):
+        for lib_path in glob.glob(os.path.join(real_installdir, '**', libname), recursive=True):
             lib_relpath = os.path.realpath(lib_path)  # avoid symlinks
             lib_relpath = lib_relpath[len(real_installdir) + 1:]  # relative path from installdir
             subdir = lib_relpath.split(os.sep)[0:-1]


### PR DESCRIPTION
Minor changes for GROMACS easyblock:
* bugfix: enable `recursive` glob expansion, otherwise the double star in the pattern doesn't do what it intends `**`
* cleanup: convert `lib_subdirs` into a property that handles the population of list if library subdirs from wherever it is called

This PR has no effective changes on the resulting installation of existing GROMACS easyconfigs or their modules.

Can be tested with `--module-only`