### PR TITLE
update Amber easyblock for version 24.x and newer

### DIFF
--- a/easybuild/easyblocks/a/amber.py
+++ b/easybuild/easyblocks/a/amber.py
@@ -329,7 +329,11 @@ class EB_Amber(CMakeMake):
 
         # Run the tests located in the build directory
         if self.cfg['runtest']:
-            pretestcommands = 'source %s/amber.sh && cd %s' % (self.installdir, self.builddir)
+            if LooseVersion(self.version) >= LooseVersion('24'):
+                testdir = os.path.join(self.builddir, 'test')
+            else:
+                testdir = self.builddir
+            pretestcommands = 'source %s/amber.sh && cd %s' % (self.installdir, testdir)
 
             # serial tests
             run_shell_cmd("%s && make test.serial" % pretestcommands)


### PR DESCRIPTION
The directory structure appears to have changed in amber24, the path where the tests are executed had to be adapted.