### PR TITLE
remove deprecated license classifier in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",
         "Intended Audience :: System Administrators",
-        "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
see also https://github.com/easybuilders/easybuild/pull/922