### PR TITLE
Don't install libomp aliases by default in LLVM easyblock

### DIFF
--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -338,7 +338,7 @@ class EB_LLVM(CMakeMake):
                 self.log.debug("Explicitly enabling OpenMP offloading for LLVM >= 19")
                 self.final_runtimes.append('offload')
             else:
-                self.log.warning("OpenMP offloading is included with the OpenMP runtime for LLVM < 19")
+                self.log.debug("OpenMP offloading is included with the OpenMP runtime for LLVM < 19")
 
         if self.cfg['build_openmp_tools'] and not self.cfg['build_openmp']:
             raise EasyBuildError("Building OpenMP tools requires building OpenMP runtime")

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -328,10 +328,22 @@ class EB_LLVM(CMakeMake):
 
         if self.cfg['build_openmp']:
             self.final_projects.append('openmp')
+        else:
+            errors = []
+            # check for all options that depend on OpenMP being enabled
+            if self.cfg['build_openmp_tools']:
+                errors.append("Building OpenMP tools requires building OpenMP runtime")
+
+            if self.cfg['build_openmp_offload']:
+                errors.append("Building OpenMP offload requires building OpenMP runtime")
+
+            if self.cfg['build_openmp_library_aliases']:
+                errors.append("Installing OpenMP library aliases requires building OpenMP runtime")
+
+            if errors:
+                raise EasyBuildError('\n'.join(errors), exit_code=EasyBuildExit.EASYCONFIG_ERROR)
 
         if self.cfg['build_openmp_offload']:
-            if not self.cfg['build_openmp']:
-                raise EasyBuildError("Building OpenMP offload requires building OpenMP runtime")
             # LLVM 19 added a new runtime target for explicit offloading
             # https://discourse.llvm.org/t/llvm-19-1-0-no-library-libomptarget-nvptx-sm-80-bc-found/81343
             if LooseVersion(self.version) >= '19':
@@ -339,9 +351,6 @@ class EB_LLVM(CMakeMake):
                 self.final_runtimes.append('offload')
             else:
                 self.log.debug("OpenMP offloading is included with the OpenMP runtime for LLVM < 19")
-
-        if self.cfg['build_openmp_tools'] and not self.cfg['build_openmp']:
-            raise EasyBuildError("Building OpenMP tools requires building OpenMP runtime")
 
         if self.cfg['use_polly']:
             self.final_projects.append('polly')

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -212,6 +212,7 @@ class EB_LLVM(CMakeMake):
             'build_lld': [False, "Build the LLVM lld linker", CUSTOM],
             'build_lldb': [False, "Build the LLVM lldb debugger", CUSTOM],
             'build_openmp': [True, "Build the LLVM OpenMP runtime", CUSTOM],
+            'build_openmp_library_aliases': [False, "Install symlinks to libomp (e.g. libgomp, libiomp5)", CUSTOM],
             'build_openmp_offload': [True, "Build the LLVM OpenMP offload runtime", CUSTOM],
             'build_openmp_tools': [True, "Build the LLVM OpenMP tools interface", CUSTOM],
             'build_runtimes': [False, "Build the LLVM runtimes (compiler-rt, libunwind, libcxx, libcxxabi)", CUSTOM],
@@ -531,7 +532,7 @@ class EB_LLVM(CMakeMake):
                     if self.nvptx_target_cond:
                         self._cmakeopts['LIBOMPTARGET_FORCE_DLOPEN_LIBCUDA'] = 'ON'
             self._cmakeopts['OPENMP_ENABLE_LIBOMPTARGET'] = 'ON'
