### PR TITLE
convert RUNPATH into RPATH for Rust binaries in recent Rust versions (> 1.79.0)

### DIFF
--- a/easybuild/easyblocks/r/rust.py
+++ b/easybuild/easyblocks/r/rust.py
@@ -65,7 +65,7 @@ class EB_Rust(ConfigureMake):
         # for Rust > 1.79.0, we also need to replace RUNPATH with RPATH in binaries like cargo and rustc
         if LooseVersion(self.version) > LooseVersion('1.79.0'):
             binaries = glob.glob(os.path.join(self.installdir, 'bin', '*'))
-            runpath_files = [file for file in binaries if is_binary(read_file(file, mode='rb'))]
+            runpath_files.extend([x for x in binaries if is_binary(read_file(x, mode='rb'))])
 
         for runpath_file in runpath_files:
             res = run_shell_cmd(f"readelf -d {runpath_file}", hidden=True)


### PR DESCRIPTION
Installations on Rust v1.80+ with RPATH enabled fail on the sanity checks of the binaries:

```
Sanity check failed: No '(RPATH)' found in 'readelf -d' output for /user/brussel/101/vsc10122/easybuild/install/zen4/software/Rust/1.83.0-GCCcore-13.3.0/bin/miri
No '(RPATH)' found in 'readelf -d' output for /user/brussel/101/vsc10122/easybuild/install/zen4/software/Rust/1.83.0-GCCcore-13.3.0/bin/cargo-clippy
No '(RPATH)' found in 'readelf -d' output for /user/brussel/101/vsc10122/easybuild/install/zen4/software/Rust/1.83.0-GCCcore-13.3.0/bin/cargo-fmt
No '(RPATH)' found in 'readelf -d' output for /user/brussel/101/vsc10122/easybuild/install/zen4/software/Rust/1.83.0-GCCcore-13.3.0/bin/cargo-miri
No '(RPATH)' found in 'readelf -d' output for /user/brussel/101/vsc10122/easybuild/install/zen4/software/Rust/1.83.0-GCCcore-13.3.0/bin/rustdoc
No '(RPATH)' found in 'readelf -d' output for /user/brussel/101/vsc10122/easybuild/install/zen4/software/Rust/1.83.0-GCCcore-13.3.0/bin/rustfmt
No '(RPATH)' found in 'readelf -d' output for /user/brussel/101/vsc10122/easybuild/install/zen4/software/Rust/1.83.0-GCCcore-13.3.0/bin/rust-analyzer
No '(RPATH)' found in 'readelf -d' output for /user/brussel/101/vsc10122/easybuild/install/zen4/software/Rust/1.83.0-GCCcore-13.3.0/bin/rustc
No '(RPATH)' found in 'readelf -d' output for /user/brussel/101/vsc10122/easybuild/install/zen4/software/Rust/1.83.0-GCCcore-13.3.0/bin/cargo
No '(RPATH)' found in 'readelf -d' output for /user/brussel/101/vsc10122/easybuild/install/zen4/software/Rust/1.83.0-GCCcore-13.3.0/bin/clippy-driver" (at easybuild/easybuild-framework/easybuild/main.py:178 in build_and_install_software)
```

These binaries have RUNPATHs instead of RPATHs. Currently, the Rust easyblock converts RUNPATHS to RPATHS for the libraries, but not the executables. This PR adds binaries inside `bin` into the conversion.