### PR TITLE
Alternative refactoring and fix for LLVM easyblock

### DIFF
--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -161,6 +161,11 @@ class CMakeMake(ConfigureMake):
         })
         return extra_vars
 
+    @staticmethod
+    def list_to_cmake_arg(lst):
+        """Convert iterable of strings to a value that can be passed as a CLI argument to CMake resulting in a list"""
+        return "'%s'" % ';'.join(lst)
+
     def __init__(self, *args, **kwargs):
         """Constructor for CMakeMake easyblock"""
         super().__init__(*args, **kwargs)
@@ -356,7 +361,7 @@ class CMakeMake(ConfigureMake):
             options['CMAKE_CUDA_COMPILER'] = which('nvcc')
             cuda_cc = build_option('cuda_compute_capabilities') or self.cfg['cuda_compute_capabilities']
             if cuda_cc:
-                options['CMAKE_CUDA_ARCHITECTURES'] = '"%s"' % ';'.join([cc.replace('.', '') for cc in cuda_cc])
+                options['CMAKE_CUDA_ARCHITECTURES'] = self.list_to_cmake_arg(cc.replace('.', '') for cc in cuda_cc)
             else:
                 raise EasyBuildError('List of CUDA compute capabilities must be specified, either via '
                                      'cuda_compute_capabilities easyconfig parameter or via '

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -184,7 +184,7 @@ class EB_LLVM(CMakeMake):
         'bootstrap',
         'full_llvm',
         'python_bindings',
-        'usepolly',
+        'use_polly',
     ]
 
     # Create symlink between equivalent host triples, useful so that other build processes that relies on older
@@ -230,7 +230,8 @@ class EB_LLVM(CMakeMake):
             'test_suite_timeout_single': [None, "Timeout for each individual test in the test suite", CUSTOM],
             'test_suite_timeout_total': [None, "Timeout for total running time of the testsuite", CUSTOM],
             'use_pic': [True, "Build with Position Independent Code (PIC)", CUSTOM],
-            'usepolly': [False, "Build Clang with polly", CUSTOM],
+            'usepolly': [None, "DEPRECATED, alias for 'use_polly'", CUSTOM],
+            'use_polly': [False, "Build Clang with polly", CUSTOM],
         })
 
         return extra_vars
@@ -238,6 +239,10 @@ class EB_LLVM(CMakeMake):
     def __init__(self, *args, **kwargs):
         """Initialize LLVM-specific variables."""
         super().__init__(*args, **kwargs)
+
+        if self.cfg['usepolly'] is not None:
+            self.log.deprecated("Use of easyconfig parameter 'usepolly', replace by 'use_polly'", '6.0')
+            self.cfg['use_polly'] = self.cfg['usepolly']
 
         self.llvm_obj_dir_stage1 = None
         self.llvm_obj_dir_stage2 = None
@@ -332,7 +337,7 @@ class EB_LLVM(CMakeMake):
             if not self.cfg['build_openmp']:
                 raise EasyBuildError("Building OpenMP tools requires building OpenMP runtime")
 
-        if self.cfg['usepolly']:
+        if self.cfg['use_polly']:
             self.final_projects.append('polly')
 
         if self.cfg['build_clang_extras']:
@@ -548,7 +553,7 @@ class EB_LLVM(CMakeMake):
             lit_args += ['--max-time', str(timeout_total)]
         self._cmakeopts['LLVM_LIT_ARGS'] = '"%s"' % ' '.join(lit_args)
 
-        if self.cfg['usepolly']:
+        if self.cfg['use_polly']:
             self._cmakeopts['LLVM_POLLY_LINK_INTO_TOOLS'] = 'ON'
         if not self.cfg['skip_all_tests']:
             self._cmakeopts['LLVM_INCLUDE_TESTS'] = 'ON'

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -333,7 +333,7 @@ class EB_LLVM(CMakeMake):
                 raise EasyBuildError("Building OpenMP offload requires building OpenMP runtime")
             # LLVM 19 added a new runtime target for explicit offloading
             # https://discourse.llvm.org/t/llvm-19-1-0-no-library-libomptarget-nvptx-sm-80-bc-found/81343
-            if LooseVersion(self.version) >= LooseVersion('19'):
+            if LooseVersion(self.version) >= '19':
                 self.log.debug("Explicitly enabling OpenMP offloading for LLVM >= 19")
                 self.final_runtimes.append('offload')
             else:
