### PR TITLE
Deprecate the Clang Easyblock in favor of the LLVM one for newer (>=18.1.6) versions of LLVM

### DIFF
--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -124,7 +124,7 @@ class EB_Clang(CMakeMake):
         if LooseVersion(self.version) >= LooseVersion('19'):
             raise EasyBuildError(
                 "The Clang EasyBlock has been deprecated and does not support LLVM versions >= 19. "
-                "Please use the 'LLVM' EasyBlock instead, which supports building Clang as well"
+                "Please use the 'LLVM' EasyBlock instead, which supports building Clang as well "
                 "as other LLVM projects."
             )
 

--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -121,9 +121,9 @@ class EB_Clang(CMakeMake):
 
         super().__init__(*args, **kwargs)
 
-        if LooseVersion(self.version) >= LooseVersion('19'):
+        if LooseVersion(self.version) >= LooseVersion('18.1.6'):
             raise EasyBuildError(
-                "The Clang EasyBlock has been deprecated and does not support LLVM versions >= 19. "
+                "The Clang EasyBlock has been deprecated and does not support LLVM versions >= 18.1.6. "
                 "Please use the 'LLVM' EasyBlock instead, which supports building Clang as well "
                 "as other LLVM projects."
             )

--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -121,9 +121,9 @@ class EB_Clang(CMakeMake):
 
         super().__init__(*args, **kwargs)
 
-        if LooseVersion(self.version) > LooseVersion('18.1.8'):
+        if LooseVersion(self.version) >= LooseVersion('19'):
             raise EasyBuildError(
-                "The Clang EasyBlock has been deprecated and does not support LLVM versions > 18.1.8. "
+                "The Clang EasyBlock has been deprecated and does not support LLVM versions >= 19. "
                 "Please use the 'LLVM' EasyBlock instead, which supports building Clang as well"
                 "as other LLVM projects."
             )

--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -120,6 +120,14 @@ class EB_Clang(CMakeMake):
         """Initialize custom class variables for Clang."""
 
         super().__init__(*args, **kwargs)
+
+        if LooseVersion(self.version) > LooseVersion('18.1.8'):
+            raise EasyBuildError(
+                "The Clang EasyBlock has been deprecated and does not support LLVM versions > 18.1.8. "
+                "Please use the 'LLVM' EasyBlock instead, which supports building Clang as well"
+                "as other LLVM projects."
+            )
+
         self.llvm_src_dir = None
         self.llvm_obj_dir_stage1 = None
         self.llvm_obj_dir_stage2 = None


### PR DESCRIPTION
The LLVM Easyblock should replace the Clang one as it supports building Clang + other subproject and has been extensively reworked to ensure the proper testing, interplay between projects, and newer subproject/project structure introduced in LLVM >= 19, in particular related to offloading

edit: need to make sure that Clang 18.1.8 easyconfigs no longer use the Clang easyblock, so requires merge of:
* https://github.com/easybuilders/easybuild-easyconfigs/pull/23055