### PR TITLE
More fixes for the LLVM easyblock

### DIFF
--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -411,17 +411,19 @@ class EB_LLVM(CMakeMake):
         self.amdgpu_target_cond = (BUILD_TARGET_AMDGPU in build_targets) or all_target_cond
 
         self.build_targets = build_targets or []
-    
+
         # Enable offload targets for LLVM >= 18
         if LooseVersion(self.version) >= LooseVersion('18'):
             if self.nvptx_target_cond:
                 self.cuda_cc = []
                 if LooseVersion(self.version) < LooseVersion('20'):
                     if not cuda_cc_list:
-                        raise EasyBuildError(f"LLVM < 20 requires 'cuda-compute-capabilities' to build with {BUILD_TARGET_NVPTX}")
+                        raise EasyBuildError(
+                            f"LLVM < 20 requires 'cuda-compute-capabilities' to build with {BUILD_TARGET_NVPTX}"
+                        )
                     self.cuda_cc = [cc.replace('.', '') for cc in cuda_cc_list]
                 self.offload_targets += ['cuda']
-                self.log.debug(f"Enabling cuda offload target")
+                self.log.debug("Enabling cuda offload target")
             if self.amdgpu_target_cond:
                 self.amd_gfx = []
                 if LooseVersion(self.version) < LooseVersion('20'):
@@ -429,11 +431,9 @@ class EB_LLVM(CMakeMake):
                         raise EasyBuildError(f"LLVM < 20 requires 'amd_gfx_list' to build with {BUILD_TARGET_AMDGPU}")
                     self.amd_gfx = amd_gfx_list
                 self.offload_targets += ['amdgpu']  # Used for LLVM >= 19
-                self.log.debug(f"Enabling amdgpu offload target")
-
+                self.log.debug("Enabling amdgpu offload target")
 
         general_opts['CMAKE_BUILD_TYPE'] = self.build_type
-
         general_opts['LLVM_TARGETS_TO_BUILD'] = '"%s"' % ';'.join(build_targets)
 
         self._cmakeopts = {}
@@ -840,7 +840,6 @@ class EB_LLVM(CMakeMake):
             # Observed in 20.1.0, the build of the offloading tools can fail due to 'cstdint' file not found
             # But will succeed if executed again with -j 1 (possible missing dependency in the CMake logic?)
             # See https://github.com/llvm/llvm-project/issues/130783
-            # 
             if res.exit_code != EasyBuildExit.SUCCESS:
                 self.log.error("Build failed, attempting again with parallel ON")
                 res = run_shell_cmd(cmd, fail_on_error=False)

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -433,8 +433,7 @@ class EB_LLVM(CMakeMake):
         self.amd_gfx = []
         if self.cfg['build_openmp_offload'] and LooseVersion(self.version) >= LooseVersion('18'):
             if self.nvptx_target_cond:
-                if LooseVersion(self.version) < LooseVersion('20'):
-                    if not cuda_cc_list:
+                if LooseVersion(self.version) < LooseVersion('20') and not cuda_cc_list:
                         raise EasyBuildError(
                             f"LLVM < 20 requires 'cuda-compute-capabilities' to build with {BUILD_TARGET_NVPTX}"
                         )
@@ -442,8 +441,7 @@ class EB_LLVM(CMakeMake):
                 self.offload_targets += ['cuda']
                 self.log.debug("Enabling `cuda` offload target")
             if self.amdgpu_target_cond:
-                if LooseVersion(self.version) < LooseVersion('20'):
-                    if not amd_gfx_list:
+                if LooseVersion(self.version) < LooseVersion('20') and not amd_gfx_list:
                         raise EasyBuildError(f"LLVM < 20 requires 'amd_gfx_list' to build with {BUILD_TARGET_AMDGPU}")
                     self.amd_gfx = amd_gfx_list
                 self.offload_targets += ['amdgpu']  # Used for LLVM >= 19
@@ -848,8 +846,6 @@ class EB_LLVM(CMakeMake):
 
     def _prepare_runtimes_rpath_wrappers(self, stage_dir):
         """Run the build command also ensuring proper rpathing for the Runtime build."""
