### PR TITLE
make AOCC compiler wrappers aware of keepsymlinks option

### DIFF
--- a/easybuild/easyblocks/a/aocc.py
+++ b/easybuild/easyblocks/a/aocc.py
@@ -48,7 +48,7 @@ from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext, get_cpu_architecture
 
 # Wrapper script definition
-WRAPPER_TEMPLATE = """#!/bin/sh
+WRAPPER_TEMPLATE = """#!/bin/bash
 
 # Patch argv[0] to the actual compiler so that the correct driver is used internally
 (exec -a "$0" {compiler_name} --gcc-toolchain=$EBROOTGCCCORE "$@")

--- a/easybuild/easyblocks/a/aocc.py
+++ b/easybuild/easyblocks/a/aocc.py
@@ -226,7 +226,7 @@ class EB_AOCC(PackedBinary):
             compilers_to_wrap += [
                 f'clang-{LooseVersion(self.clangversion).version[0]}',
             ]
-            if self.cfg['keepsymlinks'] is False:
+            if not self.cfg['keepsymlinks']:
                 compilers_to_wrap += [
                     'clang',
                     'clang++',


### PR DESCRIPTION
AOCC easyblock is broken since the recent change enabling `keepsymlinks` by default. More information: https://github.com/easybuilders/easybuild-framework/issues/4794

This PR makes AOCC aware of `keepsymlinks`. Wrappers will only be made for _real_ executables and the wrapper is updated to forward whatever command is used to execute the compiler (_i.e._ the wrapper forwards `$0`).