### PR TITLE
enhance `PythonPackage` and `PythonBundle` to verify Python package names and versions with `pip list` with `sanity_check_pip_list` parameter

### DIFF
--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -229,7 +229,7 @@ class PythonBundle(Bundle):
             self.log.deprecated(msg, '6.0')
 
         if sanity_pip_check:
-            run_pip_check(python_cmd=self.python_cmd, unversioned_packages=all_unversioned_packages)
+            run_pip_check(python_cmd=self.python_cmd)
             pkgs = [(x.name, x.version) for x in py_exts]
             run_pip_list(pkgs, python_cmd=self.python_cmd, unversioned_packages=all_unversioned_packages)
 

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -29,7 +29,6 @@ EasyBuild support for installing a bundle of Python packages, implemented as a g
 """
 import os
 
-
 from easybuild.easyblocks.generic.bundle import Bundle
 from easybuild.easyblocks.generic.pythonpackage import EXTS_FILTER_PYTHON_PACKAGES, find_python_cmd_from_ec
 from easybuild.easyblocks.generic.pythonpackage import get_pylibdirs, PythonPackage, run_pip_check, run_pip_list
@@ -231,14 +230,15 @@ class PythonBundle(Bundle):
         for param in mismatched_params:
             msg = (f"For bundles of PythonPackage extensions the {param} parameter "
                    "must be set at the top level, outside of exts_list")
-            if param == 'sanity_pip_list':
-                raise EasyBuildError(msg)
-            else:
+            if param == 'sanity_pip_check':
                 self.log.deprecated(msg, '6.0')
+            else:
+                # no deprecation warning needed for sanity_pip_list
+                raise EasyBuildError(msg)
 
         if sanity_pip_check:
             run_pip_check(python_cmd=self.python_cmd, unversioned_packages=all_unversioned_packages)
 
         if sanity_pip_list:
-            eb_pkgs = [(x.name, x.version) for x in py_exts]
-            run_pip_list(eb_pkgs, python_cmd=self.python_cmd)
+            pkgs = [(x.name, x.version) for x in py_exts]
+            run_pip_list(pkgs, python_cmd=self.python_cmd)

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -215,9 +215,10 @@ class PythonBundle(Bundle):
         for ext in py_exts:
             if ext.cfg['sanity_pip_check'] != sanity_pip_check:
                 mismatched_params.add('sanity_pip_check')
-                sanity_pip_check = True  # Either the main set it or any extension enabled it
-
             all_unversioned_packages.update(ext.cfg['unversioned_packages'])
+
+        if 'sanity_pip_check' in mismatched_params:
+            sanity_pip_check = True  # Either the main set it or any extension enabled it
 
         if all_unversioned_packages != unversioned_packages:
             mismatched_params.add('unversioned_packages')

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -29,9 +29,11 @@ EasyBuild support for installing a bundle of Python packages, implemented as a g
 """
 import os
 
+
 from easybuild.easyblocks.generic.bundle import Bundle
-from easybuild.easyblocks.generic.pythonpackage import EXTS_FILTER_PYTHON_PACKAGES, run_pip_check, set_py_env_vars
-from easybuild.easyblocks.generic.pythonpackage import PythonPackage, get_pylibdirs, find_python_cmd_from_ec
+from easybuild.easyblocks.generic.pythonpackage import EXTS_FILTER_PYTHON_PACKAGES, find_python_cmd_from_ec
+from easybuild.easyblocks.generic.pythonpackage import get_pylibdirs, PythonPackage, run_pip_check, run_pip_list
+from easybuild.easyblocks.generic.pythonpackage import set_py_env_vars
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option, PYTHONPATH, EBPYTHONPREFIXES
 from easybuild.tools.modules import get_software_root
@@ -201,26 +203,42 @@ class PythonBundle(Bundle):
         super()._sanity_check_step_extensions()
 
         sanity_pip_check = self.cfg['sanity_pip_check']
+        sanity_pip_list = self.cfg['sanity_pip_list']
         unversioned_packages = set(self.cfg['unversioned_packages'])
 
         # The options should be set in the main EC and cannot be different between extensions.
         # For backwards compatibility and to avoid surprises enable the pip-check if it is enabled
         # in the main EC or any extension and build the union of all unversioned_packages.
-        has_sanity_pip_check_mismatch = False
         all_unversioned_packages = unversioned_packages.copy()
-        for ext in self.ext_instances:
-            if isinstance(ext, PythonPackage):
-                if ext.cfg['sanity_pip_check'] != sanity_pip_check:
-                    has_sanity_pip_check_mismatch = True
-                all_unversioned_packages.update(ext.cfg['unversioned_packages'])
+        py_exts = [x for x in self.ext_instances if isinstance(x, PythonPackage)]
 
-        if has_sanity_pip_check_mismatch:
-            self.log.deprecated("For bundles of PythonPackage extensions the sanity_pip_check parameter "
-                                "must be set at the top level, outside of exts_list", '6.0')
-            sanity_pip_check = True  # Either the main set it or any extension enabled it
+        checks = {
+            'sanity_pip_check': sanity_pip_check,
+            'sanity_pip_list': sanity_pip_list,
+        }
+        mismatched_params = set()
+
+        for ext in py_exts:
+            for param, value in checks.items():
+                if ext.cfg[param] != value:
+                    mismatched_params.add(param)
+
+            all_unversioned_packages.update(ext.cfg['unversioned_packages'])
+
         if all_unversioned_packages != unversioned_packages:
-            self.log.deprecated("For bundles of PythonPackage extensions the unversioned_packages parameter "
-                                "must be set at the top level, outside of exts_list", '6.0')
+            mismatched_params.add('unversioned_packages')
+
+        for param in mismatched_params:
+            msg = (f"For bundles of PythonPackage extensions the {param} parameter "
+                   "must be set at the top level, outside of exts_list")
+            if param == 'sanity_pip_list':
+                raise EasyBuildError(msg)
+            else:
+                self.log.deprecated(msg, '6.0')
 
         if sanity_pip_check:
             run_pip_check(python_cmd=self.python_cmd, unversioned_packages=all_unversioned_packages)
