### PR TITLE
add `-std=c++11` to `$CXXFLAGS` when building binutils 2.42+ with system GCC 4.8.1 to 5.x

### DIFF
--- a/easybuild/easyblocks/b/binutils.py
+++ b/easybuild/easyblocks/b/binutils.py
@@ -209,7 +209,8 @@ class EB_binutils(ConfigureMake):
                     LooseVersion(gcc_version) >= LooseVersion('4.8.1')
                     and LooseVersion(gcc_version) < LooseVersion('6.1.0')
                 ):
-                    self.cfg.update('buildopts', 'CXXFLAGS="-std=c++11"')
+                    # append "-std=c++11" to $CXXFLAGS, not overriding
+                    self.cfg.update('buildopts', 'CXXFLAGS="$CXXFLAGS -std=c++11"')
 
     def install_step(self):
         """Install using 'make install', also install libiberty if desired."""

--- a/easybuild/easyblocks/b/binutils.py
+++ b/easybuild/easyblocks/b/binutils.py
@@ -204,11 +204,10 @@ class EB_binutils(ConfigureMake):
                 LooseVersion(self.version) >= LooseVersion('2.42')
                 and self.toolchain.comp_family() == toolchain.SYSTEM
             ):
-                res = run_shell_cmd('g++ --version')
-                gxx_version = res.output.strip().split(' ')[2]
+                gcc_version = get_gcc_version()
                 if (
-                    LooseVersion(gxx_version) >= LooseVersion('4.8.1')
-                    and LooseVersion(gxx_version) < LooseVersion('6.1.0')
+                    LooseVersion(gcc_version) >= LooseVersion('4.8.1')
+                    and LooseVersion(gcc_version) < LooseVersion('6.1.0')
                 ):
                     self.cfg.update('buildopts', 'CXXFLAGS="-std=c++11"')
 

--- a/easybuild/easyblocks/b/binutils.py
+++ b/easybuild/easyblocks/b/binutils.py
@@ -40,7 +40,7 @@ from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import apply_regex_substitutions, copy_file
 from easybuild.tools.modules import get_software_libdir, get_software_root
 from easybuild.tools.run import run_shell_cmd
-from easybuild.tools.systemtools import RISCV, get_cpu_family, get_shared_lib_ext
+from easybuild.tools.systemtools import RISCV, get_cpu_family, get_gcc_version, get_shared_lib_ext
 from easybuild.tools.utilities import nub
 
 

--- a/easybuild/easyblocks/b/binutils.py
+++ b/easybuild/easyblocks/b/binutils.py
@@ -33,6 +33,7 @@ import re
 from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
+import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
@@ -198,6 +199,18 @@ class EB_binutils(ConfigureMake):
                 # if $CFLAGS is not defined, make sure we retain "-g -O2",
                 # since not specifying any optimization level implies -O0...
                 self.cfg.update('buildopts', 'CFLAGS="-g -O2 -fPIC"')
+
+            if (
+                LooseVersion(self.version) >= LooseVersion('2.42')
+                and self.toolchain.comp_family() == toolchain.SYSTEM
+            ):
+                res = run_shell_cmd('g++ --version')
+                gxx_version = res.output.strip().split(' ')[2]
+                if (
+                    LooseVersion(gxx_version) >= LooseVersion('4.8.1')
+                    and LooseVersion(gxx_version) < LooseVersion('6.1.0')
+                ):
+                    self.cfg.update('buildopts', 'CXXFLAGS="-std=c++11"')
 
     def install_step(self):
         """Install using 'make install', also install libiberty if desired."""


### PR DESCRIPTION
https://github.com/easybuilders/easybuild-easyconfigs/issues/22651