### PR TITLE
Reset `runtest` for components in a bundle

### DIFF
--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -39,6 +39,7 @@ import os
 import easybuild.tools.environment as env
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.framework.easyconfig.default import DEFAULT_CONFIG
 from easybuild.framework.easyconfig.easyconfig import get_easyblock_class
 from easybuild.tools.build_log import EasyBuildError, print_msg
 from easybuild.tools.config import build_option
@@ -130,7 +131,13 @@ class Bundle(EasyBlock):
                 # which is not a valid value for many easyblocks.
                 # Reset runtest to the original default, if people want the test step
                 # they can set it explicitly.
-                comp_cfg['runtest'] = None
+                if comp_cfg._config['runtest'] != DEFAULT_CONFIG["runtest"]:
+                    self.log.warning(
+                        "Resetting runtest to default value for component easyblock "
+                        f"(from {comp_cfg._config['runtest']})."
+                        )
+                    comp_cfg["runtest"] = DEFAULT_CONFIG["runtest"][0]
+                    comp_cfg._config['runtest'] = DEFAULT_CONFIG["runtest"]
 
                 # determine easyblock to use for this component
                 # - if an easyblock is specified explicitly, that will be used

--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -130,13 +130,12 @@ class Bundle(EasyBlock):
                 #  runtest = True
                 # which is not a valid value for many easyblocks.
                 # Reset runtest to the original default, if people want the test step
-                # they can set it explicitly (or it can be set by the component easyblock).
+                # they can set it explicitly, in default_component_specs or by the component easyblock
                 if comp_cfg._config['runtest'] != DEFAULT_CONFIG["runtest"]:
                     self.log.warning(
                         "Resetting runtest to default value for component easyblock "
                         f"(from {comp_cfg._config['runtest']})."
                         )
-                    comp_cfg["runtest"] = DEFAULT_CONFIG["runtest"][0]
                     comp_cfg._config['runtest'] = DEFAULT_CONFIG["runtest"]
 
                 # determine easyblock to use for this component

--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -130,7 +130,7 @@ class Bundle(EasyBlock):
                 #  runtest = True
                 # which is not a valid value for many easyblocks.
                 # Reset runtest to the original default, if people want the test step
-                # they can set it explicitly.
+                # they can set it explicitly (or it can be set by the component easyblock).
                 if comp_cfg._config['runtest'] != DEFAULT_CONFIG["runtest"]:
                     self.log.warning(
                         "Resetting runtest to default value for component easyblock "

--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -124,8 +124,16 @@ class Bundle(EasyBlock):
                 comp_cfg['name'] = comp_name
                 comp_cfg['version'] = comp_version
 
+                # The copy above may include unexpected settings for common values.
+                # In particular a Pythonbundle for we have seen a component inheriting
+                #  runtest = True
+                # which is not a valid value for many easyblocks.
+                # Reset runtest to the original default, if people want the test step
+                # they can set it explicitly.
+                comp_cfg['runtest'] = None
+
                 # determine easyblock to use for this component
-                # - if an easyblock is specified explicitely, that will be used
+                # - if an easyblock is specified explicitly, that will be used
                 # - if not, a software-specific easyblock will be considered by get_easyblock_class
                 # - if no easyblock was found, default_easyblock is considered
                 comp_easyblock = comp_specs.get('easyblock')


### PR DESCRIPTION
Follow up to #3748 for the case where it is have been shown to be problematic (components in a Pythonbundle)