### PR TITLE
enhance custom easyblock for LLVM: ensure sysroot dynamic linker is used + add ignore patterns for failing tests that can be ignored

### DIFF
--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -690,6 +690,7 @@ class EB_LLVM(CMakeMake):
         else:
             general_opts['LLVM_ENABLE_Z3_SOLVER'] = 'OFF'
 
+        new_ignore_patterns = []
         if self.sysroot:
             # Some tests will run a FileCheck on the output of `clang -v` for `-internal-externc-isystem /usr/include`
             # where the path is hardcoded. If sysroot is set we replace that path by prepending the sysroot to it.
@@ -706,15 +707,29 @@ class EB_LLVM(CMakeMake):
             known_frontend_files = [
                 'warning-poison-system-directories.c'
             ]
-            prev = self.ignore_patterns.copy()
             for file in known_driver_files:
-                self.ignore_patterns.append(f'Clang :: Driver/{file}')
+                new_ignore_patterns.append(f'Clang :: Driver/{file}')
             for file in known_frontend_files:
-                self.ignore_patterns.append(f'Clang :: Frontend/{file}')
-            self.log.info(
-                f"Ignore patterns for tests updated from {prev} to {self.ignore_patterns} to avoid known ignorable "
-                "failures with sysroot builds."
-                )
+                new_ignore_patterns.append(f'Clang :: Frontend/{file}')
+
+            # Test related to config files, can fail due to overriding the default config file that we set to
+            # ensure correct working with sysroot builds
+            new_ignore_patterns.append('Flang :: Driver/config-file.f90')
+
+
+        # See https://github.com/easybuilders/easybuild-easyblocks/pull/3741#issuecomment-2944852391
+        # System-related failures due to /etc/timezone behavior
+        new_ignore_patterns.append('llvm-libc++-shared.cfg.in :: std/time/time.zone/')
+
+        # Can give different behavior based on system Scrt1.o
+        new_ignore_patterns.append('Flang :: Driver/missing-input.f90')
+
+        # See https://github.com/llvm/llvm-project/issues/140024
+        if LooseVersion(self.version) <= LooseVersion('20.1.5'):
+            new_ignore_patterns.append('LLVM :: CodeGen/Hexagon/isel/pfalse-v4i1.ll')
+
+        self.ignore_patterns += new_ignore_patterns
+        self.log.info(f"Ignore patterns added due to known and ignorable test failures: {new_ignore_patterns}")
 
         python_opts = get_cmake_python_config_dict()
         general_opts.update(python_opts)

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -606,7 +606,7 @@ class EB_LLVM(CMakeMake):
                 trace_msg(msg)
                 self.log.warning(msg)
 
-    def _update_ignore_patterns(self):
+    def _update_test_ignore_patterns(self):
         """Update the ignore patterns based on known ignorable test failures when running with specific LLVM versions
         or with specific dependencies/options."""
         new_ignore_patterns = []

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -775,6 +775,18 @@ class EB_LLVM(CMakeMake):
             # prefix = self.sysroot.rstrip('/')
             # opts.append(f'--dyld-prefix={prefix}')
 
+        # Check, for a non `full_llvm` build, if GCCcore is in the LIBRARY_PATH, and if not add it
+        # This is needed as the runtimes tests will not add the -L option to the linker command line for GCCcore
+        # otherwise
+        if not self.full_llvm:
+            gcc_root = get_software_root('GCCcore')
+            gcc_lib = os.path.join(gcc_root, 'lib64')
+            library_path = os.getenv('LLIBRARY_PATH', '')
+            if gcc_lib not in library_path:
+                self.log.info("Adding GCCcore libraries location `%s` the config files", gcc_lib)
+                lib_path = f"{gcc_lib}:{lib_path}" if lib_path else gcc_lib
+                opts.append(f'-L{lib_path}')
+
         for comp in self.cfg_compilers:
             write_file(os.path.join(bin_dir, f'{comp}.cfg'), ' '.join(opts))
 

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -357,6 +357,8 @@ class EB_LLVM(CMakeMake):
         # Sysroot
         self.sysroot = build_option('sysroot')
         if self.sysroot:
