### PR TITLE
update workflows to use Ubuntu 22.04

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -10,12 +10,12 @@ concurrency:
 
 jobs:
   python-linting:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
     - name: set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: 3.8
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -10,10 +10,10 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
+        python: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
         modules_tool: [Lmod-8.1.14, modules-tcl-1.147, modules-3.2.10, modules-4.5.3]
         module_syntax: [Lua, Tcl]
         # exclude some configuration for non-Lmod modules tool:
@@ -64,10 +64,10 @@ jobs:
             python: '3.12'
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
     - name: set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: ${{matrix.python}}
         architecture: x64

--- a/test/easyblocks/module.py
+++ b/test/easyblocks/module.py
@@ -233,7 +233,7 @@ class ModuleOnlyTest(TestCase):
         self.assertTrue(pick_python_cmd(3) is not None)
         self.assertTrue(pick_python_cmd(3, 6) is not None)
         self.assertTrue(pick_python_cmd(123, 456) is None)
-        self.assertTrue(pick_python_cmd(2, 6, 123, 456) is not None)
+        self.assertTrue(pick_python_cmd(3, 6, 123, 456) is not None)
         self.assertTrue(pick_python_cmd(2, 6, 1, 1) is None)
 
 


### PR DESCRIPTION
Ubuntu 20.04 image for GitHub Actions is deprecated since 2025-02-01, see also https://github.com/actions/runner-images/issues/11101