-        # curdir = os.getcwd()
-        # bin_dir = os.path.join(prev_dir, 'bin')
         # TODO: need a way to find what lib_dir_runtime will be before the build
         lib_dir_runtime = self.get_runtime_lib_path(stage_dir, fail_ok=True)
 

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -592,7 +592,8 @@ class EB_LLVM(CMakeMake):
         if self.cfg.parallel:
             self.make_parallel_opts = f"-j {self.cfg.parallel}"
 
-        # Moved here from the __init__ to ensure this easyblock can be used as a Bundle component
+        # CMAKE_INSTALL_PREFIX and LLVM start directory are set here instead of in __init__ to 
+        # ensure this easyblock can be used as a Bundle component, see
         # https://github.com/easybuilders/easybuild-easyblocks/issues/3680
         general_opts['CMAKE_INSTALL_PREFIX'] = self.installdir
         start_dir = self.cfg['start_dir']
@@ -686,7 +687,7 @@ class EB_LLVM(CMakeMake):
         src_dir = os.path.join(self.llvm_src_dir, 'llvm')
         output = super().configure_step(builddir=self.llvm_obj_dir_stage1, srcdir=src_dir)
 
-        # Get the LLVM HOST TRIPLE (e.g. x86_64-unknown-linux-gnu) from the output
+        # Get LLVM_HOST_TRIPLE (e.g. x86_64-unknown-linux-gnu) from the output
         for line in output.splitlines():
             if 'llvm host triple' in line.lower():
                 self.host_triple = line.split(':')[1].strip()
@@ -901,6 +902,7 @@ class EB_LLVM(CMakeMake):
 
             symlink(os.path.join(stage_dir, 'opt'), os.path.join(clang_mock_wrapper_dir, 'opt'))
 
+            # Use mocked rpath wrappers
             self.runtimes_cmake_args['CMAKE_C_COMPILER'] = [clang_mock]
             self.runtimes_cmake_args['CMAKE_CXX_COMPILER'] = [clangxx_mock]
 

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -42,7 +42,7 @@ import stat
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.toolchains.compiler.clang import Clang
 from easybuild.tools import LooseVersion
-from easybuild.tools.build_log import EasyBuildError, print_msg, print_warning
+from easybuild.tools.build_log import EasyBuildError, print_msg
 from easybuild.tools.config import ERROR, IGNORE, SEARCH_PATH_LIB_DIRS, build_option
 from easybuild.tools.environment import setvar
 from easybuild.tools.filetools import apply_regex_substitutions, change_dir, copy_dir, adjust_permissions
@@ -694,7 +694,6 @@ class EB_LLVM(CMakeMake):
                 raise EasyBuildError("`LLVM_HOST_TRIPLE` not found in the output of the configure step")
             else:
                 self.log.warning("`LLVM_HOST_TRIPLE` not found in the output of the configure step")
-
 
     def disable_sanitizer_tests(self):
         """Disable the tests of all the sanitizers by removing the test directories from the build system"""

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -428,7 +428,7 @@ class EB_LLVM(CMakeMake):
         self.build_targets = build_targets or []
 
         # Enable offload targets for LLVM >= 18
-        if LooseVersion(self.version) >= LooseVersion('18'):
+        if self.cfg['build_openmp_offload'] and LooseVersion(self.version) >= LooseVersion('18'):
             if self.nvptx_target_cond:
                 self.cuda_cc = []
                 if LooseVersion(self.version) < LooseVersion('20'):

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -686,7 +686,7 @@ class EB_LLVM(CMakeMake):
 
         # Get the LLVM HOST TRIPLE (e.g. x86_64-unknown-linux-gnu) from the output
         for line in output.splitlines():
