### PR TITLE
update configuration options for version 4+ of MPICH

### DIFF
--- a/easybuild/easyblocks/m/mpich.py
+++ b/easybuild/easyblocks/m/mpich.py
@@ -92,23 +92,29 @@ class EB_MPICH(ConfigureMake):
         # additional configuration options
         add_configopts = []
 
-        # use POSIX threads
-        add_configopts.append('--with-thread-package=pthreads')
-
         if self.cfg['debug']:
             # debug build, with error checking, timing and debug info
             # note: this will affect performance
-            add_configopts.append('--enable-fast=none')
+            if LooseVersion(self.version) < LooseVersion('4.0.0'):
+                add_configopts.append('--enable-fast=none')
+            else:
+                add_configopts.append('--enable-error-checking=all')
+                add_configopts.append('--enable-timing=runtime')
+                add_configopts.append('--enable-debuginfo')
         else:
             # optimized build, no error checking, timing or debug info
-            add_configopts.append('--enable-fast')
+            if LooseVersion(self.version) < LooseVersion('4.0.0'):
+                add_configopts.append('--enable-fast')
+            else:
+                add_configopts.append('--enable-error-checking=no')
+                add_configopts.append('--enable-timing=none')
 
         # enable shared libraries, using GCC and GNU ld options
-        add_configopts.extend(['--enable-shared', '--enable-sharedlibs=gcc'])
+        add_configopts.append('--enable-shared')
         # enable static libraries
-        add_configopts.extend(['--enable-static'])
+        add_configopts.append('--enable-static')
         # enable Fortran 77/90 and C++ bindings
-        add_configopts.extend(['--enable-f77', '--enable-fc', '--enable-cxx'])
+        add_configopts.extend(['--enable-fortran=all', '--enable-cxx'])
 
         self.cfg.update('configopts', ' '.join(add_configopts))
 


### PR DESCRIPTION
Build fails due to changes in EB5 related to unknown configuration options.

```
== Results of the build can be found in the log file(s) /user/brussel/101/vsc10122/easybuild/install/zen4/log/easybuild-MPICH-4.2.2-20250313.025805.axOEo.log
   2 == 2025-03-13 03:03:02,367 build_log.py:226 ERROR EasyBuild encountered an error (at easybuild/easybuild-framework/easybuild/base/exceptions.py:126 in __init__): Found unrecognized co
     nfigure options: --with-devices, --with-thread-package, --enable-sharedlibs, --enable-fc (at easybuild/easybuild-framework/easybuild/main.py:140 in build_and_install_software)
   1 == 2025-03-13 03:03:02,370 build_log.py:226 ERROR EasyBuild encountered an error (at easybuild/easybuild-framework/easybuild/base/exceptions.py:126 in __init__): Installation of MPICH
     -4.2.2-GCC-13.3.0.eb failed: 'Found unrecognized configure options: --with-devices, --with-thread-package, --enable-sharedlibs, --enable-fc' (at easybuild/easybuild-framework/easybuil
     d/main.py:178 in build_and_install_software)
3663 ERROR: Installation of MPICH-4.2.2-GCC-13.3.0.eb failed: 'Found unrecognized configure options: --with-devices, --with-thread-package, --enable-sharedlibs, --enable-fc'
```

Current configuration options seem to be ancient, some are already deprecated in MPICH v3.

Companion PR in easyconfigs: https://github.com/easybuilders/easybuild-easyconfigs/pull/22555