@@ -367,13 +367,13 @@ class EB_LLVM(CMakeMake):
             self.final_projects.append('bolt')
 
         # Fix for https://github.com/easybuilders/easybuild-easyblocks/issues/3689
-        if LooseVersion(self.version) < LooseVersion('16'):
+        if LooseVersion(self.version) < '16':
             self.general_opts['LLVM_INCLUDE_GO_TESTS'] = 'OFF'
 
         # Sysroot
         self.sysroot = build_option('sysroot')
         if self.sysroot:
-            if LooseVersion(self.version) < LooseVersion('19'):
+            if LooseVersion(self.version) < '19':
                 raise EasyBuildError("Using sysroot is not supported by EasyBuild for LLVM < 19")
             self.general_opts['DEFAULT_SYSROOT'] = self.sysroot
             self.general_opts['CMAKE_SYSROOT'] = self.sysroot
@@ -458,9 +458,9 @@ class EB_LLVM(CMakeMake):
         # Enable offload targets for LLVM >= 18
         self.cuda_cc = []
         self.amd_gfx = []
-        if self.cfg['build_openmp_offload'] and LooseVersion(self.version) >= LooseVersion('18'):
+        if self.cfg['build_openmp_offload'] and LooseVersion(self.version) >= '18':
             if self.nvptx_target_cond:
-                if LooseVersion(self.version) < LooseVersion('20') and not cuda_cc_list:
+                if LooseVersion(self.version) < '20' and not cuda_cc_list:
                     raise EasyBuildError(
                         f"LLVM < 20 requires 'cuda_compute_capabilities' to build with {BUILD_TARGET_NVPTX}"
                     )
@@ -468,7 +468,7 @@ class EB_LLVM(CMakeMake):
                 self.offload_targets += ['cuda']
                 self.log.debug("Enabling `cuda` offload target")
             if self.amdgpu_target_cond:
-                if LooseVersion(self.version) < LooseVersion('20') and not amd_gfx_list:
+                if LooseVersion(self.version) < '20' and not amd_gfx_list:
                     raise EasyBuildError(f"LLVM < 20 requires 'amd_gfx_list' to build with {BUILD_TARGET_AMDGPU}")
                 self.amd_gfx = amd_gfx_list
                 self.offload_targets += ['amdgpu']  # Used for LLVM >= 19
@@ -528,7 +528,7 @@ class EB_LLVM(CMakeMake):
         if 'openmp' in self.final_projects:
             if self.cfg['build_openmp_offload']:
                 # Force dlopen of the GPU libraries at runtime, not using existing libraries
-                if LooseVersion(self.version) >= LooseVersion('19'):
+                if LooseVersion(self.version) >= '19':
                     self.runtimes_cmake_args['LIBOMPTARGET_PLUGINS_TO_BUILD'] = '%s' % '|'.join(self.offload_targets)
                     dlopen_plugins = set(self.offload_targets) & set(AVAILABLE_OFFLOAD_DLOPEN_PLUGIN_OPTIONS)
                     if dlopen_plugins:
@@ -608,7 +608,7 @@ class EB_LLVM(CMakeMake):
             # For LLVM 18+ config files should be used and this option is deprecated and causes an error in 19
             # But the --gcc-toolchain and --gcc-install-dir for flang are not supported before LLVM 19
             # https://github.com/llvm/llvm-project/pull/87360
-            if LooseVersion(self.version) < LooseVersion('19'):
+            if LooseVersion(self.version) < '19':
                 self.log.debug("Using GCC_INSTALL_PREFIX")
                 self.general_opts['GCC_INSTALL_PREFIX'] = gcc_root
             else:
@@ -671,7 +671,7 @@ class EB_LLVM(CMakeMake):
         new_ignore_patterns.append('Flang :: Driver/missing-input.f90')
 
         # See https://github.com/llvm/llvm-project/issues/140024
-        if LooseVersion(self.version) <= LooseVersion('20.1.5'):
+        if LooseVersion(self.version) <= '20.1.5':
             new_ignore_patterns.append('LLVM :: CodeGen/Hexagon/isel/pfalse-v4i1.ll')
 
         self.ignore_patterns += new_ignore_patterns
