### PR TITLE
Ensure AmberTools will find the correct python library and include dir

### DIFF
--- a/easybuild/easyblocks/a/amber.py
+++ b/easybuild/easyblocks/a/amber.py
@@ -356,7 +356,10 @@ class EB_Amber(CMakeMake):
                 testdir = self.builddir
                 testname_cs = 'test.cuda_serial'
                 testname_cp = 'test.cuda_parallel'
-            pretestcommands = 'source %s/amber.sh && cd %s' % (self.installdir, testdir)
+            pretestcommands = ' && '.join([
+                'export OMP_NUM_THREADS=1',  # avoid having as many threads as cores
+                'source %s/amber.sh && cd %s' % (self.installdir, testdir)
+            ])
 
             # serial tests
             if LooseVersion(self.version) >= LooseVersion('24'):


### PR DESCRIPTION
Addresses failure of building `AmberTools` on EESSI

- https://github.com/EESSI/software-layer/pull/1332

AmberTools uses `find_package(PythonLibs)` which has been deprecated (require different hints than the one we currently set for python in CMake).

With this changes we provide the dedicated hints for it to find the correct library and include directory.