### PR TITLE
LAMMPS: select best performing FFT lib

### DIFF
--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -443,6 +443,19 @@ class EB_LAMMPS(CMakeMake):
                 else:
                     self.cfg.update('configopts', '-D%s_ARCH="%s"' % (self.kokkos_prefix, processor_arch))
 
+            # Selection of the FFT library for KOKKOS (available since version 29Aug2024)
+            # See: https://docs.lammps.org/Build_settings.html#fft-library
+            #      https://docs.lammps.org/Build_extras.html#kokkos
+            # For the sake of performance, do not use internal KISS FFT library, if possible
+            if LooseVersion(self.cur_version) >= LooseVersion(translate_lammps_version('29Aug2024')):
+                if self.cuda:
+                    self.cfg.update('configopts', '-DFFT_KOKKOS=CUFFT')
+                else:
+                    if get_software_root("imkl"):
+                        self.cfg.update('configopts', '-DFFT_KOKKOS=MKL')
+                    elif get_software_root("FFTW"):
+                        self.cfg.update('configopts', '-DFFT_KOKKOS=FFTW3')
+
         # CUDA only
         elif self.cuda:
             print_msg("Using GPU package (not Kokkos) with arch: CPU - %s, GPU - %s" % (processor_arch, gpu_arch))


### PR DESCRIPTION
From version `29Aug2024` it is possible to specify the FFT library used in Kokkos by the Cmake setting `FFT_KOKKOS`.

LAMMPS is shipped with the internal KISS FFT library, which is selected by default.
However, for CUDA builds, messages appear at runtime advising the user to use `cuFFT` for better performance.
For CPU-only builds, it is also advised to use FFTW or MKL, if available.