### PR TITLE
updates + fixes for GitHub Actions workflows

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -12,10 +12,10 @@ jobs:
   python-linting:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
     - name: set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: 3.8
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -10,12 +10,12 @@ concurrency:
 
 jobs:
   python-linting:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+    - uses: actions/checkout@v4
 
     - name: set up Python
-      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -58,10 +58,10 @@ jobs:
             python: '3.12'
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
     - name: set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: ${{matrix.python}}
         architecture: x64

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -18,7 +18,7 @@ jobs:
         module_syntax: [Lua, Tcl]
         # exclude some configuration for non-Lmod modules tool:
         # - don't test with Lua module syntax (only supported in Lmod)
-        # - don't test with Python 3.7+ (only with 3.6), to limit test configurations
+        # - don't test with Python 3.8+ (only with 3.7), to limit test configurations
         exclude:
           - modules_tool: modules-tcl-1.147
             module_syntax: Lua
@@ -27,8 +27,6 @@ jobs:
           - modules_tool: modules-4.5.3
             module_syntax: Lua
           - modules_tool: modules-tcl-1.147
-            python: 3.7
-          - modules_tool: modules-tcl-1.147
             python: 3.8
           - modules_tool: modules-tcl-1.147
             python: 3.9
@@ -39,8 +37,6 @@ jobs:
           - modules_tool: modules-tcl-1.147
             python: '3.12'
           - modules_tool: modules-3.2.10
-            python: 3.7
-          - modules_tool: modules-3.2.10
             python: 3.8
           - modules_tool: modules-3.2.10
             python: 3.9
@@ -50,8 +46,6 @@ jobs:
             python: '3.11'
           - modules_tool: modules-3.2.10
             python: '3.12'
-          - modules_tool: modules-4.5.3
-            python: 3.7
           - modules_tool: modules-4.5.3
             python: 3.8
           - modules_tool: modules-4.5.3
@@ -64,10 +58,10 @@ jobs:
             python: '3.12'
       fail-fast: false
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+    - uses: actions/checkout@v4
 
     - name: set up Python
-      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+      uses: actions/setup-python@v5
       with:
         python-version: ${{matrix.python}}
         architecture: x64
@@ -79,11 +73,6 @@ jobs:
         # sudo apt-get update
         # for modules tool
         sudo apt-get install lua5.2 liblua5.2-dev lua-filesystem lua-posix tcl tcl-dev
-        # fix for lua-posix packaging issue, see https://bugs.launchpad.net/ubuntu/+source/lua-posix/+bug/1752082
-        # needed for Ubuntu 18.04, but not for Ubuntu 20.04, so skipping symlinking if posix.so already exists
-        if [ ! -e /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so ] ; then
-            sudo ln -s /usr/lib/x86_64-linux-gnu/lua/5.2/posix_c.so /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so
-        fi
         # for testing OpenMPI-system*eb we need to have Open MPI installed
         sudo apt-get install libopenmpi-dev openmpi-bin
         # Python packages

--- a/test/easyblocks/module.py
+++ b/test/easyblocks/module.py
@@ -229,6 +229,10 @@ class ModuleOnlyTest(TestCase):
     def test_pythonpackage_pick_python_cmd(self):
         """Test pick_python_cmd function from pythonpackage.py."""
         from easybuild.easyblocks.generic.pythonpackage import pick_python_cmd
+        # Install a dummy Python to use. It only needs to echo the major, minor and patch version
+        tmpdir = tempfile.mkdtemp()
+        for cmd in ('python2', 'python2.6'):
+            install_fake_command(cmd, "#!/bin/bash\n echo 2.6.4", tmpdir)
         self.assertTrue(pick_python_cmd() is not None)
         self.assertTrue(pick_python_cmd(3) is not None)
         self.assertTrue(pick_python_cmd(3, 6) is not None)


### PR DESCRIPTION
Rebase of https://github.com/easybuilders/easybuild-easyblocks/pull/3652 for 5.0x

- Use Ubuntu 24 for linting
- Readd missing tests for modules-tool (3.6 is no longer tested so removing 3.7 removes **all** jobs)
- Fix failing test depending on OS