### PR TITLE
Workaround for NWChem: prepend "-" to "DMKL_ILP64" flag

### DIFF
--- a/easybuild/easyblocks/n/nwchem.py
+++ b/easybuild/easyblocks/n/nwchem.py
@@ -232,7 +232,7 @@ class EB_NWChem(ConfigureMake):
                 libmpi += " -libumad -libverbs -lpthread"
 
         # compiler optimization flags: set environment variables _and_ add them to list of make options
-        self.setvar_env_makeopt('COPTIMIZE', os.getenv('CFLAGS').replace(" DMKL_ILP64"," -DMKL_ILP64"))
+        self.setvar_env_makeopt('COPTIMIZE', os.getenv('CFLAGS').replace(" DMKL_ILP64", " -DMKL_ILP64"))
         self.setvar_env_makeopt('FOPTIMIZE', os.getenv('FFLAGS'))
 
         # BLAS and ScaLAPACK

--- a/easybuild/easyblocks/n/nwchem.py
+++ b/easybuild/easyblocks/n/nwchem.py
@@ -232,7 +232,7 @@ class EB_NWChem(ConfigureMake):
                 libmpi += " -libumad -libverbs -lpthread"
 
         # compiler optimization flags: set environment variables _and_ add them to list of make options
-        self.setvar_env_makeopt('COPTIMIZE', os.getenv('CFLAGS'))
+        self.setvar_env_makeopt('COPTIMIZE', os.getenv('CFLAGS').replace(" DMKL_ILP64"," -DMKL_ILP64"))
         self.setvar_env_makeopt('FOPTIMIZE', os.getenv('FFLAGS'))
 
         # BLAS and ScaLAPACK


### PR DESCRIPTION
The easybuild framework intelmkl.py is missing a "-" before "DMKL_ILP64" flag, causing NWChem to fail to build. This workaround will search for " DMKL_ILP64" (note the space at the beginning) in CFLAGS and replace it with " -DMKL_ILP64". This will avoid double-replacing the correct flag should easybuild framework devs decide to fix their intelmkl.py.