### PR TITLE
remove use of verbose in build_step 

### DIFF
--- a/easybuild/easyblocks/b/blat.py
+++ b/easybuild/easyblocks/b/blat.py
@@ -42,7 +42,7 @@ class EB_BLAT(MakeCp):
         """Configure build: just create a 'bin' directory."""
         mkdir("bin")
 
-    def build_step(self, verbose=False):
+    def build_step(self):
         """Build BLAT using make and the appropriate options (e.g. BINDIR=)."""
         self.cfg.update('prebuildopts', "MACHTYPE=x86_64")
         bindir = os.path.join(os.getcwd(), "bin")

--- a/easybuild/easyblocks/g/ghc.py
+++ b/easybuild/easyblocks/g/ghc.py
@@ -37,7 +37,7 @@ class EB_GHC(ConfigureMake):
     Support for building and installing applications with configure/make/make install
     """
 
-    def build_step(self, verbose=False):
+    def build_step(self):
         """
         Support for a binary 6.12.x installation. Starting there,
         later GHC versions are build from source and thus require

--- a/easybuild/easyblocks/generic/scons.py
+++ b/easybuild/easyblocks/generic/scons.py
@@ -51,7 +51,7 @@ class SCons(EasyBlock):
         else:
             self.prefix = ''
 
-    def build_step(self, verbose=False):
+    def build_step(self):
         """
         Build with SCons
         """


### PR DESCRIPTION
We give a hard error on our systems when a warning is reported so we are already hitting this deprecation warning for EasyBuidld 6.0.

```
ERROR: Installation of BLAT-3.7-GCC-12.3.0.eb failed: "DEPRECATED (since v6.0) functionality used: The 'verbose' parameter to build_step is deprecated and unneeded.; see https://docs.easybuild.io/deprecated-functionality/ for more information"
```