### PR TITLE
Make HPL easyblock intel-aware + allow running the `xhpl` benchmark as a test

### DIFF
--- a/easybuild/easyblocks/h/hpl.py
+++ b/easybuild/easyblocks/h/hpl.py
@@ -37,7 +37,6 @@ import re
 import os
 
 import easybuild.tools.toolchain as toolchain
-from easybuild.framework.easyconfig import CUSTOM
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option


### PR DESCRIPTION
Potential fix for 

- https://github.com/easybuilders/easybuild-easyconfigs/issues/19322

I think we could also not run the benchmark as a a test instead of pinning everything to 1 core (if we do not wanna deal with pinning with every different type of MPI)