### PR TITLE
Fix access to unassigned variable when installing Python < 3.9.1 with using sysroot 

### DIFF
--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -284,9 +284,9 @@ class EB_Python(ConfigureMake):
         }
 
         exts_default_options = self.cfg.get_ref('exts_default_options')
-        for key in ext_defaults:
+        for key, default_value in ext_defaults.items():
             if key not in exts_default_options:
-                exts_default_options[key] = ext_defaults[key]
+                exts_default_options[key] = default_value
         self.log.debug("exts_default_options: %s", self.cfg['exts_default_options'])
 
         self.install_pip = self.cfg['install_pip']

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -401,7 +401,6 @@ class EB_Python(ConfigureMake):
             # Have confirmed for all versions starting with this one that _findSoname_ldconfig hardcodes /sbin/ldconfig
             if LooseVersion(self.version) >= "3.9.1":
                 orig_ld_config_call = "with subprocess.Popen(['/sbin/ldconfig', '-p'],"
-            if orig_ld_config_call:
                 ctypes_util_py = os.path.join("Lib", "ctypes", "util.py")
                 orig_ld_config_call_regex = r'(\s*)' + re.escape(orig_ld_config_call) + r'(\s*)'
                 updated_ld_config_call = "with subprocess.Popen(['%s/sbin/ldconfig', '-p']," % sysroot


### PR DESCRIPTION
```
if LooseVersion(self.version) >= "3.9.1":
    orig_ld_config_call = "with subprocess.Popen(['/sbin/ldconfig', '-p'],"
if orig_ld_config_call:
```

This code will crash when the Python version to be installed is less than 3.9.1 as the variable is unbound/unset in that case.
Fix is trivial: Remove the line of the 2nd if as this is the only place where the variable is set

I included 2 other changes suggested by PyLint:
- Use `dict.items` instead of iterating over keys and then requesting values
- Combine nested (single) ifs to remove one level of indentation at the cost of a longer condition

I can remove one or both again but IMO they make sense. At least the former which doesn't has any drawbacks I can see