### PR TITLE
Accept arguments for sanity_check_step in HPL easyblock

### DIFF
--- a/easybuild/easyblocks/h/hpl.py
+++ b/easybuild/easyblocks/h/hpl.py
@@ -119,14 +119,15 @@ class EB_HPL(ConfigureMake):
             srcfile = os.path.join(srcdir, filename)
             copy_file(srcfile, destdir)
 
-    def sanity_check_step(self):
+    def sanity_check_step(self, **kwargs):
         """
         Custom sanity check for HPL
         """
 
-        custom_paths = {
+        # Allow subclasses to set own custom paths
+        kwargs.setdefault('custom_paths', {
             'files': ["bin/xhpl"],
             'dirs': []
-        }
+        })
 
-        super().sanity_check_step(custom_paths)
+        super().sanity_check_step(**kwargs)


### PR DESCRIPTION
Only accept kwargs though such that custom_paths cannot be passed twice (via positional args)

Fixes #3889

cc @Micket 