### PR TITLE
clean up easyblocks to let `CMakeMake` they derive from set `cmake` option to specify Python paths

### DIFF
--- a/easybuild/easyblocks/a/amber.py
+++ b/easybuild/easyblocks/a/amber.py
@@ -165,7 +165,6 @@ class EB_Amber(CMakeMake):
         pythonroot = get_software_root('Python')
         if pythonroot:
             self.cfg.update('configopts', '-DDOWNLOAD_MINICONDA=FALSE')
-            self.cfg.update('configopts', '-DPYTHON_EXECUTABLE=%s' % os.path.join(pythonroot, 'bin', 'python'))
 
             self.pylibdir = det_pylibdir()
             pythonpath = os.environ.get('PYTHONPATH', '')

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -332,12 +332,6 @@ class EB_GROMACS(CMakeMake):
                     python_root = get_software_root('Python')
                     if python_root:
                         self.cfg.update('configopts', "-DGMX_PYTHON_PACKAGE=ON")
-                        bin_python = os.path.join(python_root, 'bin', 'python')
-                        # For find_package(PythonInterp)
-                        self.cfg.update('configopts', "-DPYTHON_EXECUTABLE=%s" % bin_python)
-                        if gromacs_version >= '2021':
-                            # For find_package(Python3) - Ignore virtual envs
-                            self.cfg.update('configopts', "-DPython3_FIND_VIRTUALENV=STANDARD")
 
             # Now patch GROMACS for PLUMED before cmake
             if plumed_root:

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -588,11 +588,6 @@ class EB_LAMMPS(CMakeMake):
                 raise EasyBuildError("Failed to determine Python include dir: %s", res.output)
             python_include_dir = res.output.strip()
 
-            # Whether you need one or the other of the options below depends on the version of CMake and LAMMPS
-            # Rather than figure this out, use both (and one will be ignored)
-            self.cfg.update('configopts', '-DPython_EXECUTABLE=%s/bin/python' % python_dir)
-            self.cfg.update('configopts', '-DPYTHON_EXECUTABLE=%s/bin/python' % python_dir)
-
             # Older LAMMPS need more hints to get things right as they use deprecated CMake packages
             self.cfg.update('configopts', '-DPYTHON_LIBRARY=%s' % python_lib_path)
             self.cfg.update('configopts', '-DPYTHON_INCLUDE_DIR=%s' % python_include_dir)

--- a/easybuild/easyblocks/n/neuron.py
+++ b/easybuild/easyblocks/n/neuron.py
@@ -88,7 +88,6 @@ class EB_NEURON(CMakeMake):
         if self.python_root:
             python_cfgopts = " ".join([
                 "-DNRN_ENABLE_PYTHON=ON",
-                f"-DPYTHON_EXECUTABLE={self.python_root}/bin/python",
                 "-DNRN_ENABLE_MODULE_INSTALL=ON",
                 f"-DNRN_MODULE_INSTALL_OPTIONS='--prefix={self.installdir}'",
             ])
@@ -100,7 +99,7 @@ class EB_NEURON(CMakeMake):
         self.pylibdir = det_pylibdir()
 
         # complete configuration with configure_method of parent
-        CMakeMake.configure_step(self)
+        super().configure_step()
 
     def test_step(self):
         """Custom tests for NEURON."""

--- a/easybuild/easyblocks/p/psi.py
+++ b/easybuild/easyblocks/p/psi.py
@@ -141,7 +141,6 @@ class EB_PSI(CMakeMake):
             ConfigureMake.configure_step(self, cmd_prefix=self.cfg['start_dir'])
         else:
             self.log.info("Using CMake based build")
-            self.cfg.update('configopts', ' -DPYTHON_EXECUTABLE=%s' % os.path.join(pythonroot, 'bin', 'python'))
             if self.name == 'PSI4' and LooseVersion(self.version) >= LooseVersion("1.2"):
                 self.log.info("Remove the CMAKE_BUILD_TYPE test in PSI4 source and the downloaded dependencies!")
                 self.log.info("Use PATCH_COMMAND in the corresponding CMakeLists.txt")

--- a/easybuild/easyblocks/p/pybind11.py
+++ b/easybuild/easyblocks/p/pybind11.py
@@ -35,7 +35,6 @@ import easybuild.tools.environment as env
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import change_dir
 from easybuild.tools.run import run_shell_cmd
-from easybuild.tools.modules import get_software_root
 
 
 class EB_pybind11(CMakePythonPackage):
@@ -45,19 +44,6 @@ class EB_pybind11(CMakePythonPackage):
     Python packages using `import pybind11`
     Hence we need to install PyBind11 twice: Once with CMake and once with pip
     """
-
-    def configure_step(self):
-        """Avoid that a system Python is picked up when a Python module is loaded"""
-
-        # make sure right 'python' command is used for installing pybind11
-        python_root = get_software_root('Python')
-        python_exe_opt = '-DPYTHON_EXECUTABLE='
-        if python_root and python_exe_opt not in self.cfg['configopts']:
-            configopt = python_exe_opt + os.path.join(python_root, 'bin', 'python')
-            self.log.info("Adding %s to configopts since it is not specified yet", configopt)
-            self.cfg.update('configopts', configopt)
-
-        super().configure_step()
 
     def test_step(self):
         """Run pybind11 tests"""

--- a/easybuild/easyblocks/r/root.py
+++ b/easybuild/easyblocks/r/root.py
@@ -90,7 +90,6 @@ class EB_ROOT(CMakeMake):
         python_root = get_software_root('Python')
         if python_root:
             pyshortver = '.'.join(get_software_version('Python').split('.')[:2])
-            self.cfg.update('configopts', '-DPYTHON_EXECUTABLE=%s' % os.path.join(python_root, 'bin', 'python'))
             python_inc_dir = find_glob_pattern(os.path.join(python_root, 'include', 'python%s*' % pyshortver))
             self.cfg.update('configopts', '-DPYTHON_INCLUDE_DIR=%s' % python_inc_dir)
             python_lib = find_glob_pattern(


### PR DESCRIPTION
When Python is used the CMakeMake easyblock already adds the required CMake options. As it has better logic to do so remove it from derived easyblocks.

There are 3 easyblocks (lammps, openbabel, root) that also set `PYTHON_LIBRARY` and `PYTHON_INCLUDE_DIR`. The comment in lammps "older lammps" and "deprecated CMake" hints at [FindPythonLibs](https://cmake.org/cmake/help/v3.15/module/FindPythonLibs.html), i.e. `find_package(PythonLibs)` where they are indeed required. So I left those there for now.