### PR TITLE
enhance LLVM easyblock to allow control over `$LLVM_PARALLEL_LINK_JOBS`

### DIFF
--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -224,6 +224,7 @@ class EB_LLVM(CMakeMake):
             'enable_rtti': [True, "Enable RTTI", CUSTOM],
             'full_llvm': [False, "Build LLVM without any dependency", CUSTOM],
             'minimal': [False, "Build LLVM only", CUSTOM],
+            'max_link_jobs': [2, "Maximum number of link jobs, defaults to 2", CUSTOM],
             'python_bindings': [False, "Install python bindings", CUSTOM],
             'skip_all_tests': [False, "Skip running of tests", CUSTOM],
             'skip_sanitizer_tests': [True, "Do not run the sanitizer tests", CUSTOM],
@@ -314,6 +315,8 @@ class EB_LLVM(CMakeMake):
             self.general_opts[opt] = 'OFF'
 
         self.full_llvm = self.cfg['full_llvm']
+
+        self.general_opts.update({"LLVM_PARALLEL_LINK_JOBS": self.cfg['max_link_jobs']})
 
         if self.cfg['minimal']:
             conflicts = [_ for _ in self.minimal_conflicts if self.cfg[_]]

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -31,6 +31,7 @@ EasyBuild support for building and installing LLVM, implemented as an easyblock
 @author: Simon Branford (University of Birmingham)
 @author: Kenneth Hoste (Ghent University)
 @author: Davide Grassano (CECAM HQ - Lausanne)
+@author: Prateek Chawla (Juelich Supercomputing Centre)
 """
 import contextlib
 import glob


### PR DESCRIPTION
Parallel builds of LLVM crash on low-memory machines. This fix adds an option for `max_link_jobs` (default value = 2) to prevent OOM kills. 

Source: [LLVM Docs](https://llvm.org/docs/CMake.html)

Fixes #3970.