+
+        if sanity_pip_list:
+            eb_pkgs = [(x.name, x.version) for x in py_exts]
+            run_pip_list(eb_pkgs, python_cmd=self.python_cmd)

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -202,6 +202,7 @@ class PythonBundle(Bundle):
         super()._sanity_check_step_extensions()
 
         sanity_pip_check = self.cfg['sanity_pip_check']
+        sanity_check_pip_list = self.cfg['sanity_check_pip_list']
         unversioned_packages = set(self.cfg['unversioned_packages'])
 
         # The options should be set in the main EC and cannot be different between extensions.
@@ -212,25 +213,34 @@ class PythonBundle(Bundle):
 
         mismatched_params = set()
 
+        params = {
+            'sanity_pip_check': sanity_pip_check,
+            'sanity_check_pip_list': sanity_check_pip_list,
+        }
+
         for ext in py_exts:
-            if ext.cfg['sanity_pip_check'] != sanity_pip_check:
-                mismatched_params.add('sanity_pip_check')
+            for param, value in params.items():
+                if ext.cfg[param] != value:
+                    mismatched_params.add(param)
             all_unversioned_packages.update(ext.cfg['unversioned_packages'])
 
-        if 'sanity_pip_check' in mismatched_params:
-            sanity_pip_check = True  # Either the main set it or any extension enabled it
+        for param in params:
+            if param in mismatched_params:
+                params[param] = True  # Either the main set it or any extension enabled it
 
         if all_unversioned_packages != unversioned_packages:
             mismatched_params.add('unversioned_packages')
 
-        for param in mismatched_params:
-            msg = (f"For bundles of PythonPackage extensions the {param} parameter "
+        for mismatch in mismatched_params:
+            msg = (f"For bundles of PythonPackage extensions the {mismatch} parameter "
                    "must be set at the top level, outside of exts_list")
             self.log.deprecated(msg, '6.0')
 
-        if sanity_pip_check:
+        if params['sanity_pip_check']:
             run_pip_check(python_cmd=self.python_cmd)
             pkgs = [(x.name, x.version) for x in py_exts]
+
+        if params['sanity_check_pip_list']:
             run_pip_list(pkgs, python_cmd=self.python_cmd, unversioned_packages=all_unversioned_packages)
 
     def make_module_footer(self):

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -26,6 +26,7 @@
 EasyBuild support for installing a bundle of Python packages, implemented as a generic easyblock
 
 @author: Kenneth Hoste (Ghent University)
+@author: Samuel Moors (Vrije Universiteit Brussel)
 """
 import os
 

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -202,8 +202,10 @@ class PythonBundle(Bundle):
         """Run the pip check for extensions if enabled"""
         super()._sanity_check_step_extensions()
 
-        sanity_pip_check = self.cfg['sanity_pip_check']
-        sanity_check_pip_list = self.cfg['sanity_check_pip_list']
+        params = {
+            'sanity_pip_check': self.cfg['sanity_pip_check'],
+            'sanity_check_pip_list': self.cfg['sanity_check_pip_list'],
+        }
         unversioned_packages = set(self.cfg['unversioned_packages'])
 
         # The options should be set in the main EC and cannot be different between extensions.
@@ -213,11 +215,6 @@ class PythonBundle(Bundle):
         py_exts = [x for x in self.ext_instances if isinstance(x, PythonPackage)]
 
         mismatched_params = set()
-
-        params = {
-            'sanity_pip_check': sanity_pip_check,
-            'sanity_check_pip_list': sanity_check_pip_list,
-        }
 
         for ext in py_exts:
             for param, value in params.items():

--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -239,9 +239,8 @@ class PythonBundle(Bundle):
         if params['sanity_pip_check']:
             run_pip_check(python_cmd=self.python_cmd)
             pkgs = [(x.name, x.version) for x in py_exts]
-
-        if params['sanity_check_pip_list']:
-            run_pip_list(pkgs, python_cmd=self.python_cmd, unversioned_packages=all_unversioned_packages)
+            run_pip_list(pkgs, python_cmd=self.python_cmd, unversioned_packages=all_unversioned_packages,
+                         check_names_versions=params['sanity_check_pip_list'])
 
     def make_module_footer(self):
         """

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -414,9 +414,8 @@ class PythonPackage(ExtensionEasyBlock):
             'max_py_majver': [None, "Maximum major Python version (only relevant when using system Python)", CUSTOM],
             'max_py_minver': [None, "Maximum minor Python version (only relevant when using system Python)", CUSTOM],
             'sanity_pip_check': [True, "Run 'python -m pip check' to ensure all required Python packages are "
-                                       "installed and check for any package with an invalid (0.0.0) version.", CUSTOM],
-            'sanity_pip_list': [False, "Run 'python -m pip list' to ensure specified package name and version "
-                                       "are correct.", CUSTOM],
+                                       "installed and run 'python -m pip list' to check for correct package names and "
+                                       "versions or any package with an invalid (0.0.0) version.", CUSTOM],
             'runtest': [True, "Run unit tests.", CUSTOM],  # overrides default
             'testinstall': [False, "Install into temporary directory prior to running the tests.", CUSTOM],
             'unpack_sources': [None, "Unpack sources prior to build/install. Defaults to 'True' except for whl files",
@@ -1103,25 +1102,15 @@ class PythonPackage(ExtensionEasyBlock):
                 kwargs.update({'exts_filter': exts_filter})
 
         sanity_pip_check = self.cfg.get('sanity_pip_check', True)
-        sanity_pip_list = self.cfg.get('sanity_pip_list', False)
-
         if self.is_extension:
             sanity_pip_check_main = self.master.cfg.get('sanity_pip_check')
             if sanity_pip_check_main is not None:
                 # If the main easyblock (e.g. PythonBundle) defines the variable
                 # we trust it does the pip check if requested and checks for mismatches
                 sanity_pip_check = False
-                self.log.info(f"Sanity 'pip check' disabled for {self.name} extension, "
+                self.log.info(f"'sanity_pip_check' disabled for {self.name} extension, "
                               f"assuming that parent will take care of it"
                               )
-
-            sanity_pip_list_main = self.master.cfg.get('sanity_pip_list')
-            if sanity_pip_list_main is not None:
-                # If the main easyblock (e.g. PythonBundle) defines the variable
-                # we trust it does the pip list if requested and checks for mismatches
-                sanity_pip_list = False
-                self.log.info(f"Sanity 'pip list' disabled for {self.name} extension, "
-                              f"assuming that parent will take care of it")
 
         if sanity_pip_check:
             if not self.is_extension:
@@ -1137,8 +1126,6 @@ class PythonPackage(ExtensionEasyBlock):
 
             unversioned_packages = self.cfg.get('unversioned_packages', [])
             run_pip_check(python_cmd=python_cmd, unversioned_packages=unversioned_packages)
-
-        if sanity_pip_list:
             run_pip_list([(self.name, self.version)], python_cmd=python_cmd)
 
         # ExtensionEasyBlock handles loading modules correctly for multi_deps, so we clean up fake_mod_data

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -1219,8 +1219,8 @@ class PythonPackage(ExtensionEasyBlock):
                                          self.short_mod_name)
 
             unversioned_packages = self.cfg.get('unversioned_packages', [])
-            run_pip_check(python_cmd=python_cmd, unversioned_packages=unversioned_packages)
-            run_pip_list([(self.name, self.version)], python_cmd=python_cmd)
+            run_pip_check(python_cmd=python_cmd)
+            run_pip_list([(self.name, self.version)], python_cmd=python_cmd, unversioned_packages=unversioned_packages)
 
         # ExtensionEasyBlock handles loading modules correctly for multi_deps, so we clean up fake_mod_data
         # and let ExtensionEasyBlock do its job

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -1233,16 +1233,9 @@ class PythonPackage(ExtensionEasyBlock):
                                          self.short_mod_name)
             run_pip_check(python_cmd=python_cmd)
 
