### PR TITLE
Switch to setuptools and `find_packages`

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -89,10 +89,8 @@ jobs:
         pip --version
         pip install --upgrade pip
         pip --version
-        if ! python -c "import distutils" 2> /dev/null; then
-          # we need setuptools for distutils in Python 3.12+, needed for python setup.py sdist
-          pip install --upgrade setuptools
-        fi
+        pip install setuptools
+
     - name: install EasyBuild framework
       run: |
           # first determine which branch of easybuild-framework repo to install

--- a/setup.py
+++ b/setup.py
@@ -34,16 +34,18 @@ or
 
 import os
 import sys
-from distutils import log
-from distutils.core import setup
+import logging
+from setuptools import setup, find_packages
 
 sys.path.append('easybuild')
 from easyblocks import VERSION  # noqa
 
 FRAMEWORK_MAJVER = VERSION.split('.')[0]
 
-# log levels: 0=WARN (default), 1=INFO, 2=DEBUG
-log.set_verbosity(1)
+log = logging.getLogger("EasyBuild")
+
+# log levels: NOTSET (default), DEBUG, INFO, WARNING, ERROR, CRITICAL
+log.setLevel(logging.INFO)
 
 
 # Utility function to read README file
@@ -63,8 +65,7 @@ setup(
     license="GPLv2",
     keywords="software build building installation installing compilation HPC scientific",
     url="https://easybuild.io",
-    packages=["easybuild", "easybuild.easyblocks", "easybuild.easyblocks.generic"],
-    package_dir={"easybuild.easyblocks": "easybuild/easyblocks"},
+    packages=find_packages(),
     package_data={'easybuild.easyblocks': ["[a-z0-9]/*.py"]},
     long_description=read("README.rst"),
     classifiers=[


### PR DESCRIPTION
Any reasonably modern Python distribution includes setuptools. So the workaround, that was useful for Python 2.x, is no longer necessary and can be removed.
This allows using `find_packages` instead of maintaining an explicit list of packages which is error-prone.

As `distutils` is removed in Python 3.12 this allows EasyBuild to work with that

see https://github.com/easybuilders/easybuild-framework/pull/5065 & https://github.com/easybuilders/easybuild-easyconfigs/pull/24747