+            if LooseVersion(self.version) < LooseVersion('19'):
+                raise EasyBuildError("Using sysroot is not supported by EasyBuild for LLVM < 19")
             general_opts['DEFAULT_SYSROOT'] = self.sysroot
             general_opts['CMAKE_SYSROOT'] = self.sysroot
             self._set_dynamic_linker()

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -674,6 +674,8 @@ class EB_LLVM(CMakeMake):
         # Should not use system SWIG if present
         general_opts['LLDB_ENABLE_SWIG'] = 'ON' if get_software_root('SWIG') else 'OFF'
 
+        # Avoid using system `gdb` in case it is not provided as a dependency
+        # This could cause the wrong sysroot/dynamic linker being picked up in a sysroot build causing tests to fail
         general_opts['LIBOMP_OMPD_GDB_SUPPORT'] = 'ON' if get_software_root('GDB') else 'OFF'
 
         z3_root = get_software_root("Z3")

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -766,7 +766,7 @@ class EB_LLVM(CMakeMake):
         """Create a config file for the compiler to point to the correct GCC installation."""
         self._set_gcc_prefix()
         bin_dir = os.path.join(installdir, 'bin')
-        opts = [f'--gcc-toolchain={self.gcc_prefix}']
+        opts = [f'--gcc-install-dir={self.gcc_prefix}']
 
         if self.dynamic_linker:
             opts.append(f'-Wl,-dynamic-linker,{self.dynamic_linker}')

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -1290,7 +1290,7 @@ class EB_LLVM(CMakeMake):
                 raise EasyBuildError(error_msg)
 
             for suffix in ('.c', '.o', '.x'):
-                remove_file('{test_fn}{suffix}')
+                remove_file(f'{test_fn}{suffix}')
 
     def sanity_check_step(self, custom_paths=None, custom_commands=None, extension=False, extra_modules=None):
         """Perform sanity checks on the installed LLVM."""

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -574,7 +574,7 @@ class EB_LLVM(CMakeMake):
         if self.sysroot:
             linkers = glob.glob(os.path.join(self.sysroot, '**', 'ld-*.so*'))
             for linker in linkers:
-                if os.path.isfile(linker):
+                if os.path.isfile(linker) and not os.path.islink(linker):
                     self.log.info("Using linker %s from sysroot", linker)
                     self.dynamic_linker = linker
                     break

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -864,6 +864,10 @@ class EB_LLVM(CMakeMake):
             if LooseVersion(self.version) >= LooseVersion('19'):
                 self._set_gcc_prefix()
                 self._create_compiler_config_file(prev_dir)
+                # Pre-create the CFG files in the `build_stage/bin` directory to enforce using the correct dynamic
+                # linker in case of sysroot builds, and to ensure the correct GCC installation is used also for the
+                # runtimes (which would otherwise use the system default dynamic linker)
+                self._create_compiler_config_file(stage_dir)
 
             self.add_cmake_opts()
 

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -781,7 +781,7 @@ class EB_LLVM(CMakeMake):
         if not self.full_llvm:
             gcc_root = get_software_root('GCCcore')
             gcc_lib = os.path.join(gcc_root, 'lib64')
-            lib_path = os.getenv('LLIBRARY_PATH', '')
+            lib_path = os.getenv('LIBRARY_PATH', '')
             if gcc_lib not in lib_path:
                 self.log.info("Adding GCCcore libraries location `%s` the config files", gcc_lib)
                 lib_path = f"{gcc_lib}:{lib_path}" if lib_path else gcc_lib

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -703,6 +703,15 @@ class EB_LLVM(CMakeMake):
         regex_subs.append((r'add_subdirectory\(bindings/python/tests\)', ''))
         apply_regex_substitutions(cmakelists_tests, regex_subs)
 
