### PR TITLE
handle PATH environment variable with `module_load_environment` in init of Binary easyblock

### DIFF
--- a/easybuild/easyblocks/generic/binary.py
+++ b/easybuild/easyblocks/generic/binary.py
@@ -79,6 +79,10 @@ class Binary(EasyBlock):
             mkdir(self.installdir, parents=True)
             self.log.info("Performing staged installation via %s" % self.installdir)
 
+        prepend_to_path = self.cfg.get('prepend_to_path', PREPEND_TO_PATH_DEFAULT)
+        if prepend_to_path:
+            self.module_load_environment.PATH.append(prepend_to_path)
+
     def extract_step(self):
         """Copy all source files to the build directory"""
 
@@ -151,13 +155,3 @@ class Binary(EasyBlock):
         """Skip the rpath sanity check, this is binary software"""
         self.log.info("RPATH sanity check is skipped when using %s easyblock (derived from Binary)",
                       self.__class__.__name__)
-
-    def make_module_extra(self):
-        """Add the specified directories to the PATH."""
-
-        txt = super().make_module_extra()
-        prepend_to_path = self.cfg.get('prepend_to_path', PREPEND_TO_PATH_DEFAULT)
-        if prepend_to_path:
-            txt += self.module_generator.prepend_paths("PATH", prepend_to_path)
-        self.log.debug("make_module_extra added this: %s" % txt)
-        return txt

--- a/easybuild/easyblocks/generic/binary.py
+++ b/easybuild/easyblocks/generic/binary.py
@@ -80,8 +80,10 @@ class Binary(EasyBlock):
             self.log.info("Performing staged installation via %s" % self.installdir)
 
         prepend_to_path = self.cfg.get('prepend_to_path', PREPEND_TO_PATH_DEFAULT)
+        if isinstance(prepend_to_path, str):
+            prepend_to_path = [prepend_to_path]
         if prepend_to_path:
-            self.module_load_environment.PATH.append(prepend_to_path)
+            self.module_load_environment.PATH.extend(prepend_to_path)
 
     def extract_step(self):
         """Copy all source files to the build directory"""


### PR DESCRIPTION
This went through the cracks with the introduction of `module_load_environment` in EB5