### PR TITLE
AOCC: Use bash for compiler wrapper

### DIFF
--- a/easybuild/easyblocks/a/aocc.py
+++ b/easybuild/easyblocks/a/aocc.py
@@ -48,7 +48,7 @@ from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext, get_cpu_architecture
 
 # Wrapper script definition
-WRAPPER_TEMPLATE = """#!/bin/sh
+WRAPPER_TEMPLATE = """#!/bin/bash
 
 # Patch argv[0] to the actual compiler so that the correct driver is used internally
 (exec -a "%(actual_compiler_name)s" %(compiler_name)s --gcc-toolchain=$EBROOTGCCCORE "$@")


### PR DESCRIPTION
AOCC 4.2.0 and lower (and `flang` for AOCC 5.0.0) use compiler wrappers to include the GCC toolchain in the compiler command. The original compilers are renamed, and a shell script is created running 'exec' which passes the original compiler name as an argument.

This however can fail if `/bin/sh` is used. On Ubuntu 22.04 LTS, using `exec -a` causes the following error message, which then causes the sanity check to fail:

```
$ exec -a "echo" echo "Hello World"
sh: 1: exec: -a: not found
```

To work around this, use `/bin/bash` instead.