### PR TITLE
Implement merging `Cargo.toml` file with workspace file

### DIFF
--- a/test/easyblocks/easyblock_specific.py
+++ b/test/easyblocks/easyblock_specific.py
@@ -351,7 +351,7 @@ class EasyBlockSpecificTest(TestCase):
             ]
             empty=''''''
         """))
-        parsed = cargo.parse_toml(cargo_toml)
+        parsed = cargo._parse_toml(cargo_toml)
         self.assertEqual(parsed, {
             'package': {
                 'name': "'my_crate\\'",
@@ -365,7 +365,7 @@ class EasyBlockSpecificTest(TestCase):
                 'empty': "''''''",
             }
         })
-        has_package, members = cargo.get_workspace_members(parsed)
+        has_package, members = cargo._get_workspace_members(parsed)
         self.assertTrue(has_package)
         self.assertIsNone(members)
 
@@ -378,13 +378,13 @@ class EasyBlockSpecificTest(TestCase):
                 "reqwest-retry",
             ]
         """))
-        parsed = cargo.parse_toml(cargo_toml)
+        parsed = cargo._parse_toml(cargo_toml)
         self.assertEqual(parsed, {
             'workspace': {
                 'members': '[\n"reqwest-middleware",\n"reqwest-tracing",\n"reqwest-retry",\n]',
             }
         })
-        has_package, members = cargo.get_workspace_members(parsed)
+        has_package, members = cargo._get_workspace_members(parsed)
         self.assertFalse(has_package)
         self.assertEqual(members, ["reqwest-middleware", "reqwest-tracing", "reqwest-retry"])
 
@@ -402,7 +402,7 @@ class EasyBlockSpecificTest(TestCase):
             [dependencies]
             leptos = { version = "0.6", features = ["csr"] }
         """))
-        parsed = cargo.parse_toml(cargo_toml)
+        parsed = cargo._parse_toml(cargo_toml)
         self.assertEqual(parsed, {
             'package': {
                 "name": '"nothing-linux-ui"',
@@ -417,7 +417,7 @@ class EasyBlockSpecificTest(TestCase):
                 "leptos": '{ version = "0.6", features = ["csr"] }',
             },
         })
-        has_package, members = cargo.get_workspace_members(parsed)
+        has_package, members = cargo._get_workspace_members(parsed)
         self.assertTrue(has_package)
         self.assertEqual(members, ["nothing", "src-tauri"])
 
@@ -440,7 +440,7 @@ class EasyBlockSpecificTest(TestCase):
             cc = "1.0.73"
             rand = "0.8.5"
         """))
-        ws_parsed = cargo.parse_toml(cargo_toml)
+        ws_parsed = cargo._parse_toml(cargo_toml)
         write_file(cargo_toml, textwrap.dedent("""
             [package]
             name = "bar"
@@ -461,7 +461,7 @@ class EasyBlockSpecificTest(TestCase):
             [dev-dependencies]
             rand = { workspace = true }
         """))
-        cargo.merge_sub_crate(cargo_toml, ws_parsed)
+        cargo._merge_sub_crate(cargo_toml, ws_parsed)
         self.assertEqual(read_file(cargo_toml).strip(), textwrap.dedent("""
             [package]
             name = "bar"
@@ -491,7 +491,7 @@ class EasyBlockSpecificTest(TestCase):
             [dependencies]
             regex = { workspace = true }
         """))
-        cargo.merge_sub_crate(cargo_toml, ws_parsed)
+        cargo._merge_sub_crate(cargo_toml, ws_parsed)
         self.assertEqual(read_file(cargo_toml).strip(), textwrap.dedent("""
             [package]
             name = "bar"


### PR DESCRIPTION
Resolve backreferences like `authors.workspace = true`

https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table
For ruff-0.14.3 the [salsa](https://github.com/salsa-rs/salsa) crate is using the[ `[workspace.package]` section](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table) where one can define values that can be inherited by members

So the members `Cargo.toml` file contains e.g.
```toml
[package]
name = "bar"
version.workspace = true
authors.workspace = true
description.workspace = true
documentation.workspace = true
[dependencies]
            leptos = { version = "0.6", features = ["csr"] }
```

For the offline builds we need to copy the members to standalone packages which has the side-effect that no "workspace" exists anymore causing `cargo` to fail with

>       error: failed to get `anyhow` as a dependency of package `ruff v0.14.3 (/dev/shm/ruff/0.14.3/GCCcore-14.3.0/ruff-0.14.3/crates/ruff)`
>       Caused by:
>         failed to load source for dependency `anyhow`
>       Caused by:
>         Unable to update registry `crates-io`
>       Caused by:
>         failed to update replaced source registry `crates-io`
>       Caused by:
>         failed to parse manifest at `/dev/shm/ruff/0.14.3/GCCcore-14.3.0/easybuild_vendor/salsa-macros/Cargo.toml`
>       Caused by:
>         error inheriting `edition` from workspace root manifest's `workspace.package.edition`
>       Caused by:
>         failed to find a workspace root


Checking `cargo vendor` output: It replaces `version.workspace = true` by `version = "1.2.3"`

Hence we need to parse both TOML files, "merge" them to replace those references and write the result to the member `Cargo.toml`

For that I enhanced the minimal TOML parser I implemented for the `"members"` key to create a `dict[str, dict[str, str]]` with sections as outer keys, keys as inner keys mapping the 1:1 copy of the value. I.e. I don't parse the value at all besides trying to find the end: TOML values support lists, strings (single & double quotes), multiline strings (triple quotes), bools, numbers

The above example results in Python:
```python
{
            'package': {
                "name": '"bar"',
                "version.workspace": 'true',
                "authors.workspace": 'true',
                "description.workspace": 'true',
                "documentation.workspace": 'true',
            },
            'dependencies': {
                "leptos": '{ version = "0.6", features = ["csr"] }',
            },
}
```


This works because we only need to copy the value 1:1 to the member file but doesn't support everything:
```
[workspace.dependencies]
cc = "1.0.73"
rand = "0.8.5"
regex = { version = "1.6.0", default-features = false, features = ["std"] }
```
Member:
```
[dependencies]
regex = { workspace = true, features = ["unicode"] }
```

would require merging the mappings, i.e. `dict.update()` in Python instead of a simple replacement.

But for that we likely need a proper TOML parser:
- Python 3.11 has [`tomllib`](https://docs.python.org/3/library/tomllib.html)
- There is a 2020 `toml` package on [PYPI](https://pypi.org/project/toml/)
- A recent `tomli` package on [PYPI](https://pypi.org/project/tomli/)
- PIP 21.2+ [vendors](https://github.com/pypa/pip/commit/e68ac94595aa3af9c8981479ce305fdb4143c8b6) `tomli` so we could `import pip._vendor.tomli`

So my idea would be to try importing `tomllib`, `tomli`, `import pip._vendor.tomli`, `toml` in this order if the previous ones failed and error out if none are available

Or we stick with the minimal parser and extend if only necessary: [YAGNI](https://en.wikipedia.org/wiki/You_aren%27t_gonna_need_it)