+        # Remove flags disabling the use of configuration files during compiler-rt tests as we in general relies on
+        # them (See https://github.com/easybuilders/easybuild-easyblocks/pull/3741#issuecomment-2939404304)
+        lit_cfg_file = os.path.join(self.llvm_src_dir, 'compiler-rt', 'test', 'lit.common.cfg.py')
+        regex_subs = [
+            (r'^if config.has_no_default_config_flag:', ''),
+            (r'^\s*config.environment\["CLANG_NO_DEFAULT_CONFIG"\] = "1"', '')
+        ]
+        apply_regex_substitutions(lit_cfg_file, regex_subs)
+
         self._set_gcc_prefix()
 
         # If we don't want to build with CUDA (not in dependencies) trick CMakes FindCUDA module into not finding it by

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -784,8 +784,7 @@ class EB_LLVM(CMakeMake):
             lib_path = os.getenv('LIBRARY_PATH', '')
             if gcc_lib not in lib_path:
                 self.log.info("Adding GCCcore libraries location `%s` the config files", gcc_lib)
-                lib_path = f"{gcc_lib}:{lib_path}" if lib_path else gcc_lib
-                opts.append(f'-L{lib_path}')
+                opts.append(f'-L{gcc_lib}')
 
         for comp in self.cfg_compilers:
             write_file(os.path.join(bin_dir, f'{comp}.cfg'), ' '.join(opts))

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -42,24 +42,18 @@ import stat
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.toolchains.compiler.clang import Clang
 from easybuild.tools import LooseVersion
-from easybuild.tools.build_log import EasyBuildError, print_msg
-from easybuild.tools.config import (ERROR, IGNORE, SEARCH_PATH_LIB_DIRS,
-                                    build_option)
-from easybuild.tools.environment import setvar
-from easybuild.tools.filetools import (adjust_permissions,
-                                       apply_regex_substitutions, change_dir,
-                                       copy_dir, mkdir, remove_dir,
-                                       remove_file, symlink, which, write_file)
-from easybuild.tools.modules import (MODULE_LOAD_ENV_HEADERS,
-                                     get_software_root, get_software_version)
-from easybuild.tools.run import EasyBuildExit, run_shell_cmd
-from easybuild.tools.systemtools import (AARCH32, AARCH64, POWER, POWER_LE,
-                                         RISCV64, X86_64, get_cpu_architecture,
-                                         get_cpu_family, get_shared_lib_ext)
 from easybuild.tools.utilities import trace_msg
+from easybuild.tools.build_log import EasyBuildError, print_msg
+from easybuild.tools.config import ERROR, IGNORE, SEARCH_PATH_LIB_DIRS, build_option
+from easybuild.tools.environment import setvar
+from easybuild.tools.filetools import apply_regex_substitutions, change_dir, copy_dir, adjust_permissions
+from easybuild.tools.filetools import mkdir, remove_file, symlink, which, write_file, remove_dir
+from easybuild.tools.modules import MODULE_LOAD_ENV_HEADERS, get_software_root, get_software_version
+from easybuild.tools.run import run_shell_cmd, EasyBuildExit
+from easybuild.tools.systemtools import AARCH32, AARCH64, POWER, RISCV64, X86_64, POWER_LE
+from easybuild.tools.systemtools import get_cpu_architecture, get_cpu_family, get_shared_lib_ext
 
-from easybuild.easyblocks.generic.cmakemake import (
-    CMakeMake, get_cmake_python_config_dict)
+from easybuild.easyblocks.generic.cmakemake import CMakeMake, get_cmake_python_config_dict
 
 BUILD_TARGET_AMDGPU = 'AMDGPU'
 BUILD_TARGET_NVPTX = 'NVPTX'
@@ -1296,7 +1290,7 @@ class EB_LLVM(CMakeMake):
                 raise EasyBuildError(error_msg)
 
             for suffix in ('.c', '.o', '.x'):
-                remove_file(f'{test_fn}{suffix}')
+                remove_file('{test_fn}{suffix}')
 
     def sanity_check_step(self, custom_paths=None, custom_commands=None, extension=False, extra_modules=None):
         """Perform sanity checks on the installed LLVM."""

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -577,6 +577,7 @@ class EB_LLVM(CMakeMake):
                 if os.path.isfile(linker):
                     self.log.info("Using linker %s from sysroot", linker)
                     self.dynamic_linker = linker
