### PR TITLE
fix call to parent for static method `src_parameter_names` in `Cargo` easyblock

### DIFF
--- a/easybuild/easyblocks/generic/cargo.py
+++ b/easybuild/easyblocks/generic/cargo.py
@@ -171,7 +171,7 @@ class Cargo(ExtensionEasyBlock):
 
     @staticmethod
     def src_parameter_names():
-        return super(Cargo, Cargo).src_parameter_names() + ['crates']
+        return ExtensionEasyBlock.src_parameter_names() + ['crates']
 
     @staticmethod
     def crate_src_filename(pkg_name, pkg_version, _url=None, rev=None):


### PR DESCRIPTION
Required for https://github.com/easybuilders/easybuild-framework/pull/4661