### PR TITLE
update sanity check in custom easyblock for MUMPS to support v5.8.0 and higher

### DIFF
--- a/easybuild/easyblocks/m/mumps.py
+++ b/easybuild/easyblocks/m/mumps.py
@@ -161,9 +161,13 @@ class EB_MUMPS(ConfigureMake):
 
     def sanity_check_step(self):
         """Custom sanity check for MUMPS."""
+        list_of_headers = ["mumps_c", "mumps_struc"]
+        if LooseVersion(self.version) < LooseVersion('5.8.0'):
+            list_of_headers.append("mumps_root")
+
         custom_paths = {
             'files': [os.path.join("include", "%s%s.h" % (x, y)) for x in ["c", "d", "s", "z"]
-                      for y in ["mumps_c", "mumps_root", "mumps_struc"]] +
+                      for y in list_of_headers] +
             [os.path.join("include", "mumps_compat.h"), os.path.join("include", "mumps_c_types.h")] +
             [os.path.join("lib", "lib%smumps.a" % x) for x in ["c", "d", "s", "z"]] +
             [os.path.join("lib", "libmumps_common.a"), os.path.join("lib", "libpord.a")],


### PR DESCRIPTION
In MUMPS v5.8.0, the `*_root.h` files are removed.