### PR TITLE
Fix duplicate `self` parameter in Bundle easyblock

### DIFF
--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -269,8 +269,8 @@ class Bundle(EasyBlock):
         """
         checksum_issues = super().check_checksums()
 
-        for comp, _ in self.comp_instances:
-            checksum_issues.extend(self.check_checksums_for(comp, sub="of component %s" % comp['name']))
+        for comp_cfg, _ in self.comp_instances:
+            checksum_issues.extend(self.check_checksums_for(comp_cfg, sub="of component %s" % comp_cfg['name']))
 
         return checksum_issues
 


### PR DESCRIPTION
Fixes https://github.com/easybuilders/easybuild-easyblocks/pull/4037

`super().x()` already passes `self` so this was equivalent to `EasyBlock.prepare_step(self, self, *args, *kwargs)`

Also fix the name in `check_checksums` as that was very confusing, especially next to each other:
```
        for comp, _ in self.comp_instances:
        ...
        for _, comp in self.comp_instances:

```