-        if sanity_check_pip_list is None:
-            # by default only run 'pip list' sanity check if --upload-test-report is set
-            if build_option('upload_test_report'):
-                sanity_check_pip_list = True
-            else:
-                sanity_check_pip_list = False
-
-        if sanity_check_pip_list:
             unversioned_packages = self.cfg.get('unversioned_packages', [])
-            run_pip_list([(self.name, self.version)], python_cmd=python_cmd, unversioned_packages=unversioned_packages)
+            run_pip_list([(self.name, self.version)], python_cmd=python_cmd, unversioned_packages=unversioned_packages,
+                         check_names_versions=sanity_check_pip_list)
 
         # ExtensionEasyBlock handles loading modules correctly for multi_deps, so we clean up fake_mod_data
         # and let ExtensionEasyBlock do its job

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -31,6 +31,7 @@ EasyBuild support for Python packages, implemented as an easyblock
 @author: Pieter De Baets (Ghent University)
 @author: Jens Timmerman (Ghent University)
 @author: Alexander Grund (TU Dresden)
+@author: Samuel Moors (Vrije Universiteit Brussel)
 """
 import os
 import re

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -505,14 +505,15 @@ class PythonPackage(ExtensionEasyBlock):
             'max_py_majver': [None, "Maximum major Python version (only relevant when using system Python)", CUSTOM],
             'max_py_minver': [None, "Maximum minor Python version (only relevant when using system Python)", CUSTOM],
             'sanity_pip_check': [True, "Run 'python -m pip check' to ensure all required Python packages are "
-                                       "installed and run 'python -m pip list' to check for correct package names and "
-                                       "versions or any package with an invalid (0.0.0) version.", CUSTOM],
+                                       "installed.", CUSTOM],
+            'sanity_check_pip_list': [None, "Run 'python -m pip list' to ensure specified package names and versions "
+                                            "are correct.", CUSTOM],
             'runtest': [True, "Run unit tests.", CUSTOM],  # overrides default
             'testinstall': [False, "Install into temporary directory prior to running the tests.", CUSTOM],
             'unpack_sources': [None, "Unpack sources prior to build/install. Defaults to 'True' except for whl files",
                                CUSTOM],
             # A version of 0.0.0 is usually an error on installation unless the package does really not provide a
-            # version. Those would fail the (extended) sanity_pip_check. So as a last resort they can be added here
+            # version. Those would fail the sanity_check_pip_list. So as a last resort they can be added here
             # and will be excluded from that check. Note that the display name is required, i.e. from `pip list`.
             'unversioned_packages': [[], "List of packages that don't have a version at all, i.e. show 0.0.0", CUSTOM],
             'use_pip': [True, "Install using '%s'" % PIP_INSTALL_CMD, CUSTOM],
@@ -1200,6 +1201,8 @@ class PythonPackage(ExtensionEasyBlock):
         self.cfg.template_values['python'] = python_cmd
 
         sanity_pip_check = self.cfg.get('sanity_pip_check', True)
+        sanity_check_pip_list = self.cfg.get('sanity_check_pip_list')
+
         if self.is_extension:
             sanity_pip_check_main = self.master.cfg.get('sanity_pip_check')
             if sanity_pip_check_main is not None:
@@ -1207,8 +1210,15 @@ class PythonPackage(ExtensionEasyBlock):
                 # we trust it does the pip check if requested and checks for mismatches
                 sanity_pip_check = False
                 self.log.info(f"'sanity_pip_check' disabled for {self.name} extension, "
-                              f"assuming that parent will take care of it"
-                              )
+                              f"assuming that parent will take care of it")
+
+            sanity_check_pip_list_main = self.master.cfg.get('sanity_check_pip_list')
+            if sanity_check_pip_list_main is not None:
+                # If the main easyblock (e.g. PythonBundle) defines the variable
+                # we trust it does the pip list if requested and checks for mismatches
+                sanity_check_pip_list = False
+                self.log.info(f"'sanity_check_pip_list' disabled for {self.name} extension, "
+                              f"assuming that parent will take care of it")
 
         if sanity_pip_check:
             if not self.is_extension:
@@ -1221,9 +1231,17 @@ class PythonPackage(ExtensionEasyBlock):
                     self.log.debug("Currently loaded modules: %s", loaded_modules)
                     raise EasyBuildError("%s module is not loaded, this should never happen...",
                                          self.short_mod_name)
-
-            unversioned_packages = self.cfg.get('unversioned_packages', [])
             run_pip_check(python_cmd=python_cmd)
+
+        if sanity_check_pip_list is None:
+            # by default only run 'pip list' sanity check if --upload-test-report is set
+            if build_option('upload_test_report'):
+                sanity_check_pip_list = True
+            else:
+                sanity_check_pip_list = False
+
+        if sanity_check_pip_list:
+            unversioned_packages = self.cfg.get('unversioned_packages', [])
             run_pip_list([(self.name, self.version)], python_cmd=python_cmd, unversioned_packages=unversioned_packages)
 
         # ExtensionEasyBlock handles loading modules correctly for multi_deps, so we clean up fake_mod_data

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -513,7 +513,7 @@ class PythonPackage(ExtensionEasyBlock):
             'unpack_sources': [None, "Unpack sources prior to build/install. Defaults to 'True' except for whl files",
                                CUSTOM],
             # A version of 0.0.0 is usually an error on installation unless the package does really not provide a
-            # version. Those would fail the sanity_check_pip_list. So as a last resort they can be added here
+            # version. Those would fail the (extended) sanity_pip_check. So as a last resort they can be added here
             # and will be excluded from that check. Note that the display name is required, i.e. from `pip list`.
             'unversioned_packages': [[], "List of packages that don't have a version at all, i.e. show 0.0.0", CUSTOM],
             'use_pip': [True, "Install using '%s'" % PIP_INSTALL_CMD, CUSTOM],

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -1201,27 +1201,21 @@ class PythonPackage(ExtensionEasyBlock):
         # inject extra '%(python)s' template value for use by sanity check commands
         self.cfg.template_values['python'] = python_cmd
 
-        sanity_pip_check = self.cfg.get('sanity_pip_check', True)
-        sanity_check_pip_list = self.cfg.get('sanity_check_pip_list')
+        params = {
+            'sanity_pip_check': self.cfg.get('sanity_pip_check', True),
+            'sanity_check_pip_list': self.cfg.get('sanity_check_pip_list'),
+        }
 
         if self.is_extension:
-            sanity_pip_check_main = self.master.cfg.get('sanity_pip_check')
-            if sanity_pip_check_main is not None:
-                # If the main easyblock (e.g. PythonBundle) defines the variable
-                # we trust it does the pip check if requested and checks for mismatches
-                sanity_pip_check = False
-                self.log.info(f"'sanity_pip_check' disabled for {self.name} extension, "
-                              f"assuming that parent will take care of it")
+            for key in params:
+                if self.master.cfg.get(key) is not None:
+                    # If the main easyblock (e.g. PythonBundle) defines the variable
+                    # we trust it does the 'pip check' or 'pip list' if requested and checks for mismatches
+                    params[key] = False
+                    self.log.info(f"'{key}' disabled for {self.name} extension, "
+                                  f"assuming that parent will take care of it")
 
-            sanity_check_pip_list_main = self.master.cfg.get('sanity_check_pip_list')
-            if sanity_check_pip_list_main is not None:
-                # If the main easyblock (e.g. PythonBundle) defines the variable
-                # we trust it does the pip list if requested and checks for mismatches
-                sanity_check_pip_list = False
-                self.log.info(f"'sanity_check_pip_list' disabled for {self.name} extension, "
-                              f"assuming that parent will take care of it")
-
-        if sanity_pip_check:
+        if params['sanity_pip_check']:
             if not self.is_extension:
                 # for stand-alone Python package installations (not part of a bundle of extensions),
                 # the (fake or real) module file must be loaded at this point,
@@ -1236,7 +1230,7 @@ class PythonPackage(ExtensionEasyBlock):
 
             unversioned_packages = self.cfg.get('unversioned_packages', [])
             run_pip_list([(self.name, self.version)], python_cmd=python_cmd, unversioned_packages=unversioned_packages,
-                         check_names_versions=sanity_check_pip_list)
+                         check_names_versions=params['sanity_check_pip_list'])
 
         # ExtensionEasyBlock handles loading modules correctly for multi_deps, so we clean up fake_mod_data
         # and let ExtensionEasyBlock do its job

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -505,7 +505,7 @@ class PythonPackage(ExtensionEasyBlock):
             'max_py_majver': [None, "Maximum major Python version (only relevant when using system Python)", CUSTOM],
             'max_py_minver': [None, "Maximum minor Python version (only relevant when using system Python)", CUSTOM],
             'sanity_pip_check': [True, "Run 'python -m pip check' to ensure all required Python packages are "
-                                       "installed.", CUSTOM],
+                                       "installed and check for any package with an invalid (0.0.0) version.", CUSTOM],
             'sanity_check_pip_list': [None, "Run 'python -m pip list' to ensure specified package names and versions "
                                             "are correct.", CUSTOM],
             'runtest': [True, "Run unit tests.", CUSTOM],  # overrides default
@@ -521,7 +521,7 @@ class PythonPackage(ExtensionEasyBlock):
             # see https://packaging.python.org/tutorials/installing-packages/#installing-setuptools-extras
             'use_pip_extras': [None, "String with comma-separated list of 'extras' to install via pip", CUSTOM],
             'use_pip_for_deps': [False, "Install dependencies using '%s'" % PIP_INSTALL_CMD, CUSTOM],
-            'use_pip_requirement': [False, "Install using 'python -m pip install --requirement'. The sources is " +
+            'use_pip_requirement': [False, "Install using 'python -m pip install --requirement'. The sources is "
                                            "expected to be the requirements file.", CUSTOM],
             'zipped_egg': [False, "Install as a zipped eggs", CUSTOM],
         })
@@ -1012,8 +1012,8 @@ class PythonPackage(ExtensionEasyBlock):
                 # Requires having the installation in place to work correctly, since no path configuration files
                 # will be found otherwise
                 if self.should_use_ebpythonprefixes():
-                    extrapath += "export EBPYTHONPREFIXES=%s && " % os.pathsep.join([self.pypkg_test_installdir] +
-                                                                                    ['$EBPYTHONPREFIXES'])
+                    extrapath += "export EBPYTHONPREFIXES=%s && " % os.pathsep.join([self.pypkg_test_installdir]
+                                                                                    + ['$EBPYTHONPREFIXES'])
             if self.testcmd:
                 testcmd = self.testcmd % {'python': self.python_cmd}
                 cmd = ' '.join([

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -202,19 +202,19 @@ def run_pip_list(pkgs, python_cmd=None):
         trace_msg(msg + 'FAIL')
         pip_list_errors.append(f"pip list cmd failed:\n{err}")
 
-    pkgs = [(normalize_pip(name), version) for name, version in pkgs]
-    pip_pkgs = {normalize_pip(x['name']): x['version'] for x in pip_pkgs_dict}
+    normalized_pkgs = [(normalize_pip(name), version) for name, version in pkgs]
+    normalized_pip_pkgs = {normalize_pip(x['name']): x['version'] for x in pip_pkgs_dict}
 
     missing_names = []
     missing_versions = []
 
-    for name, version in pkgs:
-        if name not in pip_pkgs:
-            close_matches = difflib.get_close_matches(name, pip_pkgs.keys())
+    for name, version in normalized_pkgs:
+        if name not in normalized_pip_pkgs:
+            close_matches = difflib.get_close_matches(name, normalized_pip_pkgs.keys())
             missing_names.append(f'{name} (close matches: {close_matches})')
 
-        elif version != pip_pkgs[name]:
-            missing_versions.append(f'{name}-{version} (pip list version: {pip_pkgs[name]})')
+        elif version != normalized_pip_pkgs[name]:
+            missing_versions.append(f'{name}-{version} (pip list version: {normalized_pip_pkgs[name]})')
 
     log.info(f"Found {len(missing_names)} missing names and {len(missing_versions)} missing versions "
              f"out of {len(pkgs)} packages")

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -31,6 +31,7 @@ EasyBuild support for building and installing Python, implemented as an easybloc
 @author: Pieter De Baets (Ghent University)
 @author: Jens Timmerman (Ghent University)
 @author: Bart Oldeman (McGill University, Calcul Quebec, Compute Canada)
+@author: Samuel Moors (Vrije Universiteit Brussel)
 """
 import difflib
 import glob

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -32,6 +32,7 @@ EasyBuild support for building and installing Python, implemented as an easybloc
 @author: Jens Timmerman (Ghent University)
 @author: Bart Oldeman (McGill University, Calcul Quebec, Compute Canada)
 """
+import difflib
 import glob
 import json
 import os
@@ -202,7 +203,9 @@ def run_pip_list(pkgs, python_cmd=None):
 
     for name, version in pkgs:
         if name not in pip_pkgs:
-            missing_names.append(name)
+            close_matches = difflib.get_close_matches(name, pip_pkgs.keys())
+            missing_names.append(f'{name} (close matches: {close_matches})')
+
         elif version != pip_pkgs[name]:
             missing_versions.append(f'{name}-{version} (pip list version: {pip_pkgs[name]})')
 

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -219,7 +219,7 @@ def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None):
 
         if name not in normalized_pip_pkgs:
             close_matches = difflib.get_close_matches(name, normalized_pip_pkgs.keys())
-            missing_names.append(f'{name} (close matches: {close_matches})')
+            missing_names.append(f'{name} (close matches in pip list: {close_matches})')
 
         elif version != normalized_pip_pkgs[name]:
             missing_versions.append(f'{name} {version} (pip list version: {normalized_pip_pkgs[name]})')
@@ -230,13 +230,13 @@ def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None):
     if missing_names:
         missing_names_str = '\n'.join(missing_names)
         msg = "The following Python packages were likely specified with a wrong name because they are missing "
-        msg += f"from the 'pip list' output:\n{missing_names_str}\n"
+        msg += f"from the 'pip list' output:\n{missing_names_str}"
         pip_list_errors.append(msg)
 
     if missing_versions:
         missing_versions_str = '\n'.join(missing_versions)
         msg = "The following Python packages were likely specified with a wrong version because they have "
-        msg += f"another version in the 'pip list' output:\n{missing_versions_str}\n"
+        msg += f"another version in the 'pip list' output:\n{missing_versions_str}"
         pip_list_errors.append(msg)
 
     if pip_list_errors:

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -74,6 +74,8 @@ PY_ENV_VARS = {
     'PIP_DISABLE_PIP_VERSION_CHECK': 'true',
 }
 
+REGEX_PIP_NORMALIZE = re.compile(r"[-_.]+")
+
 # We want the following import order:
 # 1. Packages installed into VirtualEnv
 # 2. Packages installed into $EBPYTHONPREFIXES (e.g. our modules)
@@ -176,9 +178,13 @@ def det_installed_python_packages(names_only=True, python_cmd=None):
     return [pkg['name'] for pkg in pkgs] if names_only else pkgs
 
 
+def normalize_pip(name):
+    return REGEX_PIP_NORMALIZE.sub("-", name).lower()
+
+
 def run_pip_list(pkgs, python_cmd=None):
     """
