### PR TITLE
Allow easier reuse of `compose_install_command` of PythonPackage, and add `%(python)s` template and default Python libdir in sanity check

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -1079,10 +1079,8 @@ class PythonPackage(ExtensionEasyBlock):
         # this is relevant for installations of Python packages for multiple Python versions (via multi_deps)
         # (we can not pass this via custom_paths, since then the %(pyshortver)s template value will not be resolved)
         if not self.is_extension:
-            kwargs.setdefault('custom_paths', {
-                'files': [],
-                'dirs': [os.path.join('lib', 'python%(pyshortver)s', 'site-packages')],
-            })
+            kwargs.setdefault('custom_paths', {'files': []}) \
+                  .setdefault('dirs', [os.path.join('lib', 'python%(pyshortver)s', 'site-packages')])
 
         # make sure 'exts_filter' is defined, which is used for sanity check
         if self.multi_python:
@@ -1100,6 +1098,9 @@ class PythonPackage(ExtensionEasyBlock):
                 orig_exts_filter = EXTS_FILTER_PYTHON_PACKAGES
                 exts_filter = (orig_exts_filter[0].replace('python', self.python_cmd), orig_exts_filter[1])
                 kwargs.update({'exts_filter': exts_filter})
+
+        # inject extra '%(python)s' template value for use by sanity check commands
+        self.cfg.template_values['python'] = python_cmd
 
         sanity_pip_check = self.cfg.get('sanity_pip_check', True)
         if self.is_extension:


### PR DESCRIPTION
This now accepts an `install_src` parameter to choose which package to install.
This can be used to e.g. install wheels without duplicating the logic
used to determine parameters such as `--no-build-isolation`.

Additionally in the sanity check `%(python)s` can be used which is populated AFTER potentially loading the module and determining `self.python_cmd` which avoids failures in `--sanity-check-only` where that might not yet be set.

Similar it keeps the default sanity check dir even when `files` parameter is set further reducing duplication.

For a use case see https://github.com/easybuilders/easybuild-easyblocks/pull/4046 which includes this change