### PR TITLE
Fix incorrect glob pattern & use `report_test_failure` in test step in LLVM easyblock

### DIFF
--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -999,7 +999,7 @@ class EB_LLVM(CMakeMake):
     def get_runtime_lib_path(self, base_dir, fail_ok=True):
         """Return the path to the runtime libraries."""
         arch = get_arch_prefix()
-        glob_pattern = os.path.join(base_dir, 'lib', f'%s-{arch}')
+        glob_pattern = os.path.join(base_dir, 'lib', f'{arch}-*')
         matches = glob.glob(glob_pattern)
         if matches:
             directory = os.path.basename(matches[0])

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -935,10 +935,10 @@ class EB_LLVM(CMakeMake):
             max_failed = self.cfg['test_suite_max_failed']
             num_failed = self._para_test_step(parallel=1)
             if num_failed is None:
-                raise EasyBuildError("Failed to extract test results from output")
+                self.report_test_failure("Failed to extract test results from output")
 
             if num_failed > max_failed:
-                raise EasyBuildError(f"Too many failed tests: {num_failed} ({max_failed} allowed)")
+                self.report_test_failure(f"Too many failed tests: {num_failed} ({max_failed} allowed)")
             elif num_failed:
                 self.log.info(f"Test suite completed with {num_failed} failed tests ({max_failed} allowed)")
             else:

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -936,6 +936,7 @@ class EB_LLVM(CMakeMake):
             num_failed = self._para_test_step(parallel=1)
             if num_failed is None:
                 self.report_test_failure("Failed to extract test results from output")
+                return
 
             if num_failed > max_failed:
                 self.report_test_failure(f"Too many failed tests: {num_failed} ({max_failed} allowed)")


### PR DESCRIPTION
Cherry-picked from #3675 for EasyBuild 5.0.1