+                    break
             else:
                 msg = f"No linker found in sysroot {self.sysroot}, using default linker"
                 trace_msg(msg)

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -355,12 +355,12 @@ class EB_LLVM(CMakeMake):
             general_opts['LLVM_INCLUDE_GO_TESTS'] = 'OFF'
 
         # Sysroot
-        sysroot = build_option('sysroot')
-        if sysroot:
-            general_opts['DEFAULT_SYSROOT'] = sysroot
-            general_opts['CMAKE_SYSROOT'] = sysroot
+        self.sysroot = build_option('sysroot')
+        if self.sysroot:
+            general_opts['DEFAULT_SYSROOT'] = self.sysroot
+            general_opts['CMAKE_SYSROOT'] = self.sysroot
             self._set_dynamic_linker()
-            trace_msg(f"Using '{self.dynamic_linker}' as dynamic linker from sysroot {sysroot}")
+            trace_msg(f"Using '{self.dynamic_linker}' as dynamic linker from sysroot {self.sysroot}")
 
         # list of CUDA compute capabilities to use can be specifed in two ways (where (2) overrules (1)):
         # (1) in the easyconfig file, via the custom cuda_compute_capabilities;

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -42,18 +42,24 @@ import stat
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.toolchains.compiler.clang import Clang
 from easybuild.tools import LooseVersion
-from easybuild.tools.utilities import trace_msg
 from easybuild.tools.build_log import EasyBuildError, print_msg
-from easybuild.tools.config import ERROR, IGNORE, SEARCH_PATH_LIB_DIRS, build_option
+from easybuild.tools.config import (ERROR, IGNORE, SEARCH_PATH_LIB_DIRS,
+                                    build_option)
 from easybuild.tools.environment import setvar
-from easybuild.tools.filetools import apply_regex_substitutions, change_dir, copy_dir, adjust_permissions
-from easybuild.tools.filetools import mkdir, remove_file, symlink, which, write_file, remove_dir
-from easybuild.tools.modules import MODULE_LOAD_ENV_HEADERS, get_software_root, get_software_version
-from easybuild.tools.run import run_shell_cmd, EasyBuildExit
-from easybuild.tools.systemtools import AARCH32, AARCH64, POWER, RISCV64, X86_64, POWER_LE
-from easybuild.tools.systemtools import get_cpu_architecture, get_cpu_family, get_shared_lib_ext
+from easybuild.tools.filetools import (adjust_permissions,
+                                       apply_regex_substitutions, change_dir,
+                                       copy_dir, mkdir, remove_dir,
+                                       remove_file, symlink, which, write_file)
+from easybuild.tools.modules import (MODULE_LOAD_ENV_HEADERS,
+                                     get_software_root, get_software_version)
+from easybuild.tools.run import EasyBuildExit, run_shell_cmd
+from easybuild.tools.systemtools import (AARCH32, AARCH64, POWER, POWER_LE,
+                                         RISCV64, X86_64, get_cpu_architecture,
+                                         get_cpu_family, get_shared_lib_ext)
+from easybuild.tools.utilities import trace_msg
 
-from easybuild.easyblocks.generic.cmakemake import CMakeMake, get_cmake_python_config_dict
+from easybuild.easyblocks.generic.cmakemake import (
+    CMakeMake, get_cmake_python_config_dict)
 
 BUILD_TARGET_AMDGPU = 'AMDGPU'
 BUILD_TARGET_NVPTX = 'NVPTX'
@@ -1290,7 +1296,7 @@ class EB_LLVM(CMakeMake):
                 raise EasyBuildError(error_msg)
 
             for suffix in ('.c', '.o', '.x'):
-                remove_file('{test_fn}{suffix}')
+                remove_file(f'{test_fn}{suffix}')
 
     def sanity_check_step(self, custom_paths=None, custom_commands=None, extension=False, extra_modules=None):
         """Perform sanity checks on the installed LLVM."""

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -781,8 +781,8 @@ class EB_LLVM(CMakeMake):
         if not self.full_llvm:
             gcc_root = get_software_root('GCCcore')
             gcc_lib = os.path.join(gcc_root, 'lib64')
