### PR TITLE
Introduce `freethreading` extra config option.

### DIFF
--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -878,9 +878,9 @@ class EB_Python(ConfigureMake):
         pyver = 'python' + self.pyshortver
         custom_paths = {
             'files': [
-                os.path.join('bin', pyver),
+                os.path.join('bin', pyver + abiflags),
                 os.path.join('bin', 'python'),
-                os.path.join('bin', pyver + '-config'),
+                os.path.join('bin', pyver + abiflags + '-config'),
                 os.path.join('bin', 'python-config'),
                 os.path.join('lib', 'lib' + pyver + abiflags + '.' + shlib_ext),
             ],

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -309,6 +309,7 @@ class EB_Python(ConfigureMake):
                                              "order to make sure ctypes can still find libraries without it. "
                                              "Please make sure to add the checksum for this patch to 'checksums'.",
                                              CUSTOM],
+            'freethreading': [False, "Build without GIL", CUSTOM],
         }
         return ConfigureMake.extra_options(extra_vars)
 
@@ -579,6 +580,9 @@ class EB_Python(ConfigureMake):
         if self._has_ensure_pip():
             self.cfg.update('configopts', "--with-ensurepip=" + ('no', 'upgrade')[self.install_pip])
 
+        if self.cfg['freethreading'] and LooseVersion(self.version) >= LooseVersion('3.13.0'):
+            self.cfg.update('configopts', "--disable-gil")
+
         modules_setup = os.path.join(self.cfg['start_dir'], 'Modules', 'Setup')
         if LooseVersion(self.version) < LooseVersion('3.8.0'):
             modules_setup += '.dist'
@@ -692,7 +696,8 @@ class EB_Python(ConfigureMake):
 
     @property
     def site_packages_path(self):
-        return os.path.join('lib', 'python' + self.pyshortver, 'site-packages')
+        suffix = "t" if self.cfg.get('freethreading') else ""
+        return os.path.join('lib', 'python' + self.pyshortver + suffix, 'site-packages')
 
     def install_step(self):
         """Extend make install to make sure that the 'python' command is present."""


### PR DESCRIPTION
For python 3.13+. 
Disable the GIL and adapt the site_packages_path accordingly

Otherwise,  `_sanity_check_ebpythonprefixes` fails with
```
== 2026-02-05 23:40:39,340 build_log.py:233 ERROR EasyBuild encountered an error: The Python install path (/home/user/.local/easybuild/software/2023/x86-64-v3/Compiler/gcccore/python-freethreading/3.14.2/lib/python3.14/site-packages) was not added to sys.path (['', '/home/user/.local/easybuild/software/2023/x86-64-v3/Compiler/gcccore/python-freethreading/3.14.2/lib/python314t.zip', '/home/user/.local/easybuild/software/2023/x86-64-v3/Compiler/gcccore/python-freethreading/3.14.2/lib/python3.14t', '/home/user/.local/easybuild/software/2023/x86-64-v3/Compiler/gcccore/python-freethreading/3.14.2/lib/python3.14t/lib-dynload', '/home/user/.local/easybuild/software/2023/x86-64-v3/Compiler/gcccore/python-freethreading/3.14.2/lib/python3.14t/site-packages']) (at easybuild/easyblocks/p/python.py:804 in _sanity_check_ebpythonprefixes)
```
since `/home/user/.local/easybuild/software/2023/x86-64-v3/Compiler/gcccore/python-freethreading/3.14.2/lib/python3.14/site-packages` does not contains the abiflags (`t`).