### PR TITLE
Use patch when filter ld library path

### DIFF
--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -349,12 +349,13 @@ class EB_Python(ConfigureMake):
                 return ext[1]
         return None
 
-    def patch_step(self, *args, **kwargs):
-        """
-        Custom patch step for Python:
-        * patch setup.py when --sysroot EasyBuild configuration setting is used
-        """
 
+    def fetch_step(self, *args, **kwargs):
+        """
+        Custom fetch step for Python: add patches from patches_filter_ld_library_path to 'patches' if
+        EasyBuild is configured to filter LD_LIBRARY_PATH (and is configured not to filter LIBRARY_PATH).
+        This needs to be done in (or before) the fetch step to ensure that those patches are also fetched.
+        """
         # If EasyBuild is configured to filter LD_LIBRARY_PATH (but not LIBRARY_PATH)
         # add any patches listed in `patches_filter_ld_library_path` to the list of patches
         # Also, add the checksums_filter_ld_library_path to the checksums list in that case.
@@ -382,6 +383,15 @@ class EB_Python(ConfigureMake):
                 msg = f"The length of patches_filter_ld_library_path (%s) "
                 msg += f"is not equal to the length of checksums_filter_ld_library_path(%s)."
                 raise EasyBuildError(msg, len(additional_patches), len(additional_checksums))
+
+        super().fetch_step(*args, **kwargs)
+
+
+    def patch_step(self, *args, **kwargs):
+        """
+        Custom patch step for Python:
+        * patch setup.py when --sysroot EasyBuild configuration setting is used
+        """
 
         super().patch_step(*args, **kwargs)
 

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -365,7 +365,6 @@ class EB_Python(ConfigureMake):
         if 'LD_LIBRARY_PATH' in filtered_env_vars and 'LIBRARY_PATH' not in filtered_env_vars:
             ctypes_util_py = os.path.join("Lib", "ctypes", "util.py")
             orig_gcc_so_name = None
-            
             # Let's do this incrementally since we are going back in time
             # if LooseVersion(self.version) >= "3.9.1":
             #    # From 3.9.1 to at least v3.12.4 there is only one match for this line

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -50,7 +50,7 @@ from easybuild.tools.build_log import EasyBuildError, print_warning
 from easybuild.tools.config import build_option, ERROR, EBPYTHONPREFIXES
 from easybuild.tools.modules import get_software_libdir, get_software_root, get_software_version
 from easybuild.tools.filetools import apply_regex_substitutions, change_dir, mkdir
-from easybuild.tools.filetools import read_file, remove_dir, symlink, write_file, open_file
+from easybuild.tools.filetools import read_file, remove_dir, symlink, write_file
 from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
 from easybuild.tools.utilities import trace_msg

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -365,11 +365,12 @@ class EB_Python(ConfigureMake):
         if 'LD_LIBRARY_PATH' in filtered_env_vars and 'LIBRARY_PATH' not in filtered_env_vars:
             ctypes_util_py = os.path.join("Lib", "ctypes", "util.py")
             orig_gcc_so_name = None
+            
             # Let's do this incrementally since we are going back in time
-            #if LooseVersion(self.version) >= "3.9.1":
+            # if LooseVersion(self.version) >= "3.9.1":
             #    # From 3.9.1 to at least v3.12.4 there is only one match for this line
             #    orig_gcc_so_name = "_get_soname(_findLib_gcc(name)) or _get_soname(_findLib_ld(name))"
-            #if orig_gcc_so_name:
+            # if orig_gcc_so_name:
             #    orig_gcc_so_name_regex = r'(\s*)' + re.escape(orig_gcc_so_name) + r'(\s*)'
             #    # _get_soname() takes the full path as an argument and uses objdump to get the SONAME field from
             #    # the shared object file. The presence or absence of the SONAME field in the ELF header of a shared

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -50,7 +50,7 @@ from easybuild.tools.build_log import EasyBuildError, print_warning
 from easybuild.tools.config import build_option, ERROR, EBPYTHONPREFIXES
 from easybuild.tools.modules import get_software_libdir, get_software_root, get_software_version
 from easybuild.tools.filetools import apply_regex_substitutions, change_dir, mkdir
-from easybuild.tools.filetools import read_file, remove_dir, symlink, write_file
+from easybuild.tools.filetools import read_file, remove_dir, symlink, write_file, open_file
 from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
 from easybuild.tools.utilities import trace_msg
@@ -366,24 +366,23 @@ class EB_Python(ConfigureMake):
             ctypes_util_py = os.path.join("Lib", "ctypes", "util.py")
             orig_gcc_so_name = None
             # Let's do this incrementally since we are going back in time
