### PR TITLE
Fix for preserving headers and pc files from 64bit installations of OpenBLAS

### DIFF
--- a/easybuild/easyblocks/o/openblas.py
+++ b/easybuild/easyblocks/o/openblas.py
@@ -33,6 +33,7 @@ DESCRIPTIONS = {
     FLAG_SYMSUFFIX64_ITER: "OpenBLAS build with 64-bit integer support and suffixed symbols",
 }
 
+
 class EB_OpenBLAS(ConfigureMake):
     """Support for building/installing OpenBLAS."""
 
@@ -129,7 +130,6 @@ class EB_OpenBLAS(ConfigureMake):
             # reset to original build/test/install options
             for key in self.orig_opts.keys():
                 self.cfg[key] = self.orig_opts[key]
-
 
         if '%s=' % TARGET in self.cfg['buildopts']:
             # Add any TARGET in buildopts to default_opts, so it is passed to testopts and installopts


### PR DESCRIPTION
Addresses issue described in

- #3872

Creates an `openblas[SUFFIX]` subdir for include files and then symlinks all the headers with a `filename[SUFFIX].h` variant.
Also preserve the PC files for `pkgconfig` for all installations so that

`pkg-config --libs openblas[SUFFIX]` works for all variants that we create

## NOTE

I tried to preserve the current behavior of the EB, but i find it weird.
Right now for a 64bit enabled installation (the default) we actually run 3 build:

- the normal non 64bit one producing a `libopenblas.so`
- A 64 bit version with the same symbol names as the normal one `libopenblas64.so`
- A 64 bit version with suffixed symbols and headers `libopenblas64_.so`

I am not a BLAS expert but if the 64bit non suffixed version can act as a drop-in replacement for the non 64bit variant i am not sure why the suffixes are needed.
On the other hand if the 64bit cannot be used as a replacement for the 32 than we want the suffixed version but not sure what is the use of the non-suffixed 64bit one.

Is this to allow to use both libraries at once in the same program (doing both 32 and 64 bit calls)?

### cmake files

Currently we only get a `lib/cmake/OpenBLASConfig.cmake` file valid for the last build, and unless people start to implement a `find_package(openblas[SUFFIX]) in their cmake files i do not see a way to improve this.

The only think that comes to mind would be to write a custom `OpenBLASConfig.cmake` exposing the different variants as components, but also that would become a behavior unique to EB.
This is probably something that should be done upstream

## TODO

- Do we want to symlink all headers or only `cblas.h` (the only one that i think changes)
  - Right now i did all of them, but I realize that would also require patching the suffixed versions to have the suffix in the internal `include "XXX.h"` statements for it actually work as intended