-            if 'LLVM_HOST_TRIPLE' in line:
+            if 'llvm host triple' in line.lower():
                 self.host_triple = line.split(':')[1].strip()
                 break
         else:

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -435,7 +435,7 @@ class EB_LLVM(CMakeMake):
             if self.nvptx_target_cond:
                 if LooseVersion(self.version) < LooseVersion('20') and not cuda_cc_list:
                     raise EasyBuildError(
-                        f"LLVM < 20 requires 'cuda-compute-capabilities' to build with {BUILD_TARGET_NVPTX}"
+                        f"LLVM < 20 requires 'cuda_compute_capabilities' to build with {BUILD_TARGET_NVPTX}"
                     )
                 self.cuda_cc = [cc.replace('.', '') for cc in cuda_cc_list]
                 self.offload_targets += ['cuda']

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -841,10 +841,10 @@ class EB_LLVM(CMakeMake):
             # But will succeed if executed again with -j 1 (possible missing dependency in the CMake logic?)
             # See https://github.com/llvm/llvm-project/issues/130783
             if res.exit_code != EasyBuildExit.SUCCESS:
-                self.log.error("Build failed, attempting again with parallel ON")
+                self.log.warning("Build failed, attempting again with parallel ON")
                 res = run_shell_cmd(cmd, fail_on_error=False)
             if res.exit_code != EasyBuildExit.SUCCESS:
-                self.log.error("Build failed, attempting again with parallel OFF")
+                self.log.warning("Build failed, attempting again with parallel OFF")
                 cmd = "make -j 1 VERBOSE=1"
                 res = run_shell_cmd(cmd)
 

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -597,10 +597,7 @@ class EB_LLVM(CMakeMake):
         # Moved here from the __init__ to ensure this easyblock can be used as a Bundle component
         # https://github.com/easybuilders/easybuild-easyblocks/issues/3680
         general_opts['CMAKE_INSTALL_PREFIX'] = self.installdir
-        if LooseVersion(self.version) < LooseVersion('20.1.2'):
-            self.llvm_src_dir = os.path.join(self.builddir, 'llvm-project-%s.src' % self.version)
-        else:
-            self.llvm_src_dir = os.path.join(self.builddir, 'llvm-project-llvmorg-%s' % self.version)
+        self.llvm_src_dir = os.path.join(self.builddir, 'llvm-project-%s.src' % self.version)
 
         # Bootstrap
         self.llvm_obj_dir_stage1 = os.path.join(self.builddir, 'llvm.obj.1')

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -434,16 +434,16 @@ class EB_LLVM(CMakeMake):
         if self.cfg['build_openmp_offload'] and LooseVersion(self.version) >= LooseVersion('18'):
             if self.nvptx_target_cond:
                 if LooseVersion(self.version) < LooseVersion('20') and not cuda_cc_list:
-                        raise EasyBuildError(
-                            f"LLVM < 20 requires 'cuda-compute-capabilities' to build with {BUILD_TARGET_NVPTX}"
-                        )
-                    self.cuda_cc = [cc.replace('.', '') for cc in cuda_cc_list]
+                    raise EasyBuildError(
+                        f"LLVM < 20 requires 'cuda-compute-capabilities' to build with {BUILD_TARGET_NVPTX}"
+                    )
+                self.cuda_cc = [cc.replace('.', '') for cc in cuda_cc_list]
                 self.offload_targets += ['cuda']
                 self.log.debug("Enabling `cuda` offload target")
             if self.amdgpu_target_cond:
                 if LooseVersion(self.version) < LooseVersion('20') and not amd_gfx_list:
-                        raise EasyBuildError(f"LLVM < 20 requires 'amd_gfx_list' to build with {BUILD_TARGET_AMDGPU}")
-                    self.amd_gfx = amd_gfx_list
+                    raise EasyBuildError(f"LLVM < 20 requires 'amd_gfx_list' to build with {BUILD_TARGET_AMDGPU}")
+                self.amd_gfx = amd_gfx_list
                 self.offload_targets += ['amdgpu']  # Used for LLVM >= 19
                 self.log.debug("Enabling `amdgpu` offload target")
 

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -411,11 +411,15 @@ class EB_LLVM(CMakeMake):
         self.amdgpu_target_cond = (BUILD_TARGET_AMDGPU in build_targets) or all_target_cond
 
         if ('cuda' in self.deps or cuda_toolchain) and not self.nvptx_target_cond:
-            raise EasyBuildError("CUDA dependency detected, but NVPTX not in manually specified build targets") 
+            raise EasyBuildError("CUDA dependency detected, but NVPTX not in manually specified build targets")
         if cuda_cc_list and not self.nvptx_target_cond:
-            raise EasyBuildError("CUDA compute capabilities specified, but NVPTX not in manually specified build targets")
+            raise EasyBuildError(
+                "CUDA compute capabilities specified, but NVPTX not in manually specified build targets"
+            )
         if 'rocr-runtime' in self.deps and not self.amdgpu_target_cond:
-            raise EasyBuildError("ROCR-Runtime dependency detected, but AMDGPU not in manually specified build targets")
+            raise EasyBuildError(
+                "ROCR-Runtime dependency detected, but AMDGPU not in manually specified build targets"
+            )
         if amd_gfx_list and not self.amdgpu_target_cond:
             raise EasyBuildError("AMD GPU list specified, but AMDGPU not in manually specified build targets")
 

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -592,7 +592,7 @@ class EB_LLVM(CMakeMake):
         if self.cfg.parallel:
             self.make_parallel_opts = f"-j {self.cfg.parallel}"
 
-        # CMAKE_INSTALL_PREFIX and LLVM start directory are set here instead of in __init__ to 
+        # CMAKE_INSTALL_PREFIX and LLVM start directory are set here instead of in __init__ to
         # ensure this easyblock can be used as a Bundle component, see
         # https://github.com/easybuilders/easybuild-easyblocks/issues/3680
         general_opts['CMAKE_INSTALL_PREFIX'] = self.installdir
@@ -693,8 +693,10 @@ class EB_LLVM(CMakeMake):
                 self.host_triple = line.split(':')[1].strip()
                 break
         else:
+            # LLVM_HOST_TRIPLE needs to be set when building runtimes or bootstrapping.
             if self.cfg['build_runtimes'] or self.cfg['bootstrap']:
                 raise EasyBuildError("`LLVM_HOST_TRIPLE` not found in the output of the configure step")
+            # Otherwise it can be inferred a posteriori from the install directory
             else:
                 self.log.warning("`LLVM_HOST_TRIPLE` not found in the output of the configure step")
 
@@ -868,9 +870,6 @@ class EB_LLVM(CMakeMake):
         # e.g. when calling the compiled clang-ast-dump for stage 3
         lib_path = os.path.join(stage_dir, lib_dir_runtime)
 
-        #######################################################
-        # PROBLEM!!!:
-        #################################################
         bin_dir_new = os.path.join(stage_dir, 'bin')
         mkdir(bin_dir_new, parents=True)
         with _wrap_env(bin_dir_new, lib_path):

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -429,9 +429,10 @@ class EB_LLVM(CMakeMake):
         self.build_targets = build_targets or []
 
         # Enable offload targets for LLVM >= 18
+        self.cuda_cc = []
+        self.amd_gfx = []
         if self.cfg['build_openmp_offload'] and LooseVersion(self.version) >= LooseVersion('18'):
             if self.nvptx_target_cond:
