### PR TITLE
Remove osmesa part of the sanity check, since osmesa is removed from mesa 25.1 onwards

### DIFF
--- a/easybuild/easyblocks/m/mesa.py
+++ b/easybuild/easyblocks/m/mesa.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2024 Ghent University
+# Copyright 2009-2025 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
@@ -43,9 +43,9 @@ class EB_Mesa(MesonNinja):
     """Custom easyblock for building and installing Mesa."""
 
     def __init__(self, *args, **kwargs):
-        """Constructor for custom Mesa easyblock: figure out which values to pass to swr-arches configuration option."""
+        """Constructor for custom Mesa easyblock: figure out some config options."""
 
-        super(EB_Mesa, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.gallium_configopts = []
 
@@ -65,12 +65,18 @@ class EB_Mesa(MesonNinja):
         if not gallium_drivers:
             # Add appropriate Gallium drivers for current architecture
             arch = get_cpu_architecture()
+            if LooseVersion(self.version) >= LooseVersion('25'):
+                default_renderer = 'llvmpipe'
+            else:
+                default_renderer = 'swrast'
+
             arch_gallium_drivers = {
-                X86_64: ['swrast'],
-                POWER: ['swrast'],
-                AARCH64: ['swrast'],
-                RISCV64: ['swrast'],
+                X86_64: [default_renderer],
+                POWER: [default_renderer],
+                AARCH64: [default_renderer],
+                RISCV64: [default_renderer],
             }
+
             if LooseVersion(self.version) < LooseVersion('22'):
                 # swr driver support removed in Mesa 22.0
                 arch_gallium_drivers[X86_64].append('swr')
@@ -133,12 +139,12 @@ class EB_Mesa(MesonNinja):
         if self.gallium_configopts:
             self.cfg.update('configopts', self.gallium_configopts)
 
-        return super(EB_Mesa, self).configure_step()
+        return super().configure_step()
 
     def install_step(self):
         """Also copy additional header files after installing Mesa."""
 
-        super(EB_Mesa, self).install_step()
+        super().install_step()
 
         # also install header files located in include/GL/internal, unless they're available already;
         # we can't enable both DRI and Gallium drivers,
@@ -160,8 +166,9 @@ class EB_Mesa(MesonNinja):
                 header_files.extend([os.path.join('include', 'EGL', 'eglext_angle.h')])
             else:
                 header_files.extend([os.path.join('include', 'EGL', 'eglextchromium.h')])
+            if LooseVersion(self.version) < LooseVersion('25.1'):
+                header_files.extend([os.path.join('include', 'GL', 'osmesa.h')])
             header_files.extend([
-                os.path.join('include', 'GL', 'osmesa.h'),
                 os.path.join('include', 'GL', 'internal', 'dri_interface.h'),
             ])
         else:
@@ -170,8 +177,13 @@ class EB_Mesa(MesonNinja):
             header_files = [os.path.join('include', 'GL', x) for x in gl_inc_files]
             header_files.extend([os.path.join('include', x, y) for (x, y) in gles_inc_files])
 
+        if LooseVersion(self.version) >= LooseVersion('25.1'):
+            file_list = header_files
+        else:
+            file_list = [os.path.join('lib', 'libOSMesa.%s' % shlib_ext)] + header_files
+
         custom_paths = {
-            'files': [os.path.join('lib', 'libOSMesa.%s' % shlib_ext)] + header_files,
+            'files': file_list,
             'dirs': [os.path.join('include', 'GL', 'internal')],
         }
 
@@ -179,12 +191,12 @@ class EB_Mesa(MesonNinja):
             swr_arch_libs = [os.path.join('lib', 'libswr%s.%s' % (a.upper(), shlib_ext)) for a in self.swr_arches]
             custom_paths['files'].extend(swr_arch_libs)
 
-        super(EB_Mesa, self).sanity_check_step(custom_paths=custom_paths)
+        super().sanity_check_step(custom_paths=custom_paths)
 
     def make_module_extra(self, *args, **kwargs):
         """ Append to EGL vendor library path,
         so that any NVidia libraries take precedence. """
-        txt = super(EB_Mesa, self).make_module_extra(*args, **kwargs)
+        txt = super().make_module_extra(*args, **kwargs)
         # Append rather than prepend path to ensure that system NVidia drivers have priority.
         txt += self.module_generator.append_paths('__EGL_VENDOR_LIBRARY_DIRS', 'share/glvnd/egl_vendor.d')
         return txt


### PR DESCRIPTION
Untested for now, but as stated in https://github.com/easybuilders/easybuild-easyconfigs/pull/23144#issuecomment-3213676715 we should adapt the sanity check for Mesa 25.1 onwards, since that's when `osmesa` got removed (see https://docs.mesa3d.org/relnotes/25.1.0.html and https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/33836 ).

Tested to work with Mesa 25.1.3 from https://github.com/easybuilders/easybuild-easyconfigs/pull/23144 . Now also testing with older versions to confirm it didn't break anything.