-    Run pip list to verify names and versions of installed Python packages
+    Run pip list to verify normalized names and versions of installed Python packages
 
     :param pkgs: list of package tuples (name, version) as specified in the easyconfig
     """
@@ -196,7 +202,8 @@ def run_pip_list(pkgs, python_cmd=None):
         trace_msg(msg + 'FAIL')
         pip_list_errors.append(f"pip list cmd failed:\n{err}")
 
-    pip_pkgs = {x['name']: x['version'] for x in pip_pkgs_dict}
+    pkgs = [(normalize_pip(name), version) for name, version in pkgs]
+    pip_pkgs = {normalize_pip(x['name']): x['version'] for x in pip_pkgs_dict}
 
     missing_names = []
     missing_versions = []

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -232,7 +232,7 @@ def normalize_pip(name):
     return REGEX_PIP_NORMALIZE.sub("-", name).lower()
 
 
-def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None):
+def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None, check_names_versions=None):
     """
     Run pip list to verify normalized names and versions of installed Python packages
 
@@ -253,6 +253,13 @@ def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None):
 
     if build_option('ignore_pip_unversioned_pkgs'):
         unversioned_packages.update(build_option('ignore_pip_unversioned_pkgs'))
+
+    if check_names_versions is None:
+        # by default only check names and versions if --upload-test-report is set
+        if build_option('upload_test_report'):
+            check_names_versions = True
+        else:
+            check_names_versions = False
 
     pip_list_errors = []
 