-            library_path = os.getenv('LLIBRARY_PATH', '')
-            if gcc_lib not in library_path:
+            lib_path = os.getenv('LLIBRARY_PATH', '')
+            if gcc_lib not in lib_path:
                 self.log.info("Adding GCCcore libraries location `%s` the config files", gcc_lib)
                 lib_path = f"{gcc_lib}:{lib_path}" if lib_path else gcc_lib
                 opts.append(f'-L{lib_path}')

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -674,6 +674,8 @@ class EB_LLVM(CMakeMake):
         # Should not use system SWIG if present
         general_opts['LLDB_ENABLE_SWIG'] = 'ON' if get_software_root('SWIG') else 'OFF'
 
+        general_opts['LIBOMP_OMPD_GDB_SUPPORT'] = 'ON' if get_software_root('GDB') else 'OFF'
+
         z3_root = get_software_root("Z3")
         if z3_root:
             self.log.info("Using %s as Z3 root", z3_root)

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -1174,6 +1174,16 @@ class EB_LLVM(CMakeMake):
                 error_msg = f"Dynamic linker is not set to the sysroot '{self.sysroot}'"
                 raise EasyBuildError(error_msg)
 
+            cmd = f'./{x_name}'
+            res = run_shell_cmd(cmd, fail_on_error=False)
+            if res.exit_code != EasyBuildExit.SUCCESS:
+                error_msg = f"Failed to run the compiled executable '{x_name}' for testing the dynamic linker"
+                raise EasyBuildError(error_msg)
+
+            remove_file(c_name)
+            remove_file(o_name)
+            remove_file(x_name)
+
     def sanity_check_step(self, custom_paths=None, custom_commands=None, extension=False, extra_modules=None):
         """Perform sanity checks on the installed LLVM."""
         lib_dir_runtime = None
@@ -1367,9 +1377,10 @@ class EB_LLVM(CMakeMake):
             # Required for 'clang -v' to work if linked to LLVM runtimes
             with _wrap_env(ld_path=os.path.join(self.installdir, lib_dir_runtime)):
                 self._sanity_check_gcc_prefix(gcc_prefix_compilers, self.gcc_prefix, self.installdir)
+                self._sanity_check_dynamic_linker()
         else:
             self._sanity_check_gcc_prefix(gcc_prefix_compilers, self.gcc_prefix, self.installdir)
-        self._sanity_check_dynamic_linker()
+            self._sanity_check_dynamic_linker()
 
         return super().sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
 

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -704,10 +704,15 @@ class EB_LLVM(CMakeMake):
             known_frontend_files = [
                 'warning-poison-system-directories.c'
             ]
+            prev = self.ignore_patterns.copy()
             for file in known_driver_files:
                 self.ignore_patterns.append(f'Clang :: Driver/{file}')
             for file in known_frontend_files:
                 self.ignore_patterns.append(f'Clang :: Frontend/{file}')
+            self.log.info(
+                f"Ignore patterns for tests updated from {prev} to {self.ignore_patterns} to avoid known ignorable "
+                "failures with sysroot builds."
+                )
 
         python_opts = get_cmake_python_config_dict()
         general_opts.update(python_opts)


### PR DESCRIPTION
This PR changes the following in the LLVM EasyBlock behavior:

- If the `sysroot` buildoption is set will now attempt to find a dynamic linker under that path (by globbing for `sysroot/**/ld-*.so*'`) that is a real file and not a link
  - If not found a warning is given that the system dynamic linker is being used (**Should we raise an error instead?**)
- When creating compiler configuration files,:
  - If the dynamic linker was identified, add a `-Wl,-dynamic-linker` option pointing to the found path
  - If not in a `full_llvm` build and with. If `GCCcore` is defined but not in the `LIBRARY_PATH` add a `-L/path/to/gcccore/libs` option to the config file. This is needed as some tests will fail for not finding GCCcore core libraries like `gcc_s` during compilation. **Is this too aggressive?**
- Configuration files are preemptively created also in the build stage directory to allow runtimes ELFs to also point to the correct dynamic linker. If this is not done the clang produced during the project step, used to compile the runtimes is unaware of the correct dynamic linker and will default to the system one

This is a fix for:
- #3740 