### PR TITLE
Increase the default for the maximum number of failed PyTorch tests to 10

### DIFF
--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -262,7 +262,7 @@ class EB_PyTorch(PythonPackage):
             'custom_opts': [[], "List of options for the build/install command. Can be used to change the defaults " +
                                 "set by the PyTorch EasyBlock, for example ['USE_MKLDNN=0'].", CUSTOM],
             'excluded_tests': [{}, "Mapping of architecture strings to list of tests to be excluded", CUSTOM],
-            'max_failed_tests': [0, "Maximum number of failing tests", CUSTOM],
+            'max_failed_tests': [10, "Maximum number of failing tests", CUSTOM],
         })
 
         # disable use of pip to install PyTorch by default, overwriting the default set in PythonPackage;


### PR DESCRIPTION
EasyConfig PR: https://github.com/easybuilders/easybuild-easyconfigs/pull/23577