### PR TITLE
don't use `get_ref` to obtain `cmds_map` value with resolved templated in `CmdCp` easyblock

### DIFF
--- a/easybuild/easyblocks/generic/cmdcp.py
+++ b/easybuild/easyblocks/generic/cmdcp.py
@@ -67,9 +67,7 @@ class CmdCp(MakeCp):
             # determine command to use
             # find (first) regex match, then complete matching command template
             cmd = None
-            for pattern, regex_cmd in self.cfg.get_ref('cmds_map'):
-                pattern = pattern % self.cfg.template_values
-                regex_cmd = regex_cmd % self.cfg.template_values
+            for pattern, regex_cmd in self.cfg['cmds_map']:
                 try:
                     regex = re.compile(pattern)
                 except re.error as err:
@@ -80,6 +78,6 @@ class CmdCp(MakeCp):
                     break
             if cmd is None:
                 raise EasyBuildError("No match for %s in %s, don't know which command to use.",
-                                     src, self.cfg.get_ref('cmds_map'))
+                                     src, self.cfg['cmds_map'])
 
             run_shell_cmd(cmd)


### PR DESCRIPTION
This reverts commit 742964579fa7588bf235e86731d6592fb6d867d8, from #3918

```
            for pattern, regex_cmd in self.cfg.get_ref('cmds_map'):
                pattern = pattern % self.cfg.template_values
                regex_cmd = regex_cmd % self.cfg.template_values
```
Is equivalent to `for pattern, regex_cmd in self.cfg['cmds_map']:` because the index-access resolves the template and does so recursively.
Hence we can keep the simpler code.
