### PR TITLE
Improve Mathematica easyblock to support license server configuration and version-specific executable names

### DIFF
--- a/easybuild/easyblocks/m/mathematica.py
+++ b/easybuild/easyblocks/m/mathematica.py
@@ -82,7 +82,7 @@ class EB_Mathematica(Binary):
         if LooseVersion(self.version) >= LooseVersion("13"):
             install_script_glob = '%s_%s_*LINUX*.sh' % (self.name, self.version)
         if LooseVersion(self.version) >= LooseVersion("14.1"):
-            install_script_glob = 'Wolfram_%s_LIN.sh' % (self.version)
+            install_script_glob = 'Wolfram_%s_BNDL_LIN.sh' % (self.version)
 
         matches = glob.glob(install_script_glob)
         if len(matches) == 1:
@@ -173,7 +173,7 @@ class EB_Mathematica(Binary):
 
         # Use appropriate executable for version check
         if LooseVersion(self.version) >= LooseVersion("14"):
-            version_cmd = 'wolframbn --version'
+            version_cmd = 'wolframnb --version'
         else:
             version_cmd = 'mathematica --version'
         custom_commands = [version_cmd]

--- a/easybuild/easyblocks/m/mathematica.py
+++ b/easybuild/easyblocks/m/mathematica.py
@@ -173,7 +173,7 @@ class EB_Mathematica(Binary):
 
         # Use appropriate executable for version check
         if LooseVersion(self.version) >= LooseVersion("14"):
-            version_cmd = 'wolfram --version'
+            version_cmd = 'wolframbn --version'
         else:
             version_cmd = 'mathematica --version'
         custom_commands = [version_cmd]

--- a/easybuild/easyblocks/m/mathematica.py
+++ b/easybuild/easyblocks/m/mathematica.py
@@ -81,7 +81,7 @@ class EB_Mathematica(Binary):
 
         if not os.path.exists(install_script):
             raise EasyBuildError("Install script not found: %s", install_script)
-        
+
         cmd = self.cfg['preinstallopts'] + './' + install_script
         shortver = '.'.join(self.version.split('.')[:2])
         # Starting at V14, the product is called "Wolfram" instead of "Mathematica"

