### PR TITLE
enhance GROMACS easyblock to improve control over PLUMED support (native vs. patching)

### DIFF
--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -385,7 +385,7 @@ class EB_GROMACS(CMakeMake):
                             self.cfg.update('configopts', "-DPython3_FIND_VIRTUALENV=STANDARD")
 
             # Now patch GROMACS for PLUMED before cmake
-            if plumed_root:
+            if plumed_root and plumed_patches:
                 if gromacs_version >= '5.1':
                     # Use shared or static patch depending on
                     # setting of self.cfg['build_shared_libs']

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -229,14 +229,20 @@ class EB_GROMACS(CMakeMake):
         elif plumed_root and self.cfg['plumed'] is False:
             self.log.info('PLUMED was found, but compilation without PLUMED has been requested.')
             plumed_root = None
-        elif plumed_root and gromacs_version >= '2025' and self.cfg['plumed'] == 'patch':
+        elif plumed_root and self.cfg['plumed'] == 'patch':
             self.log.info('PLUMED was found, and PLUMED patching has been requested.')
+            print('PLUMED was found, and PLUMED patching has been requested.')
             plumed_patches = True
-        elif plumed_root and gromacs_version >= '2025' and self.cfg['plumed'] is True:
-            self.log.info('PLUMED was found, and PLUMED support has been requested.')
-        elif plumed_root and gromacs_version < '2025' and self.cfg['plumed'] is True:
-            self.log.info('PLUMED was found, and PLUMED support has been requested.')
-            plumed_patches = True
+        elif plumed_root and self.cfg['plumed'] is True:
+            msg = 'PLUMED was found, and PLUMED support has been requested.'
+            if gromacs_version >= '2025':
+                msg += ' Will use native PLUMED support.'
+                plumed_patches = False
+            else:
+                msg += ' Will apply PLUMED patches.'
+                plumed_patches = True
+            self.log.info(msg)
+            print(msg)
 
         if plumed_root:
             self.log.info('PLUMED support has been enabled.')
@@ -269,7 +275,7 @@ class EB_GROMACS(CMakeMake):
         if (gromacs_version >= '2020' and
                 '-DGMX_VERSION_STRING_OF_FORK=' not in self.cfg['configopts']):
             gromacs_version_string_suffix = 'EasyBuild-%s' % EASYBUILD_VERSION
-            if plumed_root and plumed_patches:
+            if plumed_patches:
                 gromacs_version_string_suffix += '-PLUMED-%s' % get_software_version('PLUMED')
             self.cfg.update('configopts', '-DGMX_VERSION_STRING_OF_FORK=%s' % gromacs_version_string_suffix)
 

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -220,7 +220,7 @@ class EB_GROMACS(CMakeMake):
         # enable PLUMED support if PLUMED is listed as a dependency.
         # plumed = 'native' will enable GROMACS' native PLUMED support ('-DGMX_USE_PLUMED=ON')
         # for GROMACS 2025 and newer. plumed = 'patch' specifically requests PLUMED patches.
-        # In auto-detect ('plumed = None' or not defined) will prefer native support for 2025
+        # In auto-detect ('plumed = None' or not defined) will prefer native support for 2026
         # and newer. Older versions of GROMACS patches are applied to enable PLUMED support.
         # plumed = True behaves like plumed = 'patch' for backwards compatibility.
         plumed_root = get_software_root('PLUMED')
@@ -250,7 +250,9 @@ class EB_GROMACS(CMakeMake):
             self.log.info(msg)
         elif plumed_root and self.cfg['plumed'] is None:
             msg = 'PLUMED was found.'
-            if gromacs_version >= '2025':
+            if gromacs_version >= '2026':
+                # Even though native support is available since GROMACS 2025, we'll only use
+                # it as default with 2026 and newer to avoid a sudden change in behaviour.
                 msg += ' Will use native PLUMED support.'
                 plumed_patches = False
             else:

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -231,7 +231,6 @@ class EB_GROMACS(CMakeMake):
             plumed_root = None
         elif plumed_root and self.cfg['plumed'] == 'patch':
             self.log.info('PLUMED was found, and PLUMED patching has been requested.')
-            print('PLUMED was found, and PLUMED patching has been requested.')
             plumed_patches = True
         elif plumed_root and self.cfg['plumed'] is True:
             msg = 'PLUMED was found, and PLUMED support has been requested.'
@@ -242,7 +241,6 @@ class EB_GROMACS(CMakeMake):
                 msg += ' Will apply PLUMED patches.'
                 plumed_patches = True
             self.log.info(msg)
-            print(msg)
 
         if plumed_root:
             self.log.info('PLUMED support has been enabled.')

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -221,7 +221,7 @@ class EB_GROMACS(CMakeMake):
         # plumed = 'native' will enable GROMACS' native PLUMED support ('-DGMX_USE_PLUMED=ON')
         # for GROMACS 2025 and newer. plumed = 'patch' specifically requests PLUMED patches.
         # In auto-detect ('plumed = None' or not defined) will prefer native support for 2026
-        # and newer. Older versions of GROMACS patches are applied to enable PLUMED support.
+        # and newer. For older versions of GROMACS, patches are applied to enable PLUMED support.
         # plumed = True behaves like plumed = 'patch' for backwards compatibility.
         plumed_root = get_software_root('PLUMED')
         plumed_patches = False


### PR DESCRIPTION
Since [GROMACS 2025][1] one can compile GROMACS with a PLUMED interface without patching it by setting CMake option [`-DGMX_USE_PLUMED=ON`][2]. 
Applying [PLUMED patches to GROMACS 2025][3] is still possible in order to get the latest PLUMED functionality.

This PR adds a fourth option `'patch'` to the extra-option `plumed`.

* `plumed = None` (default) auto detects whether PLUMED is available and do the same as `plumed = True`
* ~`plumed = True` sets `-DGMX_USE_PLUMED=ON` for GROMACS >= 2025 or try to patch GROMACS with PLUMED's patches for older (<=2024.x) versions (depends whether the loaded version has patches for that version of GROMACS~
* `plumed = 'patch'` will try to patch GROMACS with PLUMED's patches regardless of the GROMACS version
* `plumed = False` will disable PLUMED functionality, even if it is found (neither apply patches nor set `-DGMX_USE_PLUMED=OFF` for GROMACS >=2025

`<edit>`_improved logic is [here](https://github.com/easybuilders/easybuild-easyblocks/pull/3984#issuecomment-3553835074)_`</edit>`

I think that's the best of both worlds. It behaves like before for older GROMACS releases (before 2025) and takes the minimal-invasive route (avoiding to patch) when set to `None` ~or `True`~.

[1]: https://manual.gromacs.org/2025.2/release-notes/2025/major/features.html#a-feature-limited-version-of-the-plumed-interface-is-available
[2]: https://manual.gromacs.org/2025.2/install-guide/index.html#building-with-plumed-support
[3]: https://www.plumed.org/doc-v2.10/user-doc/html/gromacs-2025-0.html