### PR TITLE
remove `2to3` file from sanity check in Anaconda easyblock (no longer there in recent versions)

### DIFF
--- a/easybuild/easyblocks/a/anaconda.py
+++ b/easybuild/easyblocks/a/anaconda.py
@@ -85,7 +85,7 @@ class EB_Anaconda(Binary):
         Custom sanity check for Anaconda and Miniconda
         """
         custom_paths = {
-            'files': [os.path.join('bin', x) for x in ['2to3', 'conda', 'pydoc', 'python', 'sqlite3']],
+            'files': [os.path.join('bin', x) for x in ['conda', 'pydoc', 'python', 'sqlite3']],
             'dirs': ['bin', 'etc', 'lib', 'pkgs'],
         }
         super().sanity_check_step(custom_paths=custom_paths)


### PR DESCRIPTION
2to3 file does not exist anymore in the latest Miniconda3 versions.