--- a/easybuild/easyblocks/m/mathematica.py
+++ b/easybuild/easyblocks/m/mathematica.py
@@ -29,7 +29,6 @@ EasyBuild support for building and installing Mathematica, implemented as an eas
 """
 
 from easybuild.tools import LooseVersion
-import glob
 import os
 
 from easybuild.easyblocks.generic.binary import Binary
@@ -77,44 +76,38 @@ class EB_Mathematica(Binary):
         # make sure $DISPLAY is not set (to avoid that installer uses GUI)
         orig_display = os.environ.pop('DISPLAY', None)
 
-        install_script_glob = '%s_%s_LINUX*.sh' % (self.name, self.version)
-        # Starting at V13, Mathematica have renamed their install file...
-        if LooseVersion(self.version) >= LooseVersion("13"):
-            install_script_glob = '%s_%s_*LINUX*.sh' % (self.name, self.version)
-        if LooseVersion(self.version) >= LooseVersion("14.1"):
-            install_script_glob = 'Wolfram_%s_BNDL_LIN.sh' % (self.version)
+        # Use install script from easyconfig sources
+        install_script = self.cfg.get("install_script") or self.src[0]['name']
 
-        matches = glob.glob(install_script_glob)
-        if len(matches) == 1:
-            install_script = matches[0]
-            cmd = self.cfg['preinstallopts'] + './' + install_script
-            shortver = '.'.join(self.version.split('.')[:2])
-            # Starting at V14, the product is called "Wolfram" instead of "Mathematica"
-            if LooseVersion(self.version) >= LooseVersion("14"):
-                product_name = "Wolfram"
-            else:
-                product_name = self.name
-            qa_install_path = os.path.join('/usr', 'local', 'Wolfram', product_name, shortver)
-            qa = [
-                (r"Enter the installation directory, or press ENTER to select[\s\n]*%s:[\s\n]*>" % qa_install_path,
-                 self.installdir),
-                (r"Create directory \(y/n\)\?[\s\n]*>", 'y'),
-                (r"Should the installer attempt to make this change \(y/n\)\?[\s\n]*>", 'n'),
-                (r"or press ENTER to select[\s\n]*/usr/local/bin:[\s\n]*>", os.path.join(self.installdir, "bin")),
-            ]
-            no_qa = [
-                r"Now installing.*\n\n.*\[.*\].*",
-                r"NOTE: Because you are not logged in with root privileges.*",
-                r".*rpm -Uvh.*wolframscript.*",
-                r".*Extracting installer.*",
-                r".*\|\d+%",
-                r".*Documentation.*Installer.*",
-                r"You are not logged in with root privilege.*",
-                r"The selected directory.*contains files.*",
-            ]
-            run_shell_cmd(cmd, qa_patterns=qa, qa_wait_patterns=no_qa, qa_timeout=200)
+        if not os.path.exists(install_script):
+            raise EasyBuildError("Install script not found: %s", install_script)
+        
+        cmd = self.cfg['preinstallopts'] + './' + install_script
+        shortver = '.'.join(self.version.split('.')[:2])
+        # Starting at V14, the product is called "Wolfram" instead of "Mathematica"
+        if LooseVersion(self.version) >= LooseVersion("14"):
+            product_name = "Wolfram"
         else:
-            raise EasyBuildError("Failed to isolate install script using '%s': %s", install_script_glob, matches)
+            product_name = self.name
+        qa_install_path = os.path.join('/usr', 'local', 'Wolfram', product_name, shortver)
+        qa = [
+            (r"Enter the installation directory, or press ENTER to select[\s\n]*%s:[\s\n]*>" % qa_install_path,
+             self.installdir),
+            (r"Create directory \(y/n\)\?[\s\n]*>", 'y'),
+            (r"Should the installer attempt to make this change \(y/n\)\?[\s\n]*>", 'n'),
+            (r"or press ENTER to select[\s\n]*/usr/local/bin:[\s\n]*>", os.path.join(self.installdir, "bin")),
+        ]
+        no_qa = [
+            r"Now installing.*\n\n.*\[.*\].*",
+            r"NOTE: Because you are not logged in with root privileges.*",
+            r".*rpm -Uvh.*wolframscript.*",
+            r".*Extracting installer.*",
+            r".*\|\d+%",
+            r".*Documentation.*Installer.*",
+            r"You are not logged in with root privilege.*",
+            r"The selected directory.*contains files.*",
+        ]
+        run_shell_cmd(cmd, qa_patterns=qa, qa_wait_patterns=no_qa, qa_timeout=200)
 
         # add license server configuration file
         # some relevant documentation at http://reference.wolfram.com/mathematica/tutorial/ConfigurationFiles.html


### PR DESCRIPTION
...figuration and version-specific executable names

The executable names have changed for Mathematica 14. I asked Claude Sonnet 4.5 to modify the script using the installer output below. I also added an option to specify the licence file via the environment variable `EB_MATHEMATICA_LICENSE_SERVER`.

It's 100% AI, but it works and looks OK to me. Feel free to make changes.

```
----------------------------------------------------------------------------------------------------------------------------
                                                  Wolfram 14.2 Installer 
----------------------------------------------------------------------------------------------------------------------------

Copyright (c) 1988-2025 Wolfram Research, Inc. All rights reserved.

WARNING: Wolfram is protected by copyright law and international treaties. Unauthorized reproduction or distribution
may result in severe civil and criminal penalties and will be prosecuted to the maximum extent possible under law.

Enter the installation directory, or press ENTER to select /usr/local/Wolfram/Wolfram/14.2:
> /tmp/ma/14

Create directory (y/n)?
> y

Now installing...

[*************************************************************************************************************************]

Type the directory path in which the Wolfram script(s) will be created, or press ENTER to select /usr/local/bin:
> /tmp/ma/14/bin

Create directory (y/n)?
> y


WolframScript allows Wolfram Language code to be run from the command line and from self-executing script files. It is
always available from /tmp/ma/14/Executables/wolframscript. WolframScript system integration makes the wolframscript binary
accessible from any terminal, and allows .wls script files to be executed by double-clicking them in the file manager.

NOTE: Because you are not logged in with root privileges, you cannot install the optional WolframScript system
integration at this time.  To do this after installation, run

    rpm -Uvh "/tmp/ma/14/SystemFiles/Installation/wolframscript-1.13-20250307871.x86_64.rpm"

as root.

		 Extracting installer ...

**************************************************|100%

--------------------------------------------------------------------------------
          Wolfram Language 14.2 English Documentation 14.2 Installer 
--------------------------------------------------------------------------------

Copyright (c) 1988-2024 Wolfram Research, Inc. All rights reserved.

WARNING: Wolfram Language 14.2 English Documentation is protected by copyright
law and international treaties. Unauthorized reproduction or distribution
may result in severe civil and criminal penalties and will be prosecuted to
the maximum extent possible under law.

You are not logged in with root privilege. Only the current user of this
computer will be able to use this software.

Y


The selected directory, /home/.../.Wolfram/Documentation/14.2/en-us,
contains files and/or directories that may be overwritten during
installation. If you have any files you wish to keep in this directory,
you should exit the installer and move the files to a separate directory
before continuing.

Now installing...

[*****************************************************************************]
```