### PR TITLE
don't build GO tests by default for LLVM versions < 16

### DIFF
--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -349,6 +349,10 @@ class EB_LLVM(CMakeMake):
         if self.cfg['build_bolt']:
             self.final_projects.append('bolt')
 
+        # Fix for https://github.com/easybuilders/easybuild-easyblocks/issues/3689
+        if LooseVersion(self.version) < LooseVersion('16'):
+            general_opts['LLVM_INCLUDE_GO_TESTS'] = 'OFF'
+
         # Sysroot
         sysroot = build_option('sysroot')
         if sysroot:

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -452,6 +452,7 @@ class EB_LLVM(CMakeMake):
                 self.log.debug("Enabling `amdgpu` offload target")
 
         general_opts['CMAKE_BUILD_TYPE'] = self.build_type
+
         general_opts['LLVM_TARGETS_TO_BUILD'] = '"%s"' % ';'.join(build_targets)
 
         self._cmakeopts = {}

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -452,7 +452,6 @@ class EB_LLVM(CMakeMake):
                 self.log.debug("Enabling `amdgpu` offload target")
 
         general_opts['CMAKE_BUILD_TYPE'] = self.build_type
-
         general_opts['LLVM_TARGETS_TO_BUILD'] = '"%s"' % ';'.join(build_targets)
 
         self._cmakeopts = {}


### PR DESCRIPTION
Should be tested with some LLVM ECs < 16 and atleast one full build with LLVM > 19

- fixes #3689
- fixes #3680
