### PR TITLE
Remove duplicated output of test command from PythonPackage

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -870,7 +870,6 @@ class PythonPackage(ExtensionEasyBlock):
                     res = run_shell_cmd(cmd, fail_on_error=False)
                     # need to retrieve ec by not failing on error
                     (out, ec) = (res.output, res.exit_code)
-                    self.log.info("cmd '%s' exited with exit code %s and output:\n%s", cmd, ec, out)
                 else:
                     run_shell_cmd(cmd)
 


### PR DESCRIPTION
`run_shell_cmd` already outputs the stderr/stdout and exit code even with `fail_on_error=False`
So don't print it again in PythonPackage which might add huge amounts of text to the log for e.g. the PyTorch tests.