### PR TITLE
Add option to `CMakeMake` to specify name of build directory

### DIFF
--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -232,7 +232,7 @@ class CMakeMake(ConfigureMake):
                 elif isinstance(separate_build_dir, str):
                     # Note that the join returns separate_build_dir if it is absolute
                     self.separate_build_dir = os.path.join(self.builddir, separate_build_dir)
-                    mkdir(self.separate_build_dir)
+                    mkdir(self.separate_build_dir, parents=True)
                 else:
                     raise EasyBuildError('Invalid value for separate_build_dir: %s (type %s)',
                                          separate_build_dir, type(separate_build_dir))


### PR DESCRIPTION
Especially for `Bundle` easyconfigs one might want to refer to the build directory of a previous build step.
Using the auto-generated name is not reliable as it might change. Enhance `separate_build_dir` to accept a string in addition to True/False to specify a specific directory.

Example is Triton:
https://github.com/easybuilders/easybuild-easyconfigs/blob/9a1462f0120bee1ed8230b18948e689a7513d3b7/easybuild/easyconfigs/t/Triton/Triton-3.1.0-foss-2024a-CUDA-12.6.0.eb#L71-L74

Test: https://github.com/easybuilders/easybuild-easyconfigs/pull/23119#issuecomment-2983414898