### PR TITLE
Fix Python shebangs for Python and Conda-like modules

### DIFF
--- a/easybuild/easyblocks/a/anaconda.py
+++ b/easybuild/easyblocks/a/anaconda.py
@@ -33,6 +33,7 @@ import os
 import stat
 
 from easybuild.easyblocks.generic.binary import Binary
+from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.filetools import adjust_permissions, remove_dir
 from easybuild.tools.modules import MODULE_LOAD_ENV_HEADERS
 from easybuild.tools.run import run_shell_cmd
@@ -40,6 +41,16 @@ from easybuild.tools.run import run_shell_cmd
 
 class EB_Anaconda(Binary):
     """Support for building/installing Anaconda and Miniconda."""
+
+    @staticmethod
+    def extra_options():
+        """Add extra config options specific to Python."""
+        extra_vars = {
+            'fix_python_shebang_for': [['bin/*'], "List of files for which Python shebang should be fixed "
+                                                  "to '#!/usr/bin/env python' (glob patterns supported) "
+                                                  "(default: ['bin/*'])", CUSTOM],
+        }
+        return Binary.extra_options(extra_vars)
 
     def __init__(self, *args, **kwargs):
         """Initialize class variables."""

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -250,6 +250,9 @@ class EB_Python(ConfigureMake):
         """Add extra config options specific to Python."""
         extra_vars = {
             'ebpythonprefixes': [True, "Create sitecustomize.py and allow use of $EBPYTHONPREFIXES", CUSTOM],
+            'fix_python_shebang_for': [['bin/*'], "List of files for which Python shebang should be fixed "
+                                                  "to '#!/usr/bin/env python' (glob patterns supported) "
+                                                  "(default: ['bin/*'])", CUSTOM],
             'install_pip': [True,
                             "Use the ensurepip module (Python 2.7.9+, 3.4+) to install the bundled versions "
                             "of pip and setuptools into Python. You _must_ then use pip for upgrading "


### PR DESCRIPTION
The core Python modules have scripts too that use `python`. However their shebangs use absolute paths to the installed python binary.
This causes serious problems with virtualenvs as e.g `pip install` would still use the core Python binary instead of the virtualenv binary leading to failures if `$PIP_REQUIRE_VIRTUALENV` is set.

Copy over the default shebang-fix from PythonPackage.