### PR TITLE
Use `self.start_dir` in LLVM easyblock

### DIFF
--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -462,6 +462,12 @@ class EB_LLVM(CMakeMake):
         self._cmakeopts = {}
         self._cfgopts = list(filter(None, self.cfg.get('configopts', '').split()))
 
+    @property
+    def llvm_src_dir(self):
+        """Return root source directory of LLVM (containing all components)"""
+        # LLVM is the first source so we already have this in start_dir. Might be changed later
+        return self.start_dir
+
     def prepare_step(self, *args, **kwargs):
         """Prepare step, modified to ensure install dir is deleted before building"""
         super(EB_LLVM, self).prepare_step(*args, **kwargs)


### PR DESCRIPTION
`self.cfg['start_dir']` gets initialized in `guess_start_dir` and hence is always set to an absolute path, so non-empty.
Note that `path.join(anything, abs-path) == abs-path`

So `llvm_src_dir` is always equal to `self.start_dir` and we can remove this property.

@Crivella am I missing anything?

I'm also wondering about the src extension in `llvm-project-%s.src`. Haven't seen that in my tests anywhere and it likely didn't cause issues due to the above which means that code path wasn't used.