### PR TITLE
Avoid writes to $HOME from Triton during PyTorch tests by setting `$TRITON_HOME`

### DIFF
--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -546,7 +546,7 @@ class EB_PyTorch(PythonPackage):
         env.setvar('XDG_CACHE_HOME', cache_dir)
         # Triton also uses a path defaulting to $HOME
         # Isolate against user-set variables
-        env.unset_env_vars(var for var in os.environ if var.startswith('TRITON_'))
+        env.unset_env_vars(('TRITON_DUMP_DIR', 'TRITON_OVERRIDE_DIR', 'TRITON_CACHE_DIR'))
         triton_home = os.path.join(self.tmpdir, '.triton_home')
         env.setvar('TRITON_HOME', triton_home)
 


### PR DESCRIPTION
I found some paths used by Triton defaulting to $HOME: https://github.com/triton-lang/triton/blob/f33bcbd4f1051d0d9ea3fdfc0b2e68f53ededfe4/python/triton/knobs.py#L338-L349

As all paths are relative to `$TRITON_HOME` if not set otherwise it is safe to just unset them and set TRITON_HOME