@@ -682,12 +682,12 @@ class EB_LLVM(CMakeMake):
         Install extra tools in bin/; enable zlib if it is a dep; optionally enable rtti; and set the build target
         """
         # Allow running with older versions of LLVM for minimal builds in order to replace EB_LLVM easyblock
-        if not self.cfg['minimal'] and LooseVersion(self.version) < LooseVersion('18.1.6'):
+        if not self.cfg['minimal'] and LooseVersion(self.version) < '18.1.6':
             raise EasyBuildError("LLVM version %s is not supported, please use version 18.1.6 or newer", self.version)
 
         # Allow running with older versions of GCC for minimal builds in order to replace EB_LLVM easyblock
         gcc_version = get_software_version('GCCcore')
-        if not self.cfg['minimal'] and LooseVersion(gcc_version) < LooseVersion('13'):
+        if not self.cfg['minimal'] and LooseVersion(gcc_version) < '13':
             raise EasyBuildError("LLVM %s requires GCC 13 or newer, found %s", self.version, gcc_version)
 
         # Lit is needed for running tests-suite
@@ -964,7 +964,7 @@ class EB_LLVM(CMakeMake):
             self._cmakeopts['CMAKE_ASM_COMPILER_ID'] = 'Clang'
 
             # Also runs of the intermediate step compilers should be made aware of the GCC installation
-            if LooseVersion(self.version) >= LooseVersion('19'):
+            if LooseVersion(self.version) >= '19':
                 self._create_compiler_config_file(prev_dir)
                 # also pre-create the CFG files in the `build_stage/bin` directory to enforce using the correct dynamic
                 # linker in case of sysroot builds, and to ensure the correct GCC installation is used also for the
@@ -1157,7 +1157,7 @@ class EB_LLVM(CMakeMake):
         """Run tests on final stage (unless disabled)."""
         if not self.cfg['skip_all_tests']:
             # Also runs of test suite compilers should be made aware of the GCC installation
-            if LooseVersion(self.version) >= LooseVersion('19'):
+            if LooseVersion(self.version) >= '19':
                 self._create_compiler_config_file(self.final_dir)
 
             # For nvptx64 tests, find out if 'ptxas' exists in $PATH. If not, ignore all nvptx64 test failures
@@ -1213,7 +1213,7 @@ class EB_LLVM(CMakeMake):
             python_bindings_source_dir = os.path.join(self.start_dir, 'mlir', 'python')
             copy_dir(python_bindings_source_dir, python_bindins_target_dir, dirs_exist_ok=True)
 
-        if LooseVersion(self.version) >= LooseVersion('19'):
+        if LooseVersion(self.version) >= '19':
             # For GCC aware installation create config files in order to point to the correct GCC installation
             # Required as GCC_INSTALL_PREFIX was removed (see https://github.com/llvm/llvm-project/pull/87360)
             self._create_compiler_config_file(self.installdir)
@@ -1320,6 +1320,7 @@ class EB_LLVM(CMakeMake):
         shlib_ext = '.' + get_shared_lib_ext()
 
         resdir_version = self.version.split('.')[0]
+        version = LooseVersion(self.version)
 
         arch = get_cpu_architecture()
         # Check architecture explicitly since Clang uses potentially different names
@@ -1376,7 +1377,7 @@ class EB_LLVM(CMakeMake):
             ]
             check_dirs += ['include/clang-tidy']
         if 'flang' in self.final_projects:
-            if LooseVersion(self.version) < LooseVersion('19'):
+            if version < '19':
                 check_bin_files += ['bbc', 'flang-new', 'flang-to-external-fc', 'f18-parse-demo', 'fir-opt', 'tco']
             else:
                 check_bin_files += ['bbc', 'flang-new', 'f18-parse-demo', 'fir-opt', 'tco']
@@ -1446,35 +1447,35 @@ class EB_LLVM(CMakeMake):
                 if version < '19':
                     omp_lib_files += [f'libomptarget.rtl.{arch}.so']
                 if self.nvptx_target_cond:
-                    if LooseVersion(self.version) < LooseVersion('19'):
+                    if version < '19':
                         omp_lib_files += ['libomptarget.rtl.cuda.so']
-                    if LooseVersion(self.version) < LooseVersion('20'):
+                    elif version < '20':
                         omp_lib_files += [f'libomptarget-nvptx-sm_{cc}.bc' for cc in self.cuda_cc]
                     else:
                         omp_lib_files += ['libomptarget-nvptx.bc']
                 if self.amdgpu_target_cond:
-                    if LooseVersion(self.version) < LooseVersion('19'):
+                    if version < '19':
                         omp_lib_files += ['libomptarget.rtl.amdgpu.so']
-                    if LooseVersion(self.version) < LooseVersion('20'):
+                    elif version < '20':
                         omp_lib_files += [f'libomptarget-amdgpu-{gfx}.bc' for gfx in self.amd_gfx]
                     else:
                         omp_lib_files += ['libomptarget-amdgpu.bc']
 
-                if LooseVersion(self.version) < LooseVersion('19'):
+                if version < '19':
                     # Before LLVM 19, omp related libraries are installed under 'ROOT/lib''
                     check_lib_files += omp_lib_files
                 else:
                     # Starting from LLVM 19, omp related libraries are installed the runtime library directory
                     check_librt_files += omp_lib_files
                     check_bin_files += ['llvm-omp-kernel-replay']
-                    if LooseVersion(self.version) < LooseVersion('20'):
+                    if version < '20':
                         check_bin_files += ['llvm-omp-device-info']
                     else:
                         check_bin_files += ['llvm-offload-device-info']
 
         if self.cfg['build_openmp_tools']:
             check_files += [os.path.join('lib', 'clang', resdir_version, 'include', 'ompt.h')]
-            if LooseVersion(self.version) < LooseVersion('19'):
+            if version < '19':
                 check_lib_files += ['libarcher.so']
             else:
                 check_librt_files += ['libarcher.so']

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -475,7 +475,7 @@ class EB_LLVM(CMakeMake):
 
     def prepare_step(self, *args, **kwargs):
         """Prepare step, modified to ensure install dir is deleted before building"""
-        super(EB_LLVM, self).prepare_step(*args, **kwargs)
+        super().prepare_step(*args, **kwargs)
         # re-create installation dir (deletes old installation),
         # Needed to ensure hardcoded rpath do not point to old installation during runtime builds and testing
         self.make_installdir()
@@ -818,7 +818,7 @@ class EB_LLVM(CMakeMake):
                 self._prepare_runtimes_rpath_wrappers(self.llvm_obj_dir_stage1)
                 self.add_cmake_opts()
                 trace_msg("Reconfiguring LLVM to use the RPATH wrappers for the runtimes")
-                super(EB_LLVM, self).configure_step(builddir=self.llvm_obj_dir_stage1, srcdir=src_dir)
+                super().configure_step(builddir=self.llvm_obj_dir_stage1, srcdir=src_dir)
             # Pre-create the CFG files in the `build_stage/bin` directory to enforce using the correct dynamic
             # linker in case of sysroot builds, and to ensure the correct GCC installation is used also for the
             # runtimes (which would otherwise use the system default dynamic linker)

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -539,7 +539,7 @@ class EB_LLVM(CMakeMake):
                     if self.nvptx_target_cond:
                         self._cmakeopts['LIBOMPTARGET_FORCE_DLOPEN_LIBCUDA'] = 'ON'
             self._cmakeopts['OPENMP_ENABLE_LIBOMPTARGET'] = 'ON'
-            self._cmakeopts['LIBOMP_INSTALL_ALIASES'] = 'OFF'
+            self._cmakeopts['LIBOMP_INSTALL_ALIASES'] = 'ON'
             if not self.cfg['build_openmp_tools']:
                 self._cmakeopts['OPENMP_ENABLE_OMPT_TOOLS'] = 'OFF'
 

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -795,7 +795,8 @@ class EB_LLVM(CMakeMake):
             setvar('CUDA_NVCC_EXECUTABLE', 'IGNORE')
 
         # 20.1+ uses a generic IR for OpenMP DeviceRTL
-        if self.cfg['build_openmp_offload'] and LooseVersion(self.version) < '20.1':
+        # Using the default ("all") for LLVM < 19 to keep behavior of previous versions of the easyblock
+        if self.cfg['build_openmp_offload'] and '19' <= LooseVersion(self.version) < '20.1':
             gpu_archs = self.cfg.get_cuda_cc_template_value("cuda_sm_space_sep", required=False).split()
             gpu_archs += self.amd_gfx
             if gpu_archs:

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -43,7 +43,7 @@ from easybuild.framework.easyconfig import CUSTOM
 from easybuild.toolchains.compiler.clang import Clang
 from easybuild.tools import LooseVersion
 from easybuild.tools.utilities import trace_msg
-from easybuild.tools.build_log import EasyBuildError, print_msg
+from easybuild.tools.build_log import EasyBuildError, print_msg, print_warning
 from easybuild.tools.config import ERROR, IGNORE, SEARCH_PATH_LIB_DIRS, build_option
 from easybuild.tools.environment import setvar
 from easybuild.tools.filetools import apply_regex_substitutions, change_dir, copy_dir, adjust_permissions
@@ -231,7 +231,7 @@ class EB_LLVM(CMakeMake):
             'test_suite_timeout_total': [None, "Timeout for total running time of the testsuite", CUSTOM],
             'use_pic': [True, "Build with Position Independent Code (PIC)", CUSTOM],
             'usepolly': [None, "DEPRECATED, alias for 'use_polly'", CUSTOM],
-            'use_polly': [False, "Build Clang with polly", CUSTOM],
+            'use_polly': [None, "Build Clang with polly, disabled by default", CUSTOM],
         })
 
         return extra_vars
@@ -242,7 +242,11 @@ class EB_LLVM(CMakeMake):
 
         if self.cfg['usepolly'] is not None:
             self.log.deprecated("Use of easyconfig parameter 'usepolly', replace by 'use_polly'", '6.0')
-            self.cfg['use_polly'] = self.cfg['usepolly']
+            if self.cfg['use_polly'] is None:
+                self.cfg['use_polly'] = self.cfg['usepolly']
+            else:
+                # Do not overwrite value set via the new name
+                print_warning("Both 'usepolly' and 'use_polly' are set, please use only 'use_polly'")
 
         self.llvm_obj_dir_stage1 = None
         self.llvm_obj_dir_stage2 = None

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -1332,6 +1332,8 @@ class EB_LLVM(CMakeMake):
             arch = 'ppc64'
         elif arch == AARCH64:
             arch = 'aarch64'
+        else:
+            print_warning("Unknown CPU architecture (%s) for OpenMP and runtime libraries check!" % arch, log=self.log)
 
         check_files = []
         check_bin_files = []

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -382,10 +382,7 @@ class EB_LLVM(CMakeMake):
 
         self.ignore_patterns = self.cfg['test_suite_ignore_patterns'] or []
 
-        # list of CUDA compute capabilities to use can be specifed in two ways (where (2) overrules (1)):
-        # (1) in the easyconfig file, via the custom cuda_compute_capabilities;
-        # (2) in the EasyBuild configuration, via --cuda-compute-capabilities configuration option;
-        cuda_cc_list = build_option('cuda_compute_capabilities') or self.cfg['cuda_compute_capabilities'] or []
+        cuda_cc_list = self.cfg.get_cuda_cc_template_value("cuda_cc_space_sep", required=False).split()
         cuda_toolchain = hasattr(self.toolchain, 'COMPILER_CUDA_FAMILY')
         amd_gfx_list = self.cfg['amd_gfx_list'] or []
 
@@ -797,9 +794,9 @@ class EB_LLVM(CMakeMake):
         if not get_software_root('CUDA'):
             setvar('CUDA_NVCC_EXECUTABLE', 'IGNORE')
 
-        if self.cfg['build_openmp_offload'] and LooseVersion('19') <= LooseVersion(self.version) < LooseVersion('20'):
-            gpu_archs = []
-            gpu_archs += ['sm_%s' % cc for cc in self.cuda_cc]
+        # 20.1+ uses a generic IR for OpenMP DeviceRTL
+        if self.cfg['build_openmp_offload'] and LooseVersion(self.version) < '20.1':
+            gpu_archs = self.cfg.get_cuda_cc_template_value("cuda_sm_space_sep", required=False).split()
             gpu_archs += self.amd_gfx
             if gpu_archs:
                 self._cmakeopts['LIBOMPTARGET_DEVICE_ARCHITECTURES'] = self.list_to_cmake_arg(gpu_archs)

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -253,10 +253,12 @@ class EB_LLVM(CMakeMake):
         self.llvm_obj_dir_stage3 = None
         self.intermediate_projects = ['llvm', 'clang']
         self.intermediate_runtimes = ['compiler-rt', 'libunwind', 'libcxx', 'libcxxabi']
-        if not self.cfg['minimal']:
-            self.final_projects = ['llvm', 'mlir', 'clang', 'flang']
-        else:
+        if self.cfg['minimal']:
             self.final_projects = ['llvm']
+        else:
+            self.final_projects = ['llvm', 'mlir', 'clang', 'flang']
+            # Bypass the .mod file check for GCCcore installs
+            self.cfg['skip_mod_files_sanity_check'] = True
         self.final_runtimes = []
         self.gcc_prefix = None
         self.runtimes_cmake_args = {


### PR DESCRIPTION
Same as https://github.com/easybuilders/easybuild-easyblocks/pull/3755 but reintroducing the restriction to LLVM < 18 to not set `LIBOMPTARGET_DEVICE_ARCHITECTURES`

This might have been the cause of test failures.