### PR TITLE
symlink CUPTI files to standard locations in CUDA installation

### DIFF
--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -318,7 +318,7 @@ class EB_CUDA(Binary):
             for cupti_subdir in ['include', 'lib64']:
                 cupti_target_dir = os.path.join(self.installdir, cupti_subdir)
                 cwd = change_dir(cupti_target_dir)
-                for cupti_file in glob(os.path.join(self.installdir, 'extras', 'CUPTI', cupti_subdir, '*')):
+                for cupti_file in glob(os.path.join(cupti_dir, cupti_subdir, '*')):
                     cupti_link_src = os.path.relpath(os.path.realpath(cupti_file), os.path.realpath(cupti_target_dir))
                     symlink(cupti_link_src, os.path.basename(cupti_file), use_abspath_source=False)
                 change_dir(cwd)


### PR DESCRIPTION
Needed by https://github.com/easybuilders/easybuild-easyconfigs/pull/22921

This PR adds symlinks of all files under `$CUDA_ROOT/extras/CUPTI` into the standard locations of the CUDA installation. Symlinks use relative paths to keep the whole installation transferable.

Part of the outcome in `$CUDA_ROOT/include`:
```
[...]
0644  13k  cufft.h
0644  20k  cufftw.h
0644  11k  cufftXt.h
0644  29k  cufile.h
0777    -  cupti.h -> ../../../extras/CUPTI/include/cupti.h
0777    -  cupti_activity.h -> ../../../extras/CUPTI/include/cupti_activity.h
0777    -  cupti_activity_deprecated.h -> ../../../extras/CUPTI/include/cupti_activity_deprecated.h
0777    -  cupti_callbacks.h -> ../../../extras/CUPTI/include/cupti_callbacks.h
0777    -  cupti_checkpoint.h -> ../../../extras/CUPTI/include/cupti_checkpoint.h
0777    -  cupti_common.h -> ../../../extras/CUPTI/include/cupti_common.h
0777    -  cupti_driver_cbid.h -> ../../../extras/CUPTI/include/cupti_driver_cbid.h
[...]
```