### PR TITLE
produce clean trace message for '`pip check`'

### DIFF
--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -53,6 +53,7 @@ from easybuild.tools.filetools import apply_regex_substitutions, change_dir, mkd
 from easybuild.tools.filetools import read_file, remove_dir, symlink, write_file
 from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
+from easybuild.tools.utilities import trace_msg
 import easybuild.tools.toolchain as toolchain
 
 
@@ -187,10 +188,13 @@ def run_pip_check(python_cmd=None, unversioned_packages=None):
 
     pip_check_errors = []
 
-    res = run_shell_cmd(pip_check_cmd, fail_on_error=False)
+    res = run_shell_cmd(pip_check_cmd, fail_on_error=False, hidden=True)
+    msg = "Check on requirements for installed Python packages with 'pip check': "
     if res.exit_code:
+        trace_msg(msg + 'FAIL')
         pip_check_errors.append(f"`{pip_check_cmd}` failed:\n{res.output}")
     else:
+        trace_msg(msg + 'OK')
         log.info(f"`{pip_check_cmd}` passed successfully")
 
     # Also check for a common issue where the package version shows up as 0.0.0 often caused


### PR DESCRIPTION
Currently:

```
== sanity checking...
  >> running shell command:
        python -m pip check
        [started at: 2025-05-23 10:26:11]
        [working dir: /tmp/vsc40023/easybuild_build/Python/3.13.1/GCCcore-14.2.0]
        [output and state saved to /tmp/eb-d_ec_z2f/run-shell-cmd-output/python-54b60zib]
  >> command completed: exit 0, ran in < 1s
```

with this change:

```
== sanity checking...
  >> Check on requirements for installed Python packages with 'pip check': OK
```