### PR TITLE
LLVM: Fix missing `LIBOMPTARGET_DEVICE_ARCHITECTURES` in third stage of bootstrap build

### DIFF
--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -385,7 +385,7 @@ class EB_LLVM(CMakeMake):
         self.log.info("Final projects to build: %s", ', '.join(self.final_projects))
         self.log.info("Final runtimes to build: %s", ', '.join(self.final_runtimes))
 
-        # CMake options passed to each building stage.
+        # CMake options passed to each build stage.
         # Will be cleared between stages. If arguments are needed in multiple stages,
         # consider adding them to general_opts instead.
         self._cmakeopts = {}

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -821,7 +821,7 @@ class EB_LLVM(CMakeMake):
             gpu_archs = self.cfg.get_cuda_cc_template_value("cuda_sm_space_sep", required=False).split()
             gpu_archs += self.amd_gfx
             if gpu_archs:
-                self._cmakeopts['LIBOMPTARGET_DEVICE_ARCHITECTURES'] = self.list_to_cmake_arg(gpu_archs)
+                self.general_opts['LIBOMPTARGET_DEVICE_ARCHITECTURES'] = self.list_to_cmake_arg(gpu_archs)
 
         self._configure_general_build()
         self.add_cmake_opts()

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -291,6 +291,10 @@ class EB_LLVM(CMakeMake):
         if self.cfg['use_pic']:
             on_opts.append('CMAKE_POSITION_INDEPENDENT_CODE')
 
+        # General options being passed to every build stage.
+        # Here, options that will be required in all build stages should be added.
+        # Update _cmakeopts in _configure_{general,intermediate,final}_build if
+        # build option is only relevant for a single build step.
         self.general_opts = GENERAL_OPTS.copy()
 
         for opt in on_opts:
@@ -381,6 +385,9 @@ class EB_LLVM(CMakeMake):
         self.log.info("Final projects to build: %s", ', '.join(self.final_projects))
         self.log.info("Final runtimes to build: %s", ', '.join(self.final_runtimes))
 
+        # CMake options passed to each building stage.
+        # Will be cleared between stages. If arguments are needed in multiple stages,
+        # consider adding them to general_opts instead.
         self._cmakeopts = {}
         self._cfgopts = list(filter(None, self.cfg.get('configopts', '').split()))
 


### PR DESCRIPTION
By using `_cmakeopts`, the argument was only passed for the first stage of the build, and ignored for subsequent stages. We therefore build all available architectures for AMDGPU / NVPTX when not necessary. Fix this by moving the argument to `general_opts`.