### PR TITLE
Add support for `UCX`, `CUDA` and `mpi_abi` directly in MPICH easyblock

### DIFF
--- a/easybuild/easyblocks/m/mpich.py
+++ b/easybuild/easyblocks/m/mpich.py
@@ -94,6 +94,7 @@ class EB_MPICH(ConfigureMake):
         # is not present in the FFLAGS variable.
         version = LooseVersion(self.version)
         if version < LooseVersion('4'):
+            self.log.info("MPICH version < 4, not unsetting FFLAGS to avoid configure failure")
             vars_to_keep.append('FFLAGS')
 
         vars_to_unset = list(set(vars_to_unset) - set(vars_to_keep))


### PR DESCRIPTION
- Add build option `mpi_abi = False[/True]` to turn the building of the MPI ABI on/off (with the related sanity check)
- Check if UCX is present at the EB level instead of in the easyconfigs
  - [x] Could also have a build option to enable disable this
  - [x] Could also automatically add the `:ucx` suffix to the `device`
- Added check for CUDA dependency to enable `--with-cuda=...` automatically