### PR TITLE
lammps sanity checks: remove LD_LIBRARY_PATH setting

### DIFF
--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -572,13 +572,7 @@ class EB_LAMMPS(CMakeMake):
         if self.toolchain.options.get('usempi', None):
             custom_commands = [self.toolchain.mpi_cmd_for(cmd, 1) for cmd in custom_commands]
 
-        # Requires liblammps.so to be findable by the runtime linker (which it might not be if using
-        # rpath and filtering out LD_LIBRARY_PATH)
-        set_ld_library_path = ''
-        if self.installdir not in os.getenv('LD_LIBRARY_PATH', default=''):
-            # Use LIBRARY_PATH to set it
-            set_ld_library_path = "LD_LIBRARY_PATH=$LIBRARY_PATH:$LD_LIBRARY_PATH "
-        custom_commands = ["cd %s && " % execution_dir + set_ld_library_path + cmd for cmd in custom_commands]
+        custom_commands = ["cd %s && " % execution_dir + cmd for cmd in custom_commands]
 
         shlib_ext = get_shared_lib_ext()
         custom_paths = {


### PR DESCRIPTION
With the `foss-2024a` toolchain (CUDA 12.6+), prepending `LD_LIBRARY_PATH` with `LIBRARY_PATH` causes LAMMPS to crash, likely because the dynamic linker gets pointed to the CUDA stubs libs instead of the system libs. Strangely, this is not a problem for older toolchains. At the same time, it appears that setting `LD_LIBRARY_PATH` has no effect on the functionality of the code (it seems that Python is able to retrieve `liblammps.so` without it), so I propose we just get rid of it, unless there are actual scenarios where it causes problems.