@@ -307,43 +314,44 @@ def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None):
         msg += "required (check the source for a pyproject.toml and see PEP517 for details on that)."
         pip_list_errors.append(msg)
 
-    normalized_pkgs = [(normalize_pip(name), version) for name, version in pkgs]
+    if check_names_versions:
+        normalized_pkgs = [(normalize_pip(name), version) for name, version in pkgs]
 
-    missing_names = []
-    missing_versions = []
+        missing_names = []
+        missing_versions = []
 
-    for name, version in normalized_pkgs:
-        # Skip packages in the unversioned list: they have already been checked
-        if name in normalized_unversioned:
-            continue
+        for name, version in normalized_pkgs:
+            # Skip packages in the unversioned list: they have already been checked
+            if name in normalized_unversioned:
+                continue
 
-        # Skip packages in the zero_pkg_names list: they have already been added to pip_list_errors
-        if name in zero_pkg_names:
-            continue
+            # Skip packages in the zero_pkg_names list: they have already been added to pip_list_errors
+            if name in zero_pkg_names:
+                continue
 
-        # Check for missing (likely wrong) packages names and propose close matches
-        if name not in normalized_pip_pkgs:
-            close_matches = difflib.get_close_matches(name, normalized_pip_pkgs.keys())
-            missing_names.append(f'{name} (close matches in pip list: {close_matches})')
+            # Check for missing (likely wrong) packages names and propose close matches
+            if name not in normalized_pip_pkgs:
+                close_matches = difflib.get_close_matches(name, normalized_pip_pkgs.keys())
+                missing_names.append(f'{name} (close matches in pip list: {close_matches})')
 
