### PR TITLE
enhance LLVM easyblock to fix tests not finding GCCcore libraries

### DIFF
--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -1089,15 +1089,14 @@ class EB_LLVM(CMakeMake):
             # prefix = self.sysroot.rstrip('/')
             # opts.append(f'--dyld-prefix={prefix}')
 
-        # Check, for a non `full_llvm` build, if GCCcore is in the LIBRARY_PATH, and if not add it;
+        # For a non `full_llvm` build, always add GCCcore with a -L in the config file
+        # This is needed even if GCCcore is in the LIBRARY_PATH as some tests will filter it out;
         # This is needed as the runtimes tests will not add the -L option to the linker command line for GCCcore
         # otherwise
         if not self.full_llvm:
             gcc_lib = self._get_gcc_libpath(strict=True)
-            lib_path = os.getenv('LIBRARY_PATH', '')
-            if gcc_lib not in lib_path:
-                self.log.info("Adding GCCcore libraries location `%s` the config files", gcc_lib)
-                opts.append(f'-L{gcc_lib}')
+            self.log.info("Adding GCCcore libraries location `%s` the config files", gcc_lib)
+            opts.append(f'-L{gcc_lib}')
 
         for comp in self.cfg_compilers:
             write_file(os.path.join(bin_dir, f'{comp}.cfg'), ' '.join(opts))


### PR DESCRIPTION
Always add the `-L` pointing to the GCCcore libraries location in the compiler config files for non-`full-llvm` installations

SEE https://github.com/EESSI/software-layer-scripts/pull/115#issuecomment-3450666867 for more details

Not 100% sure but i guess we did not hit this on the bot's newer LLVM builds as some system `-lstdc++` and `-lgcc_s` where being used for those tests that exclude `LIBRARY_PATH` from their environment

Since this is only adding redundancy, as we specify the location of the GCC libraries both through `LIBRARY_PATH` (since https://github.com/easybuilders/easybuild-easyblocks/commit/adf3b83e28a9fe4d8eb9be9bbc3ce6dac96e4787) and the `-L` in the compiler config file) this should not cause any trouble