### PR TITLE
fix `FATAL ERROR` regex to not match `printf` lines in OpenBLAS easyblock

### DIFF
--- a/easybuild/easyblocks/o/openblas.py
+++ b/easybuild/easyblocks/o/openblas.py
@@ -227,7 +227,7 @@ class EB_OpenBLAS(ConfigureMake):
             res = run_shell_cmd(cmd)
 
             # Raise an error if any test failed
-            regex = re.compile("FATAL ERROR", re.M)
+            regex = re.compile("^((?!printf).)*FATAL ERROR", re.M)
             errors = regex.findall(res.output)
             if errors:
                 raise EasyBuildError("Found %d fatal errors in test output!", len(errors))


### PR DESCRIPTION
Hopefully fix https://github.com/easybuilders/easybuild-easyconfigs/issues/23854

We do not want to match the `FATAL ERROR` in:
```c
printf(" ******* FATAL ERROR - PARAMETER NUMBER %2d WAS CHANGED INCORRECTLY *******\n",i__);
```