### PR TITLE
enhance OpenBabel easyblock to re-create install dir (which may already exist) in prepare step

### DIFF
--- a/easybuild/easyblocks/o/openbabel.py
+++ b/easybuild/easyblocks/o/openbabel.py
@@ -54,6 +54,12 @@ class EB_OpenBabel(CMakeMake):
         super().__init__(*args, **kwargs)
         self.with_python = False
 
+    def prepare_step(self, *args, **kwargs):
+        """Prepare step, modified to ensure install dir is deleted before building"""
+        super().prepare_step(*args, **kwargs)
+        # Needs to delete the install dir to avoid segfaults when doing the pybind tests
+        self.make_installdir()
+
     def configure_step(self):
         """Custom configure procedure for OpenBabel."""
 


### PR DESCRIPTION
OpenBabel `test_step` will fail in a rebuild scenario due to memory errors (vary from double-free to null pointers) when testing the python bindings

See more in 

-  easybuilders/easybuild-easyconfigs/pull/24174