-            if LooseVersion(self.version) >= "3.9.1":
-                # From 3.9.1 to at least v3.12.4 there is only one match for this line
-                orig_gcc_so_name = "_get_soname(_findLib_gcc(name)) or _get_soname(_findLib_ld(name))"
-            if orig_gcc_so_name:
-                orig_gcc_so_name_regex = r'(\s*)' + re.escape(orig_gcc_so_name) + r'(\s*)'
-                # _get_soname() takes the full path as an argument and uses objdump to get the SONAME field from
-                # the shared object file. The presence or absence of the SONAME field in the ELF header of a shared
-                # library is influenced by how the library is compiled and linked. For manually built libraries we
-                # may be lacking this field, this approach also solves that problem.
-                updated_gcc_so_name = (
-                    "_findLib_gcc(name) or _findLib_ld(name)"
-                )
-                apply_regex_substitutions(
-                    ctypes_util_py,
-                    [(orig_gcc_so_name_regex, r'\1' + updated_gcc_so_name + r'\2')],
-                    on_missing_match=ERROR
-                )
-
+            #if LooseVersion(self.version) >= "3.9.1":
+            #    # From 3.9.1 to at least v3.12.4 there is only one match for this line
+            #    orig_gcc_so_name = "_get_soname(_findLib_gcc(name)) or _get_soname(_findLib_ld(name))"
+            #if orig_gcc_so_name:
+            #    orig_gcc_so_name_regex = r'(\s*)' + re.escape(orig_gcc_so_name) + r'(\s*)'
+            #    # _get_soname() takes the full path as an argument and uses objdump to get the SONAME field from
+            #    # the shared object file. The presence or absence of the SONAME field in the ELF header of a shared
+            #    # library is influenced by how the library is compiled and linked. For manually built libraries we
+            #    # may be lacking this field, this approach also solves that problem.
+            #    updated_gcc_so_name = (
+            #        "_findLib_gcc(name) or _findLib_ld(name)"
+            #    )
+            #    apply_regex_substitutions(
+            #        ctypes_util_py,
+            #        [(orig_gcc_so_name_regex, r'\1' + updated_gcc_so_name + r'\2')],
+            #        on_missing_match=ERROR
+            #    )
         # if we're installing Python with an alternate sysroot,
         # we need to patch setup.py which includes hardcoded paths like /usr/include and /lib64;
         # this fixes problems like not being able to build the _ssl module ("Could not build the ssl module")

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -303,9 +303,9 @@ class EB_Python(ConfigureMake):
             'use_lto': [None, "Build with Link Time Optimization (>= v3.7.0, potentially unstable on some toolchains). "
                         "If None: auto-detect based on toolchain compiler (version)", CUSTOM],
             'patches_filter_ld_library_path': [[], "Patches to apply when EasyBuild is configured to filter "
-                                               "LD_LIBRARY_PATH.", CUSTOM]
+                                               "LD_LIBRARY_PATH.", CUSTOM],
             'checksums_filter_ld_library_path': [[], "Checksums to use for validating the patches listed in "
-                                                 "patches_filter_ld_library_path.", CUSTOM]
+                                                 "patches_filter_ld_library_path.", CUSTOM],
         }
         return ConfigureMake.extra_options(extra_vars)
 

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -373,8 +373,11 @@ class EB_Python(ConfigureMake):
                 msg += "The following patches will be applied to make sure ctypes.CDLL, ctypes.cdll.LoadLibrary "
                 msg += f"and ctypes.util.find_library will still work correctly: {additional_patches}."
                 self.log.info(msg)
-                self.cfg['patches'].extend(additional_patches)
-                self.cfg['checksums'].extend(additional_checksums)
+                self.log.info(f"Original list of patches: {self.cfg['patches']}")
+                self.log.info(f"List of patches to be added: {additional_patches}")
+                self.cfg.update('patches', additional_patches)
+                self.cfg.update('checksums', additional_checksums)
+                self.log.info(f"Updated list of patches: {self.cfg['patches']}")
             else:
                 msg = f"The length of patches_filter_ld_library_path (%s) "
                 msg += f"is not equal to the length of checksums_filter_ld_library_path(%s)."


### PR DESCRIPTION
This change introduces extra easyblock-specific configuration items. They allow us to define patches that should be applied conditionally if EasyBuild is configured to filter `LD_LIBRARY_PATH`. Since these patches (see Should be used together with: https://github.com/easybuilders/easybuild-easyconfigs/pull/23499) are quite fundamental (change `ctypes` functions) we prefer them to only be applied in the scenario where they are really needed.

Replaces: https://github.com/easybuilders/easybuild-easyblocks/pull/3798
Should be used together with: https://github.com/easybuilders/easybuild-easyconfigs/pull/23499