### PR TITLE
Test oversubscription implemented in framework with HPL easyblock

### DIFF
--- a/easybuild/easyblocks/h/hpl.py
+++ b/easybuild/easyblocks/h/hpl.py
@@ -134,8 +134,8 @@ class EB_HPL(ConfigureMake):
 
         parallel = self.cfg.parallel
         if not build_option('mpi_tests'):
-            self.log.info("MPI tests disabled from buildoption. Setting parallel to 1")
-            parallel = 1
+            self.log.warning("MPI tests disabled from buildoption. Skipping tests")
+            return
 
         oversubscribe = parallel < req_cpus
 


### PR DESCRIPTION
Companion PR to 

- https://github.com/easybuilders/easybuild-framework/pull/4995

Used to test changes.

## Notes

Manually tested by modifying the value of `req_cpus` or setting `--disable-mpi-tests` seems to trigger the correct oversubscription flags being inserted (more reports to come)