### PR TITLE
LLVM: Run dynamic linker check only if `clang` is being built

### DIFF
--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -1487,7 +1487,7 @@ class EB_LLVM(CMakeMake):
 
     def _sanity_check_dynamic_linker(self):
         """Check if the dynamic linker is correct."""
-        if self.sysroot:
+        if self.sysroot and 'clang' in self.final_projects:
             # compile & test trivial C program to verify that works
             test_fn = 'test123'
             test_txt = '#include <stdio.h>\n'


### PR DESCRIPTION
The EB attempts to run the `clang` sanity check on `sysroot` builds even if `clang` is not being build (form `-minimal` builds).
Thanks @bedroge for reporting this.

## Fixes

- Compilation test for the dynamic-linker is ran only in case `clang` is being built
- Minor fix to allow properly working with `--sanity-check-only` and `--module-only`