### PR TITLE
Remove`--force` option from generic `Conda` easyblock, was removed in Conda 24.3

### DIFF
--- a/easybuild/easyblocks/generic/conda.py
+++ b/easybuild/easyblocks/generic/conda.py
@@ -96,9 +96,9 @@ class Conda(Binary):
             else:
                 env_spec = self.cfg['remote_environment']
 
-            # use --force to ignore existing installation directory
+            # use "-y" to skip the prompt
             cmd = f"{self.cfg['preinstallopts']} {conda_cmd} env create "
-            cmd += f"--force {env_spec} -p {self.installdir}"
+            cmd += f"-y {env_spec} -p {self.installdir}"
             run_shell_cmd(cmd)
 
         else:


### PR DESCRIPTION
As for newer conda versions it's deprecated and all creations of new environments fail, see: https://github.com/conda/conda/issues/13704

Changed for "-y" to avoid the question prompt creating the environment. 