-                self.cuda_cc = []
                 if LooseVersion(self.version) < LooseVersion('20'):
                     if not cuda_cc_list:
                         raise EasyBuildError(
@@ -441,7 +442,6 @@ class EB_LLVM(CMakeMake):
                 self.offload_targets += ['cuda']
                 self.log.debug("Enabling `cuda` offload target")
             if self.amdgpu_target_cond:
-                self.amd_gfx = []
                 if LooseVersion(self.version) < LooseVersion('20'):
                     if not amd_gfx_list:
                         raise EasyBuildError(f"LLVM < 20 requires 'amd_gfx_list' to build with {BUILD_TARGET_AMDGPU}")
@@ -672,7 +672,7 @@ class EB_LLVM(CMakeMake):
         if not get_software_root('CUDA'):
             setvar('CUDA_NVCC_EXECUTABLE', 'IGNORE')
 
-        if 'openmp' in self.final_projects and LooseVersion('19') <= LooseVersion(self.version) < LooseVersion('20'):
+        if self.cfg['build_openmp_offload'] and LooseVersion('19') <= LooseVersion(self.version) < LooseVersion('20'):
             gpu_archs = []
             gpu_archs += ['sm_%s' % cc for cc in self.cuda_cc]
             gpu_archs += self.amd_gfx

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -1130,7 +1130,7 @@ class EB_LLVM(CMakeMake):
                 raise EasyBuildError("Failed to extract GCC installation path from output of '%s': %s", cmd, out)
             check_prefix = mch.group(1)
             if check_prefix != gcc_prefix:
-                error_msg = "GCC installation path '{check_prefix}' does not match expected path '{gcc_prefix}'"
+                error_msg = f"GCC installation path '{check_prefix}' does not match expected path '{gcc_prefix}'"
                 raise EasyBuildError(error_msg)
 
     def sanity_check_step(self, custom_paths=None, custom_commands=None, extension=False, extra_modules=None):

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -1008,21 +1008,19 @@ class EB_LLVM(CMakeMake):
                 self._set_gcc_prefix()
                 self._create_compiler_config_file(self.cfg_compilers, self.gcc_prefix, self.final_dir)
 
-            self.ignore_patterns = ignore_patterns = self.cfg['test_suite_ignore_patterns'] or []
-            nvptx_cond = self.nvptx_target_cond
-            amdgpu_cond = self.amdgpu_target_cond
+            self.ignore_patterns = self.cfg['test_suite_ignore_patterns'] or []
 
             # For nvptx64 tests, find out if 'ptxas' exists in $PATH. If not, ignore all nvptx64 test failures
             pxtas_path = which('ptxas', on_error=IGNORE)
-            if nvptx_cond and not pxtas_path:
-                ignore_patterns += ['nvptx64-nvidia-cuda', 'nvptx64-nvidia-cuda-LTO']
+            if self.nvptx_target_cond and not pxtas_path:
+                self.ignore_patterns += ['nvptx64-nvidia-cuda', 'nvptx64-nvidia-cuda-LTO']
                 self.log.warning("PTXAS not found in PATH, ignoring failing tests for NVPTX target")
             # If the AMDGPU target is built, tests will be run if libhsa-runtime64.so is found.
             # However, this can cause issues if the system libraries are used, due to other loaded modules.
             # Therefore, ignore failing tests if ROCr-Runtime is not in the dependencies and
             # warn about this in the logs.
-            if amdgpu_cond and 'rocr-runtime' not in self.deps:
-                ignore_patterns += ['amdgcn-amd-amdhsa']
+            if self.amdgpu_target_cond and 'rocr-runtime' not in self.deps:
+                self.ignore_patterns += ['amdgcn-amd-amdhsa']
                 self.log.warning("ROCr-Runtime not in dependencies, ignoring failing tests for AMDGPU target.")
 
             max_failed = self.cfg['test_suite_max_failed']

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -358,6 +358,7 @@ class EB_LLVM(CMakeMake):
         # (1) in the easyconfig file, via the custom cuda_compute_capabilities;
         # (2) in the EasyBuild configuration, via --cuda-compute-capabilities configuration option;
         cuda_cc_list = build_option('cuda_compute_capabilities') or self.cfg['cuda_compute_capabilities'] or []
+        cuda_toolchain = hasattr(self.toolchain, 'COMPILER_CUDA_FAMILY')
         amd_gfx_list = self.cfg['amd_gfx_list'] or []
 
         # List of (lower-case) dependencies
@@ -374,7 +375,6 @@ class EB_LLVM(CMakeMake):
 
             # If CUDA is included as a dep, add NVPTX as a target
             # There are (old) toolchains with CUDA as part of the toolchain
-            cuda_toolchain = hasattr(self.toolchain, 'COMPILER_CUDA_FAMILY')
             if 'cuda' in self.deps or cuda_toolchain:
                 self.log.info("CUDA dependency detected, adding NVPTX as a target")
                 build_targets.append(BUILD_TARGET_NVPTX)

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -1133,21 +1133,19 @@ class EB_LLVM(CMakeMake):
 
     def get_runtime_lib_path(self, base_dir, fail_ok=False):
         """Return the path to the runtime libraries."""
-        # arch = get_arch_prefix()
-        # glob_pattern = os.path.join(base_dir, 'lib', f'{arch}-*')
-        # matches = glob.glob(glob_pattern)
-        # if matches:
-        #     directory = os.path.basename(matches[0])
-        #     res = os.path.join("lib", directory)
-        # else:
-        #     if not fail_ok:
-        #         raise EasyBuildError("Could not find runtime library directory")
-        #     print_warning("Could not find runtime library directory")
-        #     res = 'lib'
         if self.host_triple is None:
-            raise EasyBuildError("Could not find runtime library directory")
-        res = os.path.join('lib', self.host_triple)
+            # Attempt using the glob based detection of the runtime library directory for runs of
+            # --sanity-check-only/--module-only where the configure step is not used
+            arch = get_arch_prefix()
+            glob_pattern = os.path.join(base_dir, 'lib', f'{arch}-*')
+            matches = glob.glob(glob_pattern)
+            if matches:
+                self.host_triple = os.path.basename(matches[0])
+                res = os.path.join("lib", self.host_triple)
+            else:
+                raise EasyBuildError("Could not find runtime library directory")
 
+        res = os.path.join('lib', self.host_triple)
         if not fail_ok:
             path = os.path.join(base_dir, res)
             if not os.path.exists(path):

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -457,7 +457,7 @@ class EB_LLVM(CMakeMake):
         """Prepare step, modified to ensure install dir is deleted before building"""
         super(EB_LLVM, self).prepare_step(*args, **kwargs)
         # re-create installation dir (deletes old installation),
-        # Needed to unsure hardcoded rpath do not point to old installation during runtime builds and testing
+        # Needed to ensure hardcoded rpath do not point to old installation during runtime builds and testing
         self.make_installdir()
 
     def _add_cmake_runtime_args(self):

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -597,7 +597,13 @@ class EB_LLVM(CMakeMake):
         # Moved here from the __init__ to ensure this easyblock can be used as a Bundle component
         # https://github.com/easybuilders/easybuild-easyblocks/issues/3680
         general_opts['CMAKE_INSTALL_PREFIX'] = self.installdir
-        self.llvm_src_dir = os.path.join(self.builddir, 'llvm-project-%s.src' % self.version)
+        start_dir = self.cfg['start_dir']
+        if start_dir:
+            self.llvm_src_dir = os.path.join(self.builddir, start_dir)
+            self.log.debug("Using `%s` as the source dir from start_dir", self.llvm_src_dir)
+        else:
+            self.llvm_src_dir = os.path.join(self.builddir, 'llvm-project-%s.src' % self.version)
+            self.log.debug("Using `%s` as the source dir from easyblock", self.llvm_src_dir)
 
         # Bootstrap
         self.llvm_obj_dir_stage1 = os.path.join(self.builddir, 'llvm.obj.1')


### PR DESCRIPTION
## Fixes issues:

- #3708 
  - Fixed by cleaning up install directory by calling `self.make_installdir()` in the `prepare_step`
- #3709 
  - Fixed by attempting to rerurn the parallel build once if failed and once again in serial if failed again
  - Possible downside: more polluted logs for actually failed builds
- #3710
  - Implemented correct logic now also including runtimes libraries files
- #3711 
  - Added check based on version for expected folder structure 
- #3702 
  - Testing a dedicated `_prepare_runtimes_rpath_wrappers` method that can be ran also at the first build step
    - Tested with `bootstrap = False` `20.1.4` build (~minimal): https://github.com/easybuilders/easybuild-easyblocks/pull/3706#issuecomment-2844941653
    - Tested with `bootstrap = False` `20.1.4` build (all components): https://github.com/easybuilders/easybuild-easyblocks/pull/3706#issuecomment-2845350451
  - Needed to implement a different way to get the host triple that can be ran before the first build
    - Now taking it form the output of the CMake config logs instead of `glob`ing for the runtimes directory after the first build

## Other changes:

- Currently offloading is properly configured only with auto-detection of build targets. This PR allows the offloading to be configured independently of target detection
- Streamlined `GPU` and `ignore_patterns` for tests
- `SPIRV` moved to a non-experimental target (this might need to be enabled in a version specific way as this happened for versions `>=20.x`