### PR TITLE
Fix llvm18 rpath

### DIFF
--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -909,12 +909,15 @@ class EB_LLVM(CMakeMake):
             # needs more digging into the CMake logic
             if build_option('rpath') and LooseVersion(self.version) < LooseVersion('19') and self.cfg['build_runtimes']:
                 self.log.warning("Removing rpath wrapping of compiler from test suite as it will result in errors")
+                to_patch = set(['cmake-bridge.cfg.in'])
                 bin_dir = os.path.join(self.final_dir, 'bin')
-                subst = [('/tmp/.*/rpath_wrappers/clangxx_wrapper', bin_dir)]
-                for root, dirs, files in os.walk(self.final_dir):
-                    if 'cmake-bridge.cfg' in files:
-                        fpath = os.path.join(root, 'cmake-bridge.cfg')
-                        apply_regex_substitutions(fpath, subst)
+                clangxx = os.path.join(bin_dir, 'clang++')
+                subst = [('@CMAKE_CXX_COMPILER@', clangxx)]
+                for root, dirs, files in os.walk(self.llvm_src_dir):
+                    for file in files:
+                        if file in to_patch:
+                            fpath = os.path.join(root, file)
+                            apply_regex_substitutions(fpath, subst)
 
             num_failed = self._para_test_step(parallel=1)
             if num_failed is None:

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -905,8 +905,8 @@ class EB_LLVM(CMakeMake):
             self.ignore_patterns = self.cfg['test_suite_ignore_patterns'] or []
 
             # When rpath is enabled, the easybuild rpath wrapper will be used for compiling the tests
-            # A combination of -Werror and the wrapper translating LD_LIBRARY_PATH to -Wl,... flags will results in failing
-            # tests due to -Wunused-command-line-argument
+            # A combination of -Werror and the wrapper translating LD_LIBRARY_PATH to -Wl,...
+            # flags will results in failing tests due to -Wunused-command-line-argument
             # This has shown to be a problem in builds for 18.1.8, but seems it was not necessary for LLVM >= 19
             # needs more digging into the CMake logic
             if build_option('rpath') and LooseVersion(self.version) < LooseVersion('19') and self.cfg['build_runtimes']:
@@ -923,7 +923,7 @@ class EB_LLVM(CMakeMake):
                 bin_dir = os.path.join(self.final_dir, 'bin')
                 clangxx = os.path.join(bin_dir, 'clang++')
                 subst = [('@CMAKE_CXX_COMPILER@', clangxx)]
-                for root, dirs, files in os.walk(self.llvm_src_dir):
+                for root, _dirs, files in os.walk(self.llvm_src_dir):
                     for file in files:
                         if file in to_patch:
                             fpath = os.path.join(root, file)


### PR DESCRIPTION
This is a Fix for the errors observer in 

- https://github.com/easybuilders/easybuild-easyconfigs/pull/21832#issuecomment-2701853276
- https://github.com/easybuilders/easybuild-easyconfigs/pull/21833#issuecomment-2701828795

Fixes https://github.com/easybuilders/easybuild-easyconfigs/issues/22509

Previously a fix was tested by setting `CFLAGS` and `CXXFLAGS` to add `-Wno-unused-command-line-argument` before running `make check-all` but this did not fix the problem as this was not being used (the CMake during the build step is responsible for this and probably in 18.1.X not all flags are properly set for the tests of the runtimes).

Manually fixing the Compiler path to the non RPATH-wrapped one in the `*.cfg.in` files for the runtime tests seems to fix this.

This leads to a few other errors in the offloading test suite which i believe can be ignored as offloading in 18.1.8 is still not mature (and this do not seem to appear in 19.X)