### PR TITLE
Fix `MesonNinja` easyblock to avoid `ninja` using all CPUs when only 1 is requested

### DIFF
--- a/easybuild/easyblocks/generic/mesonninja.py
+++ b/easybuild/easyblocks/generic/mesonninja.py
@@ -136,7 +136,7 @@ class MesonNinja(EasyBlock):
         """
         build_cmd = self.cfg.get('build_cmd', DEFAULT_BUILD_CMD)
 
-        parallel = f'-j {self.cfg.parallel}'
+        parallel = f'-j {self.cfg.parallel}' if self.cfg.parallel >= 1 else ''
 
         cmd = "%(prebuildopts)s %(build_cmd)s -v %(parallel)s %(buildopts)s" % {
             'buildopts': self.cfg['buildopts'],


### PR DESCRIPTION
Running `ninja` with no `-j` option will result in it using all available CPUs, which is the opposite of what one would want when running with `max_parallel = 1`