### PR TITLE
Bundle: Add missing call to `make_module_step` for components

### DIFF
--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -307,7 +307,7 @@ class Bundle(EasyBlock):
                 self.comp_cfgs_sanity_check.append(comp)
 
             # run relevant steps
-            for step_name in ['patch', 'configure', 'build', 'test', 'install']:
+            for step_name in ['patch', 'configure', 'build', 'test', 'install', 'make_module']:
                 if step_name in cfg['skipsteps']:
                     comp.log.info("Skipping '%s' step for component %s v%s", step_name, cfg['name'], cfg['version'])
                 elif build_option('skip_test_step') and step_name == TEST_STEP:


### PR DESCRIPTION
When EasyBlocks are not using the deprecated `make_module_req_guess`, the Bundle EasyBlock would only collect the `module_load_environment` set outside of `make_module_step`. `make_module_step` was never called by Bundle, and hence additional module paths were missing.

To fix this, also run the `make_module` step for each component.

Fixes #3800 