### PR TITLE
Don't modify `self.cfg['configopts']` in CMakeMake easyblock

### DIFF
--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -213,7 +213,7 @@ class CMakeMake(ConfigureMake):
         # All options are of the form '-D<key>=<value>'
         new_opts = ' '.join('-D%s=%s' % (key, value) for key, value in config_opts.items()
                             if '-D%s=' % key not in cfg_configopts)
-        self.cfg['configopts'] = ' '.join([new_opts, cfg_configopts])
+        return ' '.join([new_opts, cfg_configopts])
 
     def configure_step(self, srcdir=None, builddir=None):
         """Configure build using cmake"""
@@ -383,12 +383,11 @@ class CMakeMake(ConfigureMake):
         self.cmake_options = options
 
         if self.cfg.get('configure_cmd') == DEFAULT_CONFIGURE_CMD:
-            self.prepend_config_opts(options)
             command = ' '.join([
                 self.cfg['preconfigopts'],
                 DEFAULT_CONFIGURE_CMD,
                 generator,
-                self.cfg['configopts'],
+                self.prepend_config_opts(options),
                 srcdir])
         else:
             command = ' '.join([


### PR DESCRIPTION
We use `multi_deps` a lot, e.g. in
https://github.com/ComputeCanada/easybuild-easyconfigs/blob/computecanada-main/easybuild/easyconfigs/r/RDKit/RDKit-2024.03.5-GCC-12.3.0.eb
The problem was now that `CMakeMake` automatically adds `-DPython_EXECUTABLE` and `-DPython3_EXECUTABLE` pointing to e.g. first python 3.10 but in the second iteration the logic keeps it that way in `configopts`, and it's wrong since there it should be pointing to 3.11 instead.

We can avoid this by *not* modifying `configopts`, so it's reconstructed from scratch in every iteration. Another way would be to use `$EBROOTPYTHON` and let the shell expand the path, instead of `get_software_root()`.