### PR TITLE
enhance LAMMPS easyblock to make it possible to overide `kokkos_arch` for GENERIC ARM target

### DIFF
--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -276,7 +276,16 @@ class EB_LAMMPS(CMakeMake):
             # For other architectures we set a custom/non-existent type, which will disable all optimizations,
             # and it should use the compiler (optimization) flags set by EasyBuild for this architecture.
             if get_cpu_architecture() == AARCH64:
-                processor_arch = 'ARMV80'
+                if kokkos_arch:
+                    # If someone is trying a manual override for this case, let them
+                    if kokkos_arch not in KOKKOS_CPU_ARCH_LIST:
+                        warning_msg = "Specified CPU ARCH (%s) " % kokkos_arch
+                        warning_msg += "was not found in listed options [%s]." % KOKKOS_CPU_ARCH_LIST
+                        warning_msg += "Still might work though."
+                        print_warning(warning_msg)
+                    processor_arch = kokkos_arch
+                else:
+                    processor_arch = 'ARMV80'
             else:
                 processor_arch = 'EASYBUILD_GENERIC'
 


### PR DESCRIPTION
Some context for this change: [there is a problem with CUDA<13.1 for Arm architectures which try to leverage NEON instructions](https://github.com/kokkos/kokkos/issues/7483). The workaround in https://github.com/EESSI/software-layer-scripts/pull/87 is to override the architecture detection so these are not included. This change allows you to do that even for the generic case.