### PR TITLE
Allow oversubscription for FFTW tests, also for OpenMPI-5.X onwards

### DIFF
--- a/easybuild/easyblocks/f/fftw.py
+++ b/easybuild/easyblocks/f/fftw.py
@@ -241,9 +241,12 @@ class EB_FFTW(ConfigureMake):
             # allow oversubscription of number of processes over number of available cores with OpenMPI 3.0 & newer,
             # to avoid that some tests fail if only a handful of cores are available
             ompi_ver = get_software_version('OpenMPI')
-            if LooseVersion(ompi_ver) >= LooseVersion('3.0'):
+            if LooseVersion(ompi_ver) >= LooseVersion('3.0') and LooseVersion(ompi_ver) < LooseVersion('5.0'):
                 if 'OMPI_MCA_rmaps_base_oversubscribe' not in self.cfg['pretestopts']:
                     self.cfg.update('pretestopts', "export OMPI_MCA_rmaps_base_oversubscribe=true && ")
+            if LooseVersion(ompi_ver) >= LooseVersion('5.0'):
+                if 'PRTE_MCA_rmaps_default_mapping_policy' not in self.cfg['pretestopts']:
+                    self.cfg.update('pretestopts', "export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe && ")
 
         super().test_step()
 


### PR DESCRIPTION
`OMPI_MCA_rmaps_base_oversubscribe=true` was converted to `PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe`, as per OpenMPI 5.X. See https://docs.open-mpi.org/en/main/mca.html#converting-mapping-parameters 

I've hit failing test steps for `FFTW.MPI` in an interactive allocation created with `salloc -n 1 -c 16 ...`. This fixes it.