### PR TITLE
enhance `run_pip_check` function to respect EasyBuild configuration option to ignore unversioned (0.0.0) Python packages

### DIFF
--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -191,7 +191,7 @@ def run_pip_check(python_cmd=None, unversioned_packages=None):
         unversioned_packages = set()
     elif isinstance(unversioned_packages, (list, tuple)):
         unversioned_packages = set(unversioned_packages)
-    else:
+    elif not isinstance(unversioned_packages, set):
         raise EasyBuildError("Incorrect value type for 'unversioned_packages' in run_pip_check: %s",
                              type(unversioned_packages))
 

--- a/test/easyblocks/easyblock_specific.py
+++ b/test/easyblocks/easyblock_specific.py
@@ -398,6 +398,9 @@ class EasyBlockSpecificTest(TestCase):
         with self.mocked_stdout_stderr():
             python.run_pip_check(python_cmd=sys.executable, unversioned_packages=('zero', ))
 
+        with self.mocked_stdout_stderr():
+            python.run_pip_check(python_cmd=sys.executable, unversioned_packages=set(['zero']))
+
         # inject all possible errors
         def mocked_run_shell_cmd_pip(cmd, **kwargs):
             if "pip check" in cmd:


### PR DESCRIPTION
useful when your OS has some packages installed that report a version of 0.0.0 (e.g. kiwisolver or mpmath in debian 12/ubuntu 24.04)

- [x] companion PR: https://github.com/easybuilders/easybuild-framework/pull/4912