### PR TITLE
enhance `PythonPackage` and `PythonBundle` easyblocks to add support to install dummy Python packages

### DIFF
--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -99,9 +99,10 @@ class PythonBundle(Bundle):
 
         # if 'python' is not used, we need to take that into account in the extensions filter
         # (which is also used during the sanity check)
-        with self.cfg.disable_templating():
-            orig_exts_filter = self.cfg['exts_filter']
-            self.cfg['exts_filter'] = (orig_exts_filter[0].replace('python', self.python_cmd), orig_exts_filter[1])
+        if self.python_cmd != 'python':
+            with self.cfg.disable_templating():
+                orig_exts_filter = self.cfg['exts_filter']
+                self.cfg['exts_filter'] = (orig_exts_filter[0].replace('python', self.python_cmd), orig_exts_filter[1])
 
     def prepare_step(self, *args, **kwargs):
         """Prepare for installing bundle of Python packages."""

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -831,6 +831,28 @@ class PythonPackage(ExtensionEasyBlock):
 
         return ' '.join(cmd)
 
+    def install_dummy_package(self):
+        """
+        Create dist-info directory inside site-packages with the metadata for
+        the given target package
+        """
+        py_package_metadata = [
+            "Metadata-Version: 2.1",
+            f"Name: {self.name}",
+            f"Version: {self.version}",
+        ]
+
+        # make dist-info directory
+        dist_info_name = f"{self.name.replace('-','_')}-{self.version}.dist-info"
+        dist_info_path = os.path.join(self.installdir, self.pylibdir, dist_info_name)
+        mkdir(dist_info_path, parents=True)
+
+        # install METADATA file
+        metadata_path = os.path.join(dist_info_path, 'METADATA')
+        write_file(metadata_path, '\n'.join(py_package_metadata))
+
+        self.log.info(f"Installation of dummy package for {self.name}-{self.version} successfull")
+
     def py_post_install_shenanigans(self, install_dir):
         """
         Run post-installation shenanigans on specified installation directory, incl:

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -852,7 +852,7 @@ class PythonPackage(ExtensionEasyBlock):
         ]
 
         # make dist-info directory
-        dist_info_name = f"{self.name.replace('-','_')}-{self.version}.dist-info"
+        dist_info_name = self.name.replace('-', '_') + f"-{self.version}.dist-info"
         dist_info_path = os.path.join(self.installdir, self.pylibdir, dist_info_name)
         mkdir(dist_info_path, parents=True)
 
@@ -860,7 +860,7 @@ class PythonPackage(ExtensionEasyBlock):
         metadata_path = os.path.join(dist_info_path, 'METADATA')
         write_file(metadata_path, '\n'.join(py_package_metadata))
 
-        self.log.info(f"Installation of dummy package for {self.name}-{self.version} successfull")
+        self.log.info(f"Installation of dummy package for {self.name}-{self.version} successfull: {metadata_path}")
 
     def py_post_install_shenanigans(self, install_dir):
         """
@@ -1222,15 +1222,15 @@ class PythonPackage(ExtensionEasyBlock):
         # (we can not pass this via custom_paths, since then the %(pyshortver)s template value will not be resolved)
         if not self.is_extension:
             site_package_dir = os.path.join('lib', 'python%(pyshortver)s', 'site-packages')
-            default_sanity_dirs = [site_package_dir]
 
+            custom_paths_files = []
             if self.cfg.get('dummy_package', False):
-                dist_info_name = f"{self.name.replace('-','_')}-{self.version}.dist-info"
-                default_sanity_dirs.append(os.path.join(site_package_dir, dist_info_name))
+                dist_info_name = self.name.replace('-', '_') + f'-{self.version}.dist-info'
+                custom_paths_files.append(os.path.join(site_package_dir, dist_info_name, 'METADATA'))
 
             kwargs.setdefault('custom_paths', {
-                'files': [],
-                'dirs': default_sanity_dirs,
+                'files': custom_paths_files,
+                'dirs': [site_package_dir],
             })
 
         # make sure 'exts_filter' argument is defined, which is used for sanity check

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -58,6 +58,7 @@ import easybuild.tools.toolchain as toolchain
 
 
 EXTS_FILTER_PYTHON_PACKAGES = ('python -c "import %(ext_name)s"', "")
+EXTS_FILTER_DUMMY_PACKAGES = ("python -m pip show -q '%(ext_name)s'", "")
 
 # magic value for unlimited stack size
 UNLIMITED = 'unlimited'


### PR DESCRIPTION
This PR adds a new `dummy_package` option to `PythonPackage` and `PythonBundle` that allows to install any python package as a _dummy package_, which is a fake installation that makes package managers believe that the package is installed.

In practice, this does the following:
* sources of the dummy python package are not fetched or extracted
* the usual build/installation of the python package does not happen
* EB creates a _dist-info_ folder in the _site-packages_ directory with just a minimal `METADATA` file that contains the name and version of the package

The purpose of dummy packages is to be able to fulfill harcoded requirements in wheels that target python packages repackaging libraries that are already available in EasyBuild. The most notorious example are the CUDA libraries, wheels with support for CUDA need a collection of wheels from Nvidia that just repackage the CUDA libraries. Therefore, with this PR we can depend on the CUDA easyconfig as usual, while still have the fake cuda python packages to not break `pip check`.

Easyconfig using this feature in https://github.com/easybuilders/easybuild-easyconfigs/pull/25266