### PR TITLE
Remove superflous assignment of sanity check module data in custom easyblock for torchvision

### DIFF
--- a/easybuild/easyblocks/t/torchvision.py
+++ b/easybuild/easyblocks/t/torchvision.py
@@ -82,8 +82,8 @@ class EB_torchvision(PythonPackage):
 
         # load module early ourselves rather than letting parent sanity_check_step method do so,
         # so the correct 'python' command is used to by det_pylibdir() below;
-        if hasattr(self, 'sanity_check_module_loaded') and not self.sanity_check_module_loaded:
-            self.fake_mod_data = self.sanity_check_load_module(extension=self.is_extension)
+        if not self.sanity_check_module_loaded:
+            self.sanity_check_load_module(extension=self.is_extension)
 
         custom_commands = []
         custom_paths = {


### PR DESCRIPTION
`sanity_check_load_module` returns `self.fake_mod_data` so there is no need to assign it to itself. Remove it to avoid confusion.

Similar `EasyBlock` is guaranteed to have the attribute so remove the check.

See https://github.com/easybuilders/easybuild-framework/pull/4851