-            self._cmakeopts['LIBOMP_INSTALL_ALIASES'] = 'ON'
+            self._cmakeopts['LIBOMP_INSTALL_ALIASES'] = 'ON' if self.cfg['build_openmp_library_aliases'] else 'OFF'
             if not self.cfg['build_openmp_tools']:
                 self._cmakeopts['OPENMP_ENABLE_OMPT_TOOLS'] = 'OFF'
 

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -88,44 +88,44 @@ GCC_DEPENDENCY_OPTS_DEFAULT = {
     # 'CLANG_DEFAULT_LINKER': 'lld',
     'CLANG_DEFAULT_UNWINDLIB': 'libunwind',
 
-    'COMPILER_RT_BUILD_GWP_ASAN': 'Off',
-    'COMPILER_RT_ENABLE_INTERNAL_SYMBOLIZER': 'On',
-    'COMPILER_RT_ENABLE_STATIC_UNWINDER': 'On',  # https://lists.llvm.org/pipermail/llvm-bugs/2016-July/048424.html
-    'COMPILER_RT_USE_BUILTINS_LIBRARY': 'On',
-    'COMPILER_RT_USE_LIBCXX': 'On',
-    'COMPILER_RT_USE_LLVM_UNWINDER': 'On',
+    'COMPILER_RT_BUILD_GWP_ASAN': 'OFF',
+    'COMPILER_RT_ENABLE_INTERNAL_SYMBOLIZER': 'ON',
+    'COMPILER_RT_ENABLE_STATIC_UNWINDER': 'ON',  # https://lists.llvm.org/pipermail/llvm-bugs/2016-July/048424.html
+    'COMPILER_RT_USE_BUILTINS_LIBRARY': 'ON',
+    'COMPILER_RT_USE_LIBCXX': 'ON',
+    'COMPILER_RT_USE_LLVM_UNWINDER': 'ON',
 
     'LIBCXX_CXX_ABI': 'libcxxabi',
     'LIBCXX_DEFAULT_ABI_LIBRARY': 'libcxxabi',
     # Needed as libatomic could not be present on the system (compilation and tests will succeed because of the
     # GCCcore builddep, but usage/sanity check will fail due to missing libatomic)
-    'LIBCXX_HAS_ATOMIC_LIB': 'NO',
-    'LIBCXX_HAS_GCC_S_LIB': 'Off',
-    'LIBCXX_USE_COMPILER_RT': 'On',
+    'LIBCXX_HAS_ATOMIC_LIB': 'OFF',
+    'LIBCXX_HAS_GCC_S_LIB': 'OFF',
+    'LIBCXX_USE_COMPILER_RT': 'ON',
 
-    'LIBCXXABI_HAS_GCC_S_LIB': 'Off',
-    'LIBCXXABI_USE_LLVM_UNWINDER': 'On',
-    'LIBCXXABI_USE_COMPILER_RT': 'On',
+    'LIBCXXABI_HAS_GCC_S_LIB': 'OFF',
+    'LIBCXXABI_USE_LLVM_UNWINDER': 'ON',
+    'LIBCXXABI_USE_COMPILER_RT': 'ON',
 
-    'LIBUNWIND_HAS_GCC_S_LIB': 'Off',
-    'LIBUNWIND_USE_COMPILER_RT': 'On',
+    'LIBUNWIND_HAS_GCC_S_LIB': 'OFF',
+    'LIBUNWIND_USE_COMPILER_RT': 'ON',
 
     # Libxml2 from system gets automatically detected and linked in bringing dependencies from stdc++, gcc_s, icuuc, etc
     # Moved to a check at the configure step. See https://github.com/easybuilders/easybuild-easyconfigs/issues/22491
-    # 'LLVM_ENABLE_LIBXML2': 'Off',
+    # 'LLVM_ENABLE_LIBXML2': 'OFF',
 
-    'SANITIZER_USE_STATIC_LLVM_UNWINDER': 'On',
+    'SANITIZER_USE_STATIC_LLVM_UNWINDER': 'ON',
 }
 
 DISABLE_WERROR_OPTS = {
-    'BENCHMARK_ENABLE_WERROR': 'Off',
-    'COMPILER_RT_ENABLE_WERROR': 'Off',
-    'FLANG_ENABLE_WERROR': 'Off',
-    'LIBC_WNO_ERROR': 'On',
-    'LIBCXX_ENABLE_WERROR': 'Off',
-    'LIBUNWIND_ENABLE_WERROR': 'Off',
-    'LLVM_ENABLE_WERROR': 'Off',
-    'OPENMP_ENABLE_WERROR': 'Off',
+    'BENCHMARK_ENABLE_WERROR': 'OFF',
+    'COMPILER_RT_ENABLE_WERROR': 'OFF',
+    'FLANG_ENABLE_WERROR': 'OFF',
+    'LIBC_WNO_ERROR': 'ON',
+    'LIBCXX_ENABLE_WERROR': 'OFF',
+    'LIBUNWIND_ENABLE_WERROR': 'OFF',
+    'LLVM_ENABLE_WERROR': 'OFF',
+    'OPENMP_ENABLE_WERROR': 'OFF',
 }
 
 GENERAL_OPTS = {
@@ -369,9 +369,9 @@ class EB_LLVM(CMakeMake):
         if self.cfg['build_lldb']:
             self.final_projects.append('lldb')
             if self.full_llvm:
-                self.remove_gcc_dependency_opts['LLDB_ENABLE_LIBXML2'] = 'Off'
-                self.remove_gcc_dependency_opts['LLDB_ENABLE_LZMA'] = 'Off'
-                self.remove_gcc_dependency_opts['LLDB_ENABLE_PYTHON'] = 'Off'
+                self.remove_gcc_dependency_opts['LLDB_ENABLE_LIBXML2'] = 'OFF'
+                self.remove_gcc_dependency_opts['LLDB_ENABLE_LZMA'] = 'OFF'
+                self.remove_gcc_dependency_opts['LLDB_ENABLE_PYTHON'] = 'OFF'
 
         if self.cfg['build_bolt']:
             self.final_projects.append('bolt')


### PR DESCRIPTION
As discussed in
https://github.com/easybuilders/easybuild-framework/issues/4535 it could lead to issues caused by incompatible libraries used by different compilers. Especially GCC and LLVM/Clang picking up the wrong `libomp` vs `libgomp`.

See also https://github.com/easybuilders/easybuild-easyblocks/pull/3755#discussion_r2128296626 & https://github.com/easybuilders/easybuild-easyblocks/pull/3815#issuecomment-3031330638

This restores the behavior changed by https://github.com/easybuilders/easybuild-easyblocks/pull/3815 but adds an option to enable them (off by default). This is useful/required for Clang easyconfigs using this easyblock as otherwise there would be a difference compared to using the Clang easyblock. See https://github.com/easybuilders/easybuild-easyblocks/pull/3755#discussion_r2128296626

I used `build_openmp_library_aliases` as the option name to group it nicely with the other OMP options, although "install" is more correct.

As there now is a new check for an incompatible combination of options dependent on OpenMP I combined them into a single place and error with correct exit code.

I also made the use of OFF/ON in the CMake arguments consistent as I had to look up whether the checks are case sensitive or not. They are not, so the change is only cosmetic but avoids further confusion.

cc @Thyre @Crivella 