-        # Check for missing (likely wrong) package versions
-        elif version != normalized_pip_pkgs[name]:
-            missing_versions.append(f'{name} {version} (pip list version: {normalized_pip_pkgs[name]})')
+            # Check for missing (likely wrong) package versions
+            elif version != normalized_pip_pkgs[name]:
+                missing_versions.append(f'{name} {version} (pip list version: {normalized_pip_pkgs[name]})')
 
-    log.info(f"Found {len(missing_names)} missing names and {len(missing_versions)} missing versions "
-             f"out of {len(pkgs)} packages")
+        log.info(f"Found {len(missing_names)} missing names and {len(missing_versions)} missing versions "
+                 f"out of {len(pkgs)} packages")
 
-    if missing_names:
-        missing_names_str = '\n'.join(missing_names)
-        msg = "The following Python packages were likely specified with a wrong name because they are missing "
-        msg += f"from the 'pip list' output:\n{missing_names_str}"
-        pip_list_errors.append(msg)
+        if missing_names:
+            missing_names_str = '\n'.join(missing_names)
+            msg = "The following Python packages were likely specified with a wrong name because they are missing "
+            msg += f"from the 'pip list' output:\n{missing_names_str}"
+            pip_list_errors.append(msg)
 
-    if missing_versions:
-        missing_versions_str = '\n'.join(missing_versions)
-        msg = "The following Python packages were likely specified with a wrong version because they have "
-        msg += f"another version in the 'pip list' output:\n{missing_versions_str}"
-        pip_list_errors.append(msg)
+        if missing_versions:
+            missing_versions_str = '\n'.join(missing_versions)
+            msg = "The following Python packages were likely specified with a wrong version because they have "
+            msg += f"another version in the 'pip list' output:\n{missing_versions_str}"
+            pip_list_errors.append(msg)
 
     if pip_list_errors:
         raise EasyBuildError('\n' + '\n'.join(pip_list_errors))

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -189,13 +189,13 @@ def run_pip_check(python_cmd=None, **kwargs):
 
     kwargs_keys = kwargs.keys()
     if 'unversioned_packages' in kwargs_keys:
-        msg = ("Parameter `unversioned_packages` is no longer supported in `run_pip_check` "
-               "and has been moved to `run_pip_list`.")
+        msg = ("Parameter unversioned_packages is no longer supported in run_pip_check, "
+               "it has been moved to run_pip_list.")
         log.deprecated(msg, '6.0')
         kwargs_keys -= {'unversioned_packages'}
 
     if kwargs_keys:
