### PR TITLE
Moved logic from the constructor to `configure_step` in LLVM easyblock (so it can be used to install bundle component)

### DIFF
--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -381,24 +381,6 @@ class EB_LLVM(CMakeMake):
         # LLVM is the first source so we already have this in start_dir. Might be changed later
         return self.start_dir
 
-    def prepare_step(self, *args, **kwargs):
-        """Prepare step, modified to ensure install dir is deleted before building"""
-        super().prepare_step(*args, **kwargs)
-        # re-create installation dir (deletes old installation),
-        # Needed to ensure hardcoded rpath do not point to old installation during runtime builds and testing
-        self.make_installdir()
-
-    def _add_cmake_runtime_args(self):
-        """Generate the value for 'RUNTIMES_CMAKE_ARGS' and add it to the cmake options."""
-        if self.runtimes_cmake_args:
-            args = []
-            for key, val in self.runtimes_cmake_args.items():
-                if isinstance(val, list):
-                    val = ' '.join(val)
-                if val:
-                    args.append('-D%s=%s' % (key, val))
-            self._cmakeopts['RUNTIMES_CMAKE_ARGS'] = '"%s"' % ';'.join(args)
-
     def _configure_build_targets(self):
         # list of CUDA compute capabilities to use can be specifed in two ways (where (2) overrules (1)):
         # (1) in the easyconfig file, via the custom cuda_compute_capabilities;

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -377,7 +377,7 @@ class EB_LLVM(CMakeMake):
 
     def prepare_step(self, *args, **kwargs):
         """Prepare step, modified to ensure install dir is deleted before building"""
-        super(EB_LLVM, self).prepare_step(*args, **kwargs)
+        super().prepare_step(*args, **kwargs)
         # re-create installation dir (deletes old installation),
         # Needed to ensure hardcoded rpath do not point to old installation during runtime builds and testing
         self.make_installdir()

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -709,8 +709,8 @@ class EB_LLVM(CMakeMake):
         if self.sysroot:
             if LooseVersion(self.version) < LooseVersion('19'):
                 raise EasyBuildError("Using sysroot is not supported by EasyBuild for LLVM < 19")
-            general_opts['DEFAULT_SYSROOT'] = self.sysroot
-            general_opts['CMAKE_SYSROOT'] = self.sysroot
+            self.general_opts['DEFAULT_SYSROOT'] = self.sysroot
+            self.general_opts['CMAKE_SYSROOT'] = self.sysroot
             self._set_dynamic_linker()
             trace_msg(f"Using '{self.dynamic_linker}' as dynamic linker from sysroot {self.sysroot}")
 

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -477,9 +477,6 @@ class EB_LLVM(CMakeMake):
         self.general_opts['CMAKE_BUILD_TYPE'] = self.build_type
         self.general_opts['LLVM_TARGETS_TO_BUILD'] = self.list_to_cmake_arg(build_targets)
 
-        self._cmakeopts = {}
-        self._cfgopts = list(filter(None, self.cfg.get('configopts', '').split()))
-
     def prepare_step(self, *args, **kwargs):
         """Prepare step, modified to ensure install dir is deleted before building"""
         super().prepare_step(*args, **kwargs)


### PR DESCRIPTION
This will be needed to ensure all the functionalities of the easyblock work properly also when used from inside a Bundle