### PR TITLE
Changes to LLVM easyblock required for LLVM 21

### DIFF
--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -1619,7 +1619,7 @@ class EB_LLVM(CMakeMake):
         shlib_ext = '.' + get_shared_lib_ext()
 
         if not hasattr(self, 'nvptx_target_cond'):
-            # Need to perform the target configuration if not done already eg whe running in `--module-only`
+            # Need to perform the target configuration if not done already e.g. when running in `--module-only`
             # or `--sanity-check-only` modes
             self._configure_build_targets()
 


### PR DESCRIPTION
## Changes

- Filter unsupported `flang` args from `FFLAGS` and `F90FLAGS` as now flang is used to compile some `.mod` files
  Fixes error of the type `flang-21: error: unknown argument: '-fno-math-errno'` during the build step
- Added EC config parameter `test_suite_include_benchmarks` to allow including/excluding benchmarks in the test-suite
- Ensure `LLVM_INCLUDE_BENCHMARKS` is set both for the projects and runtimes builds
