### PR TITLE
disable FlexiBLAS backends that are in the list of filtered dependencies

### DIFF
--- a/easybuild/easyblocks/f/flexiblas.py
+++ b/easybuild/easyblocks/f/flexiblas.py
@@ -75,7 +75,8 @@ class EB_FlexiBLAS(CMakeMake):
             # make sure that all listed backends except imkl are (build)dependencies
             if 'imkl' in self.blas_libs and 'imkl' not in dep_names:
                 self.blas_libs.remove('imkl')
-            backends_filtered = [x for x in self.blas_libs if x in build_option('filter_deps') or []]
+            filtered_deps = build_option('filter_deps') or []
+            backends_filtered = [x for x in self.blas_libs if x in filtered_deps]
             if backends_filtered:
                 warning_msg = "The following backends are also included in the list of filtered dependencies, "
                 warning_msg += "so they will be disabled anyway: " + ", ".join(backends_filtered)


### PR DESCRIPTION
This allows you to disable for instance the NVPL or AOCL-BLAS backend by adding them to the filtered dependencies. Without the change, it would lead to an error:
```
ERROR: Failed to get application instance for FlexiBLAS (easyblock: Bundle): One or more backends not listed as (build)dependencies: NVPL
```
because it's still added to the list of backends here: https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/f/FlexiBLAS/FlexiBLAS-3.4.5-GCC-14.3.0.eb#L36.