### PR TITLE
Explicitely set OMPT options for LLVM

### DIFF
--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -805,11 +805,6 @@ class EB_LLVM(CMakeMake):
         self.general_opts.update(python_opts)
         self.runtimes_cmake_args.update(python_opts)
 
-        if self.cfg['bootstrap']:
-            self._configure_intermediate_build()
-        else:
-            self._configure_final_build()
-
         if self.cfg['skip_sanitizer_tests'] and build_option('strict') != ERROR:
             self.log.info("Disabling the sanitizer tests")
             self.disable_sanitizer_tests()
@@ -855,6 +850,11 @@ class EB_LLVM(CMakeMake):
                 self.general_opts['LIBOMPTARGET_DEVICE_ARCHITECTURES'] = self.list_to_cmake_arg(gpu_archs)
 
         self._configure_general_build()
+        if self.cfg['bootstrap']:
+            self._configure_intermediate_build()
+        else:
+            self._configure_final_build()
+
         self.add_cmake_opts()
 
         src_dir = os.path.join(self.start_dir, 'llvm')

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -874,7 +874,7 @@ class EB_LLVM(CMakeMake):
                 self.log.warning("`LLVM_HOST_TRIPLE` not found in the output of the configure step")
 
         if not self.cfg['bootstrap']:
-            if build_option('rpath') and self._cmakeopts['LLVM_ENABLE_RUNTIMES'] != '""':
+            if build_option('rpath') and self._cmakeopts['LLVM_ENABLE_RUNTIMES'] not in ('""', "''", ''):
                 # Ensure RPATH wrappers are used for the runtimes also at the first stage
                 # Call configure again now that the host triple is known from the previous configure call
                 remove_dir(self.llvm_obj_dir_stage1)

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -1371,7 +1371,7 @@ class EB_LLVM(CMakeMake):
             for suffix in ('.c', '.o', '.x'):
                 remove_file(f'{test_fn}{suffix}')
 
-    def sanity_check_step(self, *args, custom_paths=None, custom_commands=None, **kwargs):
+    def sanity_check_step(self, custom_paths=None, custom_commands=None, *args, **kwargs):
         """Perform sanity checks on the installed LLVM."""
         lib_dir_runtime = None
         if self.cfg['build_runtimes']:

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -575,8 +575,13 @@ class EB_LLVM(CMakeMake):
                         self._cmakeopts['LIBOMPTARGET_FORCE_DLOPEN_LIBCUDA'] = 'ON'
             self._cmakeopts['OPENMP_ENABLE_LIBOMPTARGET'] = 'ON'
             self._cmakeopts['LIBOMP_INSTALL_ALIASES'] = 'ON' if self.cfg['build_openmp_library_aliases'] else 'OFF'
-            if not self.cfg['build_openmp_tools']:
-                self._cmakeopts['OPENMP_ENABLE_OMPT_TOOLS'] = 'OFF'
+            # OpenMP Tools interface
+            ompt_value = 'ON' if self.cfg['build_openmp_tools'] else 'OFF'
+            self._cmakeopts['LIBOMP_OMPT_SUPPORT'] = ompt_value
+            if self.cfg['build_openmp_offload']:
+                self._cmakeopts['LIBOMPTARGET_OMPT_SUPPORT'] = ompt_value
+            # OMPT based tools
+            self._cmakeopts['OPENMP_ENABLE_OMPT_TOOLS'] = ompt_value
 
         # Make sure tests are not running with more than 'parallel' tasks
         parallel = self.cfg.parallel

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -874,7 +874,7 @@ class EB_LLVM(CMakeMake):
                 self.log.warning("`LLVM_HOST_TRIPLE` not found in the output of the configure step")
 
         if not self.cfg['bootstrap']:
-            if build_option('rpath') and self._cmakeopts['LLVM_ENABLE_RUNTIMES'] not in ('""', "''", ''):
+            if build_option('rpath') and self._cmakeopts['LLVM_ENABLE_RUNTIMES'] != self.list_to_cmake_arg([]):
                 # Ensure RPATH wrappers are used for the runtimes also at the first stage
                 # Call configure again now that the host triple is known from the previous configure call
                 remove_dir(self.llvm_obj_dir_stage1)

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -1371,7 +1371,7 @@ class EB_LLVM(CMakeMake):
             for suffix in ('.c', '.o', '.x'):
                 remove_file(f'{test_fn}{suffix}')
 
-    def sanity_check_step(self, custom_paths=None, custom_commands=None, *args, **kwargs):
+    def sanity_check_step(self, *args, custom_paths=None, custom_commands=None, **kwargs):
         """Perform sanity checks on the installed LLVM."""
         lib_dir_runtime = None
         if self.cfg['build_runtimes']:

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -874,7 +874,7 @@ class EB_LLVM(CMakeMake):
                 self.log.warning("`LLVM_HOST_TRIPLE` not found in the output of the configure step")
 
         if not self.cfg['bootstrap']:
-            if build_option('rpath') and self._cmakeopts['LLVM_ENABLE_RUNTIMES'] != self.list_to_cmake_arg([]):
+            if build_option('rpath') and self.final_runtimes:  # Check for final runtimes as we are not bootstrapping
                 # Ensure RPATH wrappers are used for the runtimes also at the first stage
                 # Call configure again now that the host triple is known from the previous configure call
                 remove_dir(self.llvm_obj_dir_stage1)


### PR DESCRIPTION
As discussed [here](https://github.com/easybuilders/easybuild-easyblocks/pull/3799#issuecomment-3035168311) it makes sense to set `LIBOMP_OMPT_SUPPORT` as that will cause a configure error instead of not building the tools interface with only a small configure message

Additionally also set the related `LIBOMPTARGET_OMPT_SUPPORT` option

Note that our definition of `build_openmp_tools` is not that of `OPENMP_ENABLE_OMPT_TOOLS` but rather matches `LIBOMP_OMPT_SUPPORT`, see https://github.com/llvm/llvm-project/blob/adb2421202e4014b4986a9f1eb40833dc7ec25ad/openmp/README.rst#optional-features

> LIBOMP_OMPT_SUPPORT = ON|OFF
    Include support for the OpenMP Tools Interface (OMPT). 
>
> option(OPENMP_ENABLE_OMPT_TOOLS "Enable building ompt based tools for OpenMP."

So we enable more than just the interface, but I don't think we should change that.

Question: Should we also explicitely enable the optional OMPT features?
> LIBOMP_OMPT_OPTIONAL = ON|OFF
    Include support for optional OMPT functionality.

It currently defaults to ON, so we can ignore it.