-        raise EasyBuildError(f'Parameter(s) {kwargs_keys} are not supported in `run_pip_check`.')
+        raise EasyBuildError("Parameter(s) used which are not supported in run_pip_check: " + ', '.join(kwargs_keys))
 
     if python_cmd is None:
         python_cmd = 'python'
@@ -229,7 +229,7 @@ def normalize_pip(name):
     Normalize pip package name according to
     https://packaging.python.org/en/latest/specifications/name-normalization/
     """
-    return REGEX_PIP_NORMALIZE.sub("-", name).lower()
+    return REGEX_PIP_NORMALIZE.sub('-', name).lower()
 
 
 def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None, check_names_versions=None):
@@ -239,6 +239,7 @@ def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None, check_names_v
     :param pkgs: list of package tuples (name, version) as specified in the easyconfig
     :param python_cmd: Python command to use (if None, 'python' is used)
     :param unversioned_packages: set of Python packages to exclude in the version existence check
+    :param check_names_versions: boolean to indicate whether name and versions of Python packages should be checked
     """
 
     log = fancylogger.getLogger('run_pip_list', fname=False)
@@ -248,14 +249,15 @@ def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None, check_names_v
     elif isinstance(unversioned_packages, (list, tuple)):
         unversioned_packages = set(unversioned_packages)
     elif not isinstance(unversioned_packages, set):
-        raise EasyBuildError("Incorrect value type for 'unversioned_packages' in run_pip_check: %s",
+        raise EasyBuildError("Incorrect value type for 'unversioned_packages' in run_pip_list: %s",
                              type(unversioned_packages))
 
     if build_option('ignore_pip_unversioned_pkgs'):
         unversioned_packages.update(build_option('ignore_pip_unversioned_pkgs'))
 
     if check_names_versions is None:
-        # by default only check names and versions if --upload-test-report is set
+        # by default only check names and versions if --upload-test-report is used,
+        # so we can enforce that extension names/versions are correct for contributions
         if build_option('upload_test_report'):
             check_names_versions = True
         else:
@@ -263,8 +265,8 @@ def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None, check_names_v
 
     pip_list_errors = []
 
+    msg = "Check on installed Python package names and versions with 'pip list': "
     try:
-        msg = "Check on installed Python package names and versions with 'pip list': "
         pip_pkgs_dict = det_installed_python_packages(names_only=False, python_cmd=python_cmd)
         trace_msg(msg + 'OK')
         log.info("pip list cmd passed successfully")
@@ -332,11 +334,11 @@ def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None, check_names_v
             # Check for missing (likely wrong) packages names and propose close matches
             if name not in normalized_pip_pkgs:
                 close_matches = difflib.get_close_matches(name, normalized_pip_pkgs.keys())
-                missing_names.append(f'{name} (close matches in pip list: {close_matches})')
+                missing_names.append(f"{name} (close matches in 'pip list' output: " + ', '.join(close_matches))
 
             # Check for missing (likely wrong) package versions
             elif version != normalized_pip_pkgs[name]:
-                missing_versions.append(f'{name} {version} (pip list version: {normalized_pip_pkgs[name]})')
+                missing_versions.append(f"{name} {version} (version in 'pip list' output: {normalized_pip_pkgs[name]})")
 
         log.info(f"Found {len(missing_names)} missing names and {len(missing_versions)} missing versions "
                  f"out of {len(pkgs)} packages")
@@ -344,7 +346,7 @@ def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None, check_names_v
         if missing_names:
             missing_names_str = '\n'.join(missing_names)
             msg = "The following Python packages were likely specified with a wrong name because they are missing "
-            msg += f"from the 'pip list' output:\n{missing_names_str}"
+            msg += f"in the 'pip list' output:\n{missing_names_str}"
             pip_list_errors.append(msg)
 
         if missing_versions:

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -183,19 +183,19 @@ def run_pip_check(python_cmd=None, **kwargs):
     """
     Check installed Python packages using 'pip check'
 
-    :param unversioned_packages: set of Python packages to exclude in the version existence check
     :param python_cmd: Python command to use (if None, 'python' is used)
     """
     log = fancylogger.getLogger('run_pip_check', fname=False)
 
     kwargs_keys = kwargs.keys()
     if 'unversioned_packages' in kwargs_keys:
-        msg = "Parameter `unversioned_packages` is no longer supported."
+        msg = ("Parameter `unversioned_packages` is no longer supported in `run_pip_check` "
+               "and has been moved to `run_pip_list`.")
         log.deprecated(msg, '6.0')
         kwargs_keys -= {'unversioned_packages'}
 
     if kwargs_keys:
-        raise EasyBuildError(f'Parameter(s) {kwargs_keys} are not allowed.')
+        raise EasyBuildError(f'Parameter(s) {kwargs_keys} are not supported in `run_pip_check`.')
 
     if python_cmd is None:
         python_cmd = 'python'
@@ -237,6 +237,8 @@ def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None):
     Run pip list to verify normalized names and versions of installed Python packages
 
     :param pkgs: list of package tuples (name, version) as specified in the easyconfig
+    :param python_cmd: Python command to use (if None, 'python' is used)
+    :param unversioned_packages: set of Python packages to exclude in the version existence check
     """
 
     log = fancylogger.getLogger('run_pip_list', fname=False)
@@ -268,7 +270,7 @@ def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None):
     else:
         normalized_unversioned = set()
 
-    # Create normalized name -> version mapping from the pip list output
+    # Create normalized name: version mapping from pip list output
     normalized_pip_pkgs = {normalize_pip(x['name']): x['version'] for x in pip_pkgs_dict}
 
     # Check for packages that likely were not installed correctly (version '0.0.0'), excluding packages that are listed

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -225,6 +225,10 @@ def run_pip_check(python_cmd=None, **kwargs):
 
 
 def normalize_pip(name):
+    """
+    Normalize pip package name according to
+    https://packaging.python.org/en/latest/specifications/name-normalization/
+    """
     return REGEX_PIP_NORMALIZE.sub("-", name).lower()
 
 
@@ -415,6 +419,8 @@ class EB_Python(ConfigureMake):
             'pip_ignore_installed': False,
             # disable per-extension 'pip check', since it's a global check done in sanity check step of Python easyblock
             'sanity_pip_check': False,
+            # disable per-extension 'pip list', since it's a global check done in sanity check step of Python easyblock
+            'sanity_check_pip_list': False,
             # EasyBuild 5
             'use_pip': True,
         }

--- a/test/easyblocks/easyblock_specific.py
+++ b/test/easyblocks/easyblock_specific.py
@@ -580,7 +580,7 @@ class EasyBlockSpecificTest(TestCase):
             python.run_pip_list([], python_cmd=sys.executable, unversioned_packages=('zero', ))
 
         with self.mocked_stdout_stderr():
-            python.run_pip_list([], python_cmd=sys.executable, unversioned_packages=set('zero'))
+            python.run_pip_list([], python_cmd=sys.executable, unversioned_packages={'zero'})
 
         # inject all possible errors
         def mocked_run_shell_cmd_pip(cmd, **kwargs):

--- a/test/easyblocks/easyblock_specific.py
+++ b/test/easyblocks/easyblock_specific.py
@@ -619,10 +619,10 @@ class EasyBlockSpecificTest(TestCase):
 
         python.run_shell_cmd = mocked_run_shell_cmd_pip
         error_pattern = '\n'.join([
-            r"The following Python packages were likely specified with a wrong name because they are missing",
-            r"wrong-name",
-            r"The following Python packages were likely specified with a wrong version",
-            r"wrong-version 5.6.7",
+            r"The following Python packages were likely specified with a wrong name because they are missing.*",
+            r"wrong-name.*",
+            r"The following Python packages were likely specified with a wrong version.*",
+            r"wrong-version 5.6.7.*",
         ])
         with self.mocked_stdout_stderr():
             self.assertErrorRegex(EasyBuildError, error_pattern, python.run_pip_list,

--- a/test/easyblocks/easyblock_specific.py
+++ b/test/easyblocks/easyblock_specific.py
@@ -562,7 +562,7 @@ class EasyBlockSpecificTest(TestCase):
 
         python.run_shell_cmd = mocked_run_shell_cmd_pip
         with self.mocked_stdout_stderr():
-            python.run_pip_list(python_cmd=sys.executable)
+            python.run_pip_list([], python_cmd=sys.executable)
 
         # test ignored unversioned Python packages
         def mocked_run_shell_cmd_pip(cmd, **kwargs):
@@ -577,10 +577,10 @@ class EasyBlockSpecificTest(TestCase):
 
         python.run_shell_cmd = mocked_run_shell_cmd_pip
         with self.mocked_stdout_stderr():
-            python.run_pip_list(python_cmd=sys.executable, unversioned_packages=('zero', ))
+            python.run_pip_list([], python_cmd=sys.executable, unversioned_packages=('zero', ))
 
         with self.mocked_stdout_stderr():
-            python.run_pip_list(python_cmd=sys.executable, unversioned_packages=set('zero'))
+            python.run_pip_list([], python_cmd=sys.executable, unversioned_packages=set('zero'))
 
         # inject all possible errors
         def mocked_run_shell_cmd_pip(cmd, **kwargs):
@@ -602,7 +602,7 @@ class EasyBlockSpecificTest(TestCase):
             "wrong",
         ])
         with self.mocked_stdout_stderr():
-            self.assertErrorRegex(EasyBuildError, error_pattern, python.run_pip_list,
+            self.assertErrorRegex(EasyBuildError, error_pattern, python.run_pip_list, [],
                                   python_cmd=sys.executable, unversioned_packages=['example', 'nosuchpkg'])
 
     def test_symlink_dist_site_packages(self):

--- a/test/easyblocks/easyblock_specific.py
+++ b/test/easyblocks/easyblock_specific.py
@@ -620,9 +620,9 @@ class EasyBlockSpecificTest(TestCase):
         python.run_shell_cmd = mocked_run_shell_cmd_pip
         error_pattern = '\n'.join([
             r"The following Python packages were likely specified with a wrong name because they are missing",
-            r"wrong-name (close matches",
+            r"wrong-name",
             r"The following Python packages were likely specified with a wrong version",
-            r"wrong-version 5.6.7 (pip list",
+            r"wrong-version 5.6.7",
         ])
         with self.mocked_stdout_stderr():
             self.assertErrorRegex(EasyBuildError, error_pattern, python.run_pip_list,

--- a/test/easyblocks/easyblock_specific.py
+++ b/test/easyblocks/easyblock_specific.py
@@ -627,7 +627,7 @@ class EasyBlockSpecificTest(TestCase):
         with self.mocked_stdout_stderr():
             self.assertErrorRegex(EasyBuildError, error_pattern, python.run_pip_list,
                                   [('wrong_name', '1.2.3'), ('wrong_version', '5.6.7')],
-                                  python_cmd=sys.executable)
+                                  python_cmd=sys.executable, check_names_versions=True)
 
     def test_symlink_dist_site_packages(self):
         """Test symlink_dist_site_packages provided by PythonPackage easyblock."""


### PR DESCRIPTION
cfr. conf call discussion https://github.com/easybuilders/easybuild/wiki/Conference-call-notes-20260114

- check if the normalized Python package extension name and version in the easyconfig match the normalized `pip list` name and version.
- show close matches in `pip list` if there is no matching name.

implemented for `Python`, `PythonPackage`, `PythonBundle` easyblocks (+ derivatives).

### UPDATE 2026-03-22:
- by default, the extended `pip list` sanity check runs only if `--upload-test-report` is enabled. you can override this by setting easyconfig parameter `sanity_check_pip_list` to `True` or `False`
- the `pip list` check for `0.0.0` versions is still done by default as before this PR, but is now done in `run_pip_list()` instead of `run_pip_check()`.