### PR TITLE
fix deprecation warning

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -1190,4 +1190,6 @@ class PythonPackage(ExtensionEasyBlock):
                 if os.path.exists(fullpath) and os.listdir(fullpath):
                     txt += self.module_generator.prepend_paths(PYTHONPATH, path)
 
-        return super(PythonPackage, self).make_module_extra(txt, *args, **kwargs)
+        super(PythonPackage, self).make_module_extra(*args, **kwargs)
+        
+        return txt

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -1190,6 +1190,6 @@ class PythonPackage(ExtensionEasyBlock):
                 if os.path.exists(fullpath) and os.listdir(fullpath):
                     txt += self.module_generator.prepend_paths(PYTHONPATH, path)
 
-        super(PythonPackage, self).make_module_extra(*args, **kwargs)
-        
+        txt += super(PythonPackage, self).make_module_extra(*args, **kwargs)
+
         return txt


### PR DESCRIPTION
`eb adjustText-0.7.3-foss-2023a.eb -r --rebuild --module-only`
```
@@ -28,10 +28,10 @@

 prepend_path("CMAKE_LIBRARY_PATH", pathJoin(root, "lib"))
 prepend_path("CMAKE_PREFIX_PATH", root)
+prepend_path("PYTHONPATH", pathJoin(root, "lib/python3.11/site-packages"))
 setenv("EBROOTADJUSTTEXT", root)
 setenv("EBVERSIONADJUSTTEXT", "0.7.3")
 setenv("EBDEVELADJUSTTEXT", pathJoin(root, "easybuild/adjustText-0.7.3-foss-2023a-easybuild-devel"))

-prepend_path("PYTHONPATH", pathJoin(root, "lib/python3.11/site-packages"))
 -- Built with EasyBuild version 5.0.1.dev0-r6950b51f7c568048710c5ae84bd4ca040a2f819d
```

`eb SciPy-bundle-2024.05-gfbf-2024a.eb -r --rebuild --module-only`
```
== comparing module file with backup /rds/projects/2017/branfosj-rse/easybuild/EL8-ice/modules/all/SciPy-bundle/2024.05-gfbf-2024a.bak_20250509141850_2713414; no differences found
```
But be aware of https://github.com/easybuilders/easybuild-easyblocks/issues/3716 that will cause a false positive.