### PR TITLE
add custom easyblock for ESPResSo

### DIFF
--- a/easybuild/easyblocks/e/espresso.py
+++ b/easybuild/easyblocks/e/espresso.py
@@ -1,0 +1,195 @@
+##
+# Copyright 2025-2026 Jean-Noël Grad
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for ESPResSo, implemented as an easyblock.
+
+@author: Jean-Noël Grad (University of Stuttgart)
+"""
+
+import os
+import re
+
+from easybuild.easyblocks.generic.cmakeninja import CMakeNinja
+from easybuild.tools.systemtools import get_cpu_architecture, get_cpu_features
+from easybuild.tools.systemtools import X86_64
+from easybuild.tools.utilities import trace_msg
+from easybuild.tools.build_log import print_error
+from easybuild.tools.filetools import remove_file, remove_dir
+from easybuild.tools import LooseVersion
+
+
+class EB_ESPResSo(CMakeNinja):
+    """Support for building and installing ESPResSo."""
+
+    def _get_extracted_tarball_paths(self):
+        """
+        Locate the source code of all dependencies.
+        """
+        extracted_paths = {}
+        for src in self.src:
+            name = src['name'].split('-', 1)[0]
+            # process main software
+            if name == 'espresso':
+                extracted_paths['espresso'] = src['finalpath']
+                continue
+            # process dependencies
+            tarball = src['name']
+            if not tarball.endswith('.tar.gz'):
+                raise ValueError(tarball + ' is not a tar.gz file')
+            prefix = tarball.rsplit('.', 2)[0]
+            matches = [x for x in os.listdir(src['finalpath']) if x.startswith(prefix)]
+            if len(matches) == 0:
+                raise RuntimeError(tarball + ' was not extracted')
+            if len(matches) > 1:
+                raise RuntimeError(tarball + ' matches multiple folders: ' + str(matches))
+            extracted_paths[name] = os.path.join(src['finalpath'], matches[0])
+        return extracted_paths
+
+    def _patch_fetchcontent(self):
+        """
+        Modify CMake ``FetchContent_Declare`` blocks to point to the folders
+        containing the already-downloaded dependencies rather than to URLs.
+        This avoids a download step during configuration.
+        """
+        extracted_paths = self._get_extracted_tarball_paths()
+        cmakelists_path = os.path.join(extracted_paths['espresso'], 'CMakeLists.txt')
+        with open(cmakelists_path, 'r') as f:
+            content = f.read()
+        for name, local_uri in extracted_paths.items():
+            if name == 'espresso':
+                continue
+            pattern = fr'FetchContent_Declare\(\s*{name}\s+GIT_REPOSITORY\s+\S+\s+GIT_TAG\s+\S+(?=\s|\))'
+            m = re.search(pattern, content, flags=re.IGNORECASE)
+            if m is None:
+                raise RuntimeError(f'{name} is not part of the ESPResSo FetchContent workflow')
+            content = re.sub(pattern, f'FetchContent_Declare({name} URL {local_uri}', content, flags=re.IGNORECASE)
+        with open(cmakelists_path, 'w') as f:
+            f.write(content)
+
+    def _get_version(self):
+        if '.' in self.version:
+            version = tuple(LooseVersion(self.version).version)
+        else:
+            version = 'commit'
+        return version
+
+    def _configure_step_release_420(self):
+        configopts = self.cfg.get('configopts', '')
+        dependencies = self.cfg.dependencies()
+        dependencies_names = {x.get('name', '') for x in dependencies}
+
+        def cmake_if_has(name):
+            return 'ON' if name in dependencies_names else 'OFF'
+
+        configopts += f' -DWITH_CUDA={cmake_if_has("CUDA")}'
+        configopts += f' -DWITH_GSL={cmake_if_has("GSL")}'
+        configopts += ' -DWITH_FFTW=ON'
+        configopts += ' -DWITH_PYTHON=ON'
+        configopts += ' -DWITH_SCAFACOS=OFF'
+        configopts += ' -DWITH_STOKESIAN_DYNAMICS=OFF'
+        configopts += ' -DWITH_TESTS=ON'
+
+        self.cfg['configopts'] = configopts
+
+    def _configure_step_release_500(self):
+        configopts = self.cfg.get('configopts', '')
+        dependencies = self.cfg.dependencies()
+        dependencies_names = {x.get('name', '') for x in dependencies}
+
+        def cmake_if_has(name):
+            return 'ON' if name in dependencies_names else 'OFF'
+
+        cpu_features = get_cpu_features()
+
+        configopts += f' -DESPRESSO_BUILD_WITH_CUDA={cmake_if_has("CUDA")}'
+        configopts += f' -DESPRESSO_BUILD_WITH_HDF5={cmake_if_has("HDF5")}'
+        configopts += f' -DESPRESSO_BUILD_WITH_GSL={cmake_if_has("GSL")}'
+        configopts += f' -DESPRESSO_BUILD_WITH_NLOPT={cmake_if_has("NLopt")}'
+        configopts += ' -DESPRESSO_BUILD_WITH_SHARED_MEMORY_PARALLELISM=ON'
+        configopts += ' -DESPRESSO_BUILD_WITH_WALBERLA=ON'
+        if get_cpu_architecture() == X86_64 and 'avx2' in cpu_features:
+            configopts += ' -DESPRESSO_BUILD_WITH_WALBERLA_AVX=ON'
+        configopts += ' -DESPRESSO_BUILD_WITH_FFTW=ON'
+        configopts += ' -DESPRESSO_BUILD_WITH_PYTHON=ON'
+        configopts += ' -DESPRESSO_BUILD_WITH_SCAFACOS=OFF'
+        configopts += ' -DESPRESSO_BUILD_WITH_STOKESIAN_DYNAMICS=OFF'
+        configopts += ' -DESPRESSO_BUILD_TESTS=ON '
+
+        self.cfg['configopts'] = configopts
+
+    def configure_step(self):
+        # patch FetchContent to avoid re-downloading dependencies
+        self._patch_fetchcontent()
+
+        version = self._get_version()
+        if version == 'commit':
+            self._configure_step_release_500()
+        elif version[:2] >= (5, 0):
+            self._configure_step_release_500()
+        elif version[:2] >= (4, 2):
+            self._configure_step_release_420()
+        else:
+            raise NotImplementedError(
+                f'EasyBlock {self.__class__.__name__} doesn\'t implement the '
+                f'configure step for ESPResSo {self.version}')
+
+        return super(EB_ESPResSo, self).configure_step()
+
+    def test_step(self):
+        version = self._get_version()
+        if version == 'commit' or version[:2] >= (5, 0):
+            testopts = self.cfg.get('testopts', '')
+            testopts += f' -j{self.cfg.parallel}'
+            testopts += f' --resource-spec-file {self.builddir}/easybuild_obj/testsuite/python/resources.json'
+            self.cfg['testopts'] = testopts
+
+        return super(EB_ESPResSo, self).test_step()
+
+    def _cleanup_aux_files(self):
+        """
+        Remove files automatically installed by CMake outside the ESPResSo
+        main directory: header files, config files, duplicated shared objects.
+        """
+        def delete_dir(path):
+            if os.path.isdir(path):
+                trace_msg('removing directory \'%s\'' % path.replace(f'{self.installdir}/', ''))
+                remove_dir(path)
+
+        def delete_file(path):
+            if os.path.isfile(path) or os.path.islink(path):
+                trace_msg('removing file \'%s\'' % path.replace(f'{self.installdir}/', ''))
+                remove_file(path)
+
+        version = self._get_version()
+        if version == 'commit' or version[:2] >= (5, 0):
+            lib_dir = f'{self.installdir}/lib'
+            if os.path.isdir(f'{self.installdir}/lib64'):
+                lib_dir = f'{self.installdir}/lib64'
+            delete_dir(f'{self.installdir}/include')
+            delete_dir(f'{self.installdir}/share')
+            delete_dir(f'{self.installdir}/walberla')
+            delete_dir(f'{lib_dir}/cmake')
+            for path in os.listdir(lib_dir):
+                if '.so' in path:
+                    delete_file(f'{lib_dir}/{path}')
+
+    def post_processing_step(self):
+        try:
+            self._cleanup_aux_files()
+        except Exception as err:
+            print_error('Failed to remove some auxiliary files '
+                        f'(easyblock: {self.__class__.__name__}): {err}')
+        return super(EB_ESPResSo, self).post_processing_step()

--- a/easybuild/easyblocks/e/espresso.py
+++ b/easybuild/easyblocks/e/espresso.py
@@ -184,7 +184,12 @@ class EB_ESPResSo(CMakeNinja):
             testopts = self.cfg.get('testopts', '')
             testopts += f' -j{self.cfg.parallel}'
             testopts += f' --resource-spec-file {self.builddir}/easybuild_obj/testsuite/python/resources.json'
+            testopts += ' --output-on-failure --no-tests=error'
             self.cfg['testopts'] = testopts
+
+            if self.cfg['runtest'] is None:
+                self.cfg['test_cmd'] = 'ctest'
+                self.cfg['runtest'] = '-L "unit_test|python_test"'
 
         return super(EB_ESPResSo, self).test_step()
 

--- a/easybuild/easyblocks/e/espresso.py
+++ b/easybuild/easyblocks/e/espresso.py
@@ -88,7 +88,7 @@ class EB_ESPResSo(CMakeNinja):
 
     def _get_version(self):
         """
-        Internal helper function to get ESPResSo version
+        Internal helper function to get the ESPResSo version.
         """
         if '.' in self.version:
             version = tuple(LooseVersion(self.version).version)
@@ -98,7 +98,7 @@ class EB_ESPResSo(CMakeNinja):
 
     def _set_exe_linker_flags(self):
         """
-        Internal helper function to set DCMAKE_EXE_LINKER_FLAGS configure option
+        Internal helper function to set the -DCMAKE_EXE_LINKER_FLAGS configure option.
         """
         exe_linker_flags_relpaths = []
         if get_software_root('HeFFTe'):
@@ -118,7 +118,7 @@ class EB_ESPResSo(CMakeNinja):
 
     def _set_configure_options_release_420(self):
         """
-        Internal helper function to set configure options for ESPResSo v4.2+ (< 5.0)
+        Internal helper function to set configure options for ESPResSo v4.2+ (< 5.0).
         """
         for dep in ['CUDA', 'GSL', 'FFTW', 'Python', 'ScaFaCoS']:
             dep_flag = 'OFF'
@@ -133,7 +133,7 @@ class EB_ESPResSo(CMakeNinja):
 
     def _set_configure_options_release_500(self):
         """
-        Internal helper function to set configure options for ESPResSo v5.0
+        Internal helper function to set configure options for ESPResSo v5.0+.
         """
         cpu_features = get_cpu_features()
         for dep in ['CUDA', 'GSL', 'FFTW', 'Python', 'ScaFaCoS', 'HDF5', 'NLopt']:
@@ -165,9 +165,9 @@ class EB_ESPResSo(CMakeNinja):
 
         version = self._get_version()
         if version[:2] >= (5, 0):
-            paths = self._set_configure_options_release_500()
+            self._set_configure_options_release_500()
         elif version[:2] >= (4, 2):
-            paths = self._set_configure_options_release_420()
+            self._set_configure_options_release_420()
         else:
             raise EasyBuildError(
                 f'EasyBlock {self.__class__.__name__} doesn\'t implement the '
@@ -262,7 +262,8 @@ class EB_ESPResSo(CMakeNinja):
             _python_modules = sorted(_python_modules + _extra_python_modules)
 
         if get_software_root('HDF5'):
-            _libs.append('espresso_hdf5')
+            if version[:2] >= (5, 0):
+                _libs.append('espresso_hdf5')
             _python_modules.append(os.path.join('io', 'writer', 'h5md.py'))
         if get_software_root('CUDA'):
             if version[:2] >= (5, 0):

--- a/easybuild/easyblocks/e/espresso.py
+++ b/easybuild/easyblocks/e/espresso.py
@@ -25,10 +25,11 @@ import re
 from easybuild.easyblocks.generic.cmakeninja import CMakeNinja
 from easybuild.tools.systemtools import get_cpu_architecture, get_cpu_features
 from easybuild.tools.systemtools import X86_64
+from easybuild.tools.systemtools import get_shared_lib_ext
 from easybuild.tools.utilities import trace_msg
 from easybuild.tools.build_log import EasyBuildError, print_error
 from easybuild.tools.filetools import remove_file, remove_dir
-from easybuild.tools.modules import get_software_root
+from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools import LooseVersion
 
 
@@ -93,18 +94,100 @@ class EB_ESPResSo(CMakeNinja):
             version = 'commit'
         return version
 
+    def _set_exe_linker_flags(self):
+        exe_linker_flags_relpaths = []
+        if get_software_root('HeFFTe'):
+            exe_linker_flags_relpaths.append('heffte-build')
+        if get_software_root('Kokkos'):
+            exe_linker_flags_relpaths += [
+                'kokkos-build/containers/src',
+                'kokkos-build/core/src',
+                'kokkos-build/simd/src',
+            ]
+        if exe_linker_flags_relpaths:
+            # workaround for https://gitlab.kitware.com/cmake/cmake/-/issues/22678
+            # (this only affects testsuite executable files in the build folder)
+            exe_linker_flags = ':'.join(f'{self.builddir}/easybuild_obj/_deps/{path}'
+                                        for path in exe_linker_flags_relpaths)
+            self.cfg.update('configopts', f' -DCMAKE_EXE_LINKER_FLAGS="-Wl,-rpath-link,{exe_linker_flags}" ')
+
     def _configure_step_release_420(self):
-        for dep in ['CUDA', 'GSL', 'FFTW', 'PYTHON', 'SCAFACOS']:
+        for dep in ['CUDA', 'GSL', 'FFTW', 'Python', 'ScaFaCoS']:
             dep_flag = 'OFF'
             if get_software_root(dep):
                 dep_flag = 'ON'
             self.cfg.update('configopts', f"-DWITH_{dep.upper()}={dep_flag}")
         self.cfg.update('configopts', ' -DWITH_STOKESIAN_DYNAMICS=OFF')
         self.cfg.update('configopts', ' -DWITH_TESTS=ON')
+        self.cfg.update('configopts', ' -DCMAKE_SKIP_RPATH=OFF')
+        # make sure the right Python is used (note: -DPython3_EXECUTABLE or -DPython_EXECUTABLE does not work!)
+        self.cfg.update('configopts', f' -DPYTHON_EXECUTABLE={get_software_root("Python")}/bin/python')
+
+        # list packaged files
+        pyshortver = '.'.join(get_software_version('Python').split('.')[:2])
+        _libs = [
+            'Espresso_config', 'Espresso_core', 'Espresso_script_interface',
+            'Espresso_shapes', '_init', 'analyze', 'code_info', 'electrokinetics',
+            'galilei', 'integrate', 'interactions', 'lb', 'particle_data', 'polymer',
+            'profiler', 'script_interface', 'system', 'thermostat', 'utils', 'version',
+        ]
+        _python_modules = [
+            '__init__.py', 'collision_detection.py', 'accumulators.py',
+            'constraints.py', 'electrostatics.py', 'magnetostatics.py',
+            'observables.py', 'reaction_methods.py',
+        ]
+        if get_software_root('CUDA'):
+            _libs.append('cuda_init')
+        _binaries = ['ipypresso',  'pypresso']
+        _lib_path = f'lib/python{pyshortver}/site-packages/espressomd'
+
+        return _binaries, _lib_path, _libs, _python_modules
 
     def _configure_step_release_500(self):
         cpu_features = get_cpu_features()
-        for dep in ['CUDA', 'GSL', 'FFTW', 'PYTHON', 'SCAFACOS', 'HDF5', 'NLOPT']:
+        for dep in ['CUDA', 'GSL', 'FFTW', 'Python', 'ScaFaCoS', 'HDF5', 'NLopt']:
+            dep_flag = 'OFF'
+            if get_software_root(dep):
+                dep_flag = 'ON'
+            self.cfg.update('configopts', f"-DESPRESSO_BUILD_WITH_{dep.upper()}={dep_flag}")
+        if get_software_root('Kokkos') and get_software_root('Cabana'):
+            self.cfg.update('configopts', ' -DESPRESSO_BUILD_WITH_SHARED_MEMORY_PARALLELISM=ON')
+        self.cfg.update('configopts', ' -DESPRESSO_BUILD_WITH_STOKESIAN_DYNAMICS=OFF')
+        self.cfg.update('configopts', ' -DESPRESSO_BUILD_WITH_WALBERLA=ON')
+        if get_cpu_architecture() == X86_64 and 'avx2' in cpu_features:
+            self.cfg.update('configopts', ' -DESPRESSO_BUILD_WITH_WALBERLA_AVX=ON')
+        self.cfg.update('configopts', ' -DESPRESSO_BUILD_TESTS=ON')
+        self._set_exe_linker_flags()
+
+        # build_cmd_targets does not work with CMakeNinja, use buildopts instead
+        self.cfg['buildopts'] = 'espresso_packaging_dependencies'
+
+        # list packaged files
+        pyshortver = '.'.join(get_software_version('Python').split('.')[:2])
+        _libs = [
+            'espresso_core', 'espresso_shapes', 'espresso_walberla',
+            'espresso_script_interface', 'script_interface', 'utils', '_init',
+        ]
+        _python_modules = [
+            '__init__.py', 'accumulators.py', 'collision_detection.py',
+            'constraints.py', 'electrokinetics.py', 'electrostatics.py',
+            'magnetostatics.py', 'lb.py', 'lees_edwards.py', 'observables.py',
+            'particle_data.py', 'reaction_methods.py', 'system.py',
+            'thermostat.py', 'version.py',
+        ]
+        if get_software_root('HDF5'):
+            _libs.append('espresso_hdf5')
+            _python_modules.append('io/writer/h5md.py')
+        if get_software_root('CUDA'):
+            _python_modules.append('cuda_init.py')
+        _binaries = ['ipypresso',  'pypresso']
+        _lib_path = f'lib/python{pyshortver}/site-packages/espressomd'
+
+        return _binaries, _lib_path, _libs, _python_modules
+
+    def _configure_step_release_510(self):
+        cpu_features = get_cpu_features()
+        for dep in ['CUDA', 'GSL', 'FFTW', 'Python', 'ScaFaCoS', 'HDF5', 'NLopt']:
             dep_flag = 'OFF'
             if get_software_root(dep):
                 dep_flag = 'ON'
@@ -114,6 +197,33 @@ class EB_ESPResSo(CMakeNinja):
         if get_cpu_architecture() == X86_64 and 'avx2' in cpu_features:
             self.cfg.update('configopts', ' -DESPRESSO_BUILD_WITH_WALBERLA_AVX=ON')
         self.cfg.update('configopts', ' -DESPRESSO_BUILD_TESTS=ON')
+        self._set_exe_linker_flags()
+
+        # build_cmd_targets does not work with CMakeNinja, use buildopts instead
+        self.cfg['buildopts'] = 'espresso_packaging_dependencies'
+
+        # list packaged files
+        pyshortver = '.'.join(get_software_version('Python').split('.')[:2])
+        _libs = [
+            'espresso_core', 'espresso_shapes', 'espresso_walberla',
+            'espresso_script_interface', 'script_interface', 'utils', '_init',
+        ]
+        _python_modules = [
+            '__init__.py', 'accumulators.py', 'collision_detection.py',
+            'constraints.py', 'electrokinetics.py', 'electrostatics.py',
+            'magnetostatics.py', 'lb.py', 'lees_edwards.py', 'observables.py',
+            'particle_data.py', 'reaction_methods.py', 'system.py',
+            'thermostat.py', 'version.py',
+        ]
+        if get_software_root('HDF5'):
+            _libs.append('espresso_hdf5')
+            _python_modules.append('io/writer/h5md.py')
+        if get_software_root('CUDA'):
+            _python_modules.append('cuda_init.py')
+        _binaries = ['ipypresso',  'pypresso']
+        _lib_path = f'lib/python{pyshortver}/site-packages/espressomd'
+
+        return _binaries, _lib_path, _libs, _python_modules
 
     def configure_step(self):
         # patch FetchContent to avoid re-downloading dependencies
@@ -121,15 +231,31 @@ class EB_ESPResSo(CMakeNinja):
 
         version = self._get_version()
         if version == 'commit':
-            self._configure_step_release_500()
+            paths = self._configure_step_release_510()
+        elif version[:2] >= (5, 1):
+            paths = self._configure_step_release_510()
         elif version[:2] >= (5, 0):
-            self._configure_step_release_500()
+            paths = self._configure_step_release_500()
         elif version[:2] >= (4, 2):
-            self._configure_step_release_420()
+            paths = self._configure_step_release_420()
         else:
             raise EasyBuildError(
                 f'EasyBlock {self.__class__.__name__} doesn\'t implement the '
                 f'configure step for ESPResSo {self.version}')
+
+        _binaries, _lib_path, _libs, _python_modules = paths
+
+        self.cfg['sanity_check_paths'] = {
+            'files': [f'bin/{x}' for x in _binaries] +
+                     [f'{_lib_path}/{x}.{get_shared_lib_ext()}' for x in _libs] +
+                     [f'{_lib_path}/{x}' for x in _python_modules],
+            'dirs': ['bin', 'lib']
+        }
+        self.cfg['sanity_check_commands'] = [
+            'pypresso -h', 'ipypresso -h',
+            'pypresso -c "import espressomd.version;print(espressomd.version.friendly())"',
+            'python3 -c "import espressomd.version;print(espressomd.version.friendly())"',
+        ]
 
         return super(EB_ESPResSo, self).configure_step()
 

--- a/easybuild/easyblocks/e/espresso.py
+++ b/easybuild/easyblocks/e/espresso.py
@@ -23,14 +23,12 @@ import os
 import re
 
 from easybuild.easyblocks.generic.cmakeninja import CMakeNinja
-from easybuild.tools.systemtools import get_cpu_architecture, get_cpu_features
-from easybuild.tools.systemtools import X86_64
-from easybuild.tools.systemtools import get_shared_lib_ext
-from easybuild.tools.utilities import trace_msg
-from easybuild.tools.build_log import EasyBuildError, print_error
-from easybuild.tools.filetools import remove_file, remove_dir
-from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools import LooseVersion
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.filetools import read_file, remove_dir, remove_file, write_file
+from easybuild.tools.modules import get_software_root, get_software_version
+from easybuild.tools.systemtools import X86_64, get_cpu_architecture, get_cpu_features, get_shared_lib_ext
+from easybuild.tools.utilities import trace_msg
 
 
 class EB_ESPResSo(CMakeNinja):
@@ -74,8 +72,9 @@ class EB_ESPResSo(CMakeNinja):
             cmakelists_path = os.path.join(extracted_paths['espresso'], 'CMakeLists.txt')
         else:
             raise EasyBuildError(f"espresso not found in extracted_paths dict: {extracted_paths}")
-        with open(cmakelists_path, 'r') as f:
-            content = f.read()
+
+        content = read_file(cmakelists_path)
+
         for name, local_uri in extracted_paths.items():
             if name == 'espresso':
                 continue
@@ -84,10 +83,13 @@ class EB_ESPResSo(CMakeNinja):
             if m is None:
                 raise EasyBuildError(f'{name} is not part of the ESPResSo FetchContent workflow')
             content = re.sub(pattern, f'FetchContent_Declare({name} URL {local_uri}', content, flags=re.IGNORECASE)
-        with open(cmakelists_path, 'w') as f:
-            f.write(content)
+
+        write_file(cmakelists_path, content)
 
     def _get_version(self):
+        """
+        Internal helper function to get ESPResSo version
+        """
         if '.' in self.version:
             version = tuple(LooseVersion(self.version).version)
         else:
@@ -95,6 +97,9 @@ class EB_ESPResSo(CMakeNinja):
         return version
 
     def _set_exe_linker_flags(self):
+        """
+        Internal helper function to set DCMAKE_EXE_LINKER_FLAGS configure option
+        """
         exe_linker_flags_relpaths = []
         if get_software_root('HeFFTe'):
             exe_linker_flags_relpaths.append('heffte-build')
@@ -111,7 +116,10 @@ class EB_ESPResSo(CMakeNinja):
                                         for path in exe_linker_flags_relpaths)
             self.cfg.update('configopts', f' -DCMAKE_EXE_LINKER_FLAGS="-Wl,-rpath-link,{exe_linker_flags}" ')
 
-    def _configure_step_release_420(self):
+    def _set_configure_options_release_420(self):
+        """
+        Internal helper function to set configure options for ESPResSo v4.2+ (< 5.0)
+        """
         for dep in ['CUDA', 'GSL', 'FFTW', 'Python', 'ScaFaCoS']:
             dep_flag = 'OFF'
             if get_software_root(dep):
@@ -123,35 +131,21 @@ class EB_ESPResSo(CMakeNinja):
         # make sure the right Python is used (note: -DPython3_EXECUTABLE or -DPython_EXECUTABLE does not work!)
         self.cfg.update('configopts', f' -DPYTHON_EXECUTABLE={get_software_root("Python")}/bin/python')
 
-        # list packaged files
-        pyshortver = '.'.join(get_software_version('Python').split('.')[:2])
-        _libs = [
-            'Espresso_config', 'Espresso_core', 'Espresso_script_interface',
-            'Espresso_shapes', '_init', 'analyze', 'code_info', 'electrokinetics',
-            'galilei', 'integrate', 'interactions', 'lb', 'particle_data', 'polymer',
-            'profiler', 'script_interface', 'system', 'thermostat', 'utils', 'version',
-        ]
-        _python_modules = [
-            '__init__.py', 'collision_detection.py', 'accumulators.py',
-            'constraints.py', 'electrostatics.py', 'magnetostatics.py',
-            'observables.py', 'reaction_methods.py',
-        ]
-        if get_software_root('CUDA'):
-            _libs.append('cuda_init')
-        _binaries = ['ipypresso',  'pypresso']
-        _lib_path = f'lib/python{pyshortver}/site-packages/espressomd'
-
-        return _binaries, _lib_path, _libs, _python_modules
-
-    def _configure_step_release_500(self):
+    def _set_configure_options_release_500(self):
+        """
+        Internal helper function to set configure options for ESPResSo v5.0
+        """
         cpu_features = get_cpu_features()
         for dep in ['CUDA', 'GSL', 'FFTW', 'Python', 'ScaFaCoS', 'HDF5', 'NLopt']:
             dep_flag = 'OFF'
             if get_software_root(dep):
                 dep_flag = 'ON'
             self.cfg.update('configopts', f"-DESPRESSO_BUILD_WITH_{dep.upper()}={dep_flag}")
-        if get_software_root('Kokkos') and get_software_root('Cabana'):
+
+        version = self._get_version()
+        if version[:2] < (5, 1) and get_software_root('Kokkos') and get_software_root('Cabana'):
             self.cfg.update('configopts', ' -DESPRESSO_BUILD_WITH_SHARED_MEMORY_PARALLELISM=ON')
+
         self.cfg.update('configopts', ' -DESPRESSO_BUILD_WITH_STOKESIAN_DYNAMICS=OFF')
         self.cfg.update('configopts', ' -DESPRESSO_BUILD_WITH_WALBERLA=ON')
         if get_cpu_architecture() == X86_64 and 'avx2' in cpu_features:
@@ -161,105 +155,30 @@ class EB_ESPResSo(CMakeNinja):
 
         # build_cmd_targets does not work with CMakeNinja, use buildopts instead
         self.cfg['buildopts'] = 'espresso_packaging_dependencies'
-
-        # list packaged files
-        pyshortver = '.'.join(get_software_version('Python').split('.')[:2])
-        _libs = [
-            'espresso_core', 'espresso_shapes', 'espresso_walberla',
-            'espresso_script_interface', 'script_interface', 'utils', '_init',
-        ]
-        _python_modules = [
-            '__init__.py', 'accumulators.py', 'collision_detection.py',
-            'constraints.py', 'electrokinetics.py', 'electrostatics.py',
-            'magnetostatics.py', 'lb.py', 'lees_edwards.py', 'observables.py',
-            'particle_data.py', 'reaction_methods.py', 'system.py',
-            'thermostat.py', 'version.py',
-        ]
-        if get_software_root('HDF5'):
-            _libs.append('espresso_hdf5')
-            _python_modules.append('io/writer/h5md.py')
-        if get_software_root('CUDA'):
-            _python_modules.append('cuda_init.py')
-        _binaries = ['ipypresso',  'pypresso']
-        _lib_path = f'lib/python{pyshortver}/site-packages/espressomd'
-
-        return _binaries, _lib_path, _libs, _python_modules
-
-    def _configure_step_release_510(self):
-        cpu_features = get_cpu_features()
-        for dep in ['CUDA', 'GSL', 'FFTW', 'Python', 'ScaFaCoS', 'HDF5', 'NLopt']:
-            dep_flag = 'OFF'
-            if get_software_root(dep):
-                dep_flag = 'ON'
-            self.cfg.update('configopts', f"-DESPRESSO_BUILD_WITH_{dep.upper()}={dep_flag}")
-        self.cfg.update('configopts', ' -DESPRESSO_BUILD_WITH_STOKESIAN_DYNAMICS=OFF')
-        self.cfg.update('configopts', ' -DESPRESSO_BUILD_WITH_WALBERLA=ON')
-        if get_cpu_architecture() == X86_64 and 'avx2' in cpu_features:
-            self.cfg.update('configopts', ' -DESPRESSO_BUILD_WITH_WALBERLA_AVX=ON')
-        self.cfg.update('configopts', ' -DESPRESSO_BUILD_TESTS=ON')
-        self._set_exe_linker_flags()
-
-        # build_cmd_targets does not work with CMakeNinja, use buildopts instead
-        self.cfg['buildopts'] = 'espresso_packaging_dependencies'
-
-        # list packaged files
-        pyshortver = '.'.join(get_software_version('Python').split('.')[:2])
-        _libs = [
-            'espresso_core', 'espresso_shapes', 'espresso_walberla',
-            'espresso_script_interface', 'script_interface', 'utils', '_init',
-        ]
-        _python_modules = [
-            '__init__.py', 'accumulators.py', 'collision_detection.py',
-            'constraints.py', 'electrokinetics.py', 'electrostatics.py',
-            'magnetostatics.py', 'lb.py', 'lees_edwards.py', 'observables.py',
-            'particle_data.py', 'reaction_methods.py', 'system.py',
-            'thermostat.py', 'version.py',
-        ]
-        if get_software_root('HDF5'):
-            _libs.append('espresso_hdf5')
-            _python_modules.append('io/writer/h5md.py')
-        if get_software_root('CUDA'):
-            _python_modules.append('cuda_init.py')
-        _binaries = ['ipypresso',  'pypresso']
-        _lib_path = f'lib/python{pyshortver}/site-packages/espressomd'
-
-        return _binaries, _lib_path, _libs, _python_modules
 
     def configure_step(self):
+        """
+        Custom configure step for ESPResSo
+        """
         # patch FetchContent to avoid re-downloading dependencies
         self._patch_fetchcontent()
 
         version = self._get_version()
-        if version == 'commit':
-            paths = self._configure_step_release_510()
-        elif version[:2] >= (5, 1):
-            paths = self._configure_step_release_510()
-        elif version[:2] >= (5, 0):
-            paths = self._configure_step_release_500()
+        if version[:2] >= (5, 0):
+            paths = self._set_configure_options_release_500()
         elif version[:2] >= (4, 2):
-            paths = self._configure_step_release_420()
+            paths = self._set_configure_options_release_420()
         else:
             raise EasyBuildError(
                 f'EasyBlock {self.__class__.__name__} doesn\'t implement the '
                 f'configure step for ESPResSo {self.version}')
 
-        _binaries, _lib_path, _libs, _python_modules = paths
-
-        self.cfg['sanity_check_paths'] = {
-            'files': [f'bin/{x}' for x in _binaries] +
-                     [f'{_lib_path}/{x}.{get_shared_lib_ext()}' for x in _libs] +
-                     [f'{_lib_path}/{x}' for x in _python_modules],
-            'dirs': ['bin', 'lib']
-        }
-        self.cfg['sanity_check_commands'] = [
-            'pypresso -h', 'ipypresso -h',
-            'pypresso -c "import espressomd.version;print(espressomd.version.friendly())"',
-            'python3 -c "import espressomd.version;print(espressomd.version.friendly())"',
-        ]
-
         return super(EB_ESPResSo, self).configure_step()
 
     def test_step(self):
+        """
+        Custom test step for ESPResSo
+        """
         version = self._get_version()
         if version == 'commit' or version[:2] >= (5, 0):
             testopts = self.cfg.get('testopts', '')
@@ -298,9 +217,78 @@ class EB_ESPResSo(CMakeNinja):
                     delete_file(f'{lib_dir}/{path}')
 
     def post_processing_step(self):
+        """
+        Custom post-processing step for ESPResSo: clean up some auxilary files
+        """
         try:
             self._cleanup_aux_files()
         except Exception as err:
-            print_error('Failed to remove some auxiliary files '
-                        f'(easyblock: {self.__class__.__name__}): {err}')
+            error_msg = "Failed to remove some auxiliary files "
+            error_msg = f"(easyblock: {self.__class__.__name__}): {err}"
+            raise EasyBuildError(error_msg)
         return super(EB_ESPResSo, self).post_processing_step()
+
+    def sanity_check_step(self):
+        """
+        Custom sanity check step for ESPResSo
+        """
+        version = self._get_version()
+
+        # libraries
+        if version[:2] >= (5, 0):
+            _libs = [
+                'espresso_core', 'espresso_shapes', 'espresso_walberla',
+                'espresso_script_interface', 'script_interface', 'utils', '_init',
+            ]
+        else:
+            _libs = [
+                'Espresso_config', 'Espresso_core', 'Espresso_script_interface',
+                'Espresso_shapes', '_init', 'analyze', 'code_info', 'electrokinetics',
+                'galilei', 'integrate', 'interactions', 'lb', 'particle_data', 'polymer',
+                'profiler', 'script_interface', 'system', 'thermostat', 'utils', 'version',
+            ]
+
+        # Python modules
+        _python_modules = [
+            '__init__.py', 'collision_detection.py', 'accumulators.py',
+            'constraints.py', 'electrostatics.py', 'magnetostatics.py',
+            'observables.py', 'reaction_methods.py',
+        ]
+        if version[:2] >= (5, 0):
+            _extra_python_modules = [
+                'electrokinetics.py', 'lb.py', 'lees_edwards.py',
+                'particle_data.py', 'system.py', 'thermostat.py', 'version.py',
+            ]
+            _python_modules = sorted(_python_modules + _extra_python_modules)
+
+        if get_software_root('HDF5'):
+            _libs.append('espresso_hdf5')
+            _python_modules.append(os.path.join('io', 'writer', 'h5md.py'))
+        if get_software_root('CUDA'):
+            if version[:2] >= (5, 0):
+                _python_modules.append('cuda_init.py')
+            else:
+                _libs.append('cuda_init')
+
+        # binaries
+        _binaries = ['ipypresso',  'pypresso']
+
+        # Python package directory
+        pyshortver = '.'.join(get_software_version('Python').split('.')[:2])
+        _lib_path = f'lib/python{pyshortver}/site-packages/espressomd'
+
+        custom_paths = {
+            'files': [f'bin/{x}' for x in _binaries] +
+                        [f'{_lib_path}/{x}.{get_shared_lib_ext()}' for x in _libs] +
+                        [f'{_lib_path}/{x}' for x in _python_modules],
+            'dirs': ['bin', 'lib']
+        }
+        custom_commands = [
+            "pypresso -h",
+            "ipypresso -h",
+            'pypresso -c "import espressomd.version;print(espressomd.version.friendly())"',
+            'python3 -c "import espressomd.version;print(espressomd.version.friendly())"',
+        ]
+
+        # call out to parent to do the actual sanity checking, pass through custom paths
+        super().sanity_check_step(custom_paths=custom_paths, custom_commads=custom_commands)

--- a/easybuild/easyblocks/e/espresso.py
+++ b/easybuild/easyblocks/e/espresso.py
@@ -277,11 +277,12 @@ class EB_ESPResSo(CMakeNinja):
         pyshortver = '.'.join(get_software_version('Python').split('.')[:2])
         _lib_path = f'lib/python{pyshortver}/site-packages/espressomd'
 
+        files = [f'bin/{x}' for x in _binaries]
+        files += [f'{_lib_path}/{x}.{get_shared_lib_ext()}' for x in _libs]
+        files += [f'{_lib_path}/{x}' for x in _python_modules]
         custom_paths = {
-            'files': [f'bin/{x}' for x in _binaries] +
-                        [f'{_lib_path}/{x}.{get_shared_lib_ext()}' for x in _libs] +
-                        [f'{_lib_path}/{x}' for x in _python_modules],
-            'dirs': ['bin', 'lib']
+            'files': files,
+            'dirs': [],
         }
         custom_commands = [
             "pypresso -h",
@@ -291,4 +292,4 @@ class EB_ESPResSo(CMakeNinja):
         ]
 
         # call out to parent to do the actual sanity checking, pass through custom paths
-        super().sanity_check_step(custom_paths=custom_paths, custom_commads=custom_commands)
+        super().sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)

--- a/easybuild/easyblocks/e/espresso.py
+++ b/easybuild/easyblocks/e/espresso.py
@@ -26,8 +26,9 @@ from easybuild.easyblocks.generic.cmakeninja import CMakeNinja
 from easybuild.tools.systemtools import get_cpu_architecture, get_cpu_features
 from easybuild.tools.systemtools import X86_64
 from easybuild.tools.utilities import trace_msg
-from easybuild.tools.build_log import print_error
+from easybuild.tools.build_log import EasyBuildError, print_error
 from easybuild.tools.filetools import remove_file, remove_dir
+from easybuild.tools.modules import get_software_root
 from easybuild.tools import LooseVersion
 
 
@@ -47,14 +48,17 @@ class EB_ESPResSo(CMakeNinja):
                 continue
             # process dependencies
             tarball = src['name']
-            if not tarball.endswith('.tar.gz'):
-                raise ValueError(tarball + ' is not a tar.gz file')
-            prefix = tarball.rsplit('.', 2)[0]
-            matches = [x for x in os.listdir(src['finalpath']) if x.startswith(prefix)]
+            if tarball.endswith(('.tar.bz2', '.tar.gz', '.tar.xz', '.tar.lz', '.tar.lz4', '.tar.Z')):
+                prefix = tarball.rsplit('.', 2)[0]
+            elif tarball.endswith(('.zip', '.7z', '.tar')):
+                prefix = tarball.rsplit('.', 1)[0]
+            else:
+                raise EasyBuildError(f'unexpected archive/compression format: {tarball}')
+            matches = [x for x in os.listdir(src['finalpath']) if x.lower().startswith(prefix.lower())]
             if len(matches) == 0:
-                raise RuntimeError(tarball + ' was not extracted')
+                raise EasyBuildError(f'{tarball} was not extracted')
             if len(matches) > 1:
-                raise RuntimeError(tarball + ' matches multiple folders: ' + str(matches))
+                raise EasyBuildError(f'{tarball} matches multiple folders: {matches}')
             extracted_paths[name] = os.path.join(src['finalpath'], matches[0])
         return extracted_paths
 
@@ -65,7 +69,10 @@ class EB_ESPResSo(CMakeNinja):
         This avoids a download step during configuration.
         """
         extracted_paths = self._get_extracted_tarball_paths()
-        cmakelists_path = os.path.join(extracted_paths['espresso'], 'CMakeLists.txt')
+        if 'espresso' in extracted_paths.keys():
+            cmakelists_path = os.path.join(extracted_paths['espresso'], 'CMakeLists.txt')
+        else:
+            raise EasyBuildError(f"espresso not found in extracted_paths dict: {extracted_paths}")
         with open(cmakelists_path, 'r') as f:
             content = f.read()
         for name, local_uri in extracted_paths.items():
@@ -74,7 +81,7 @@ class EB_ESPResSo(CMakeNinja):
             pattern = fr'FetchContent_Declare\(\s*{name}\s+GIT_REPOSITORY\s+\S+\s+GIT_TAG\s+\S+(?=\s|\))'
             m = re.search(pattern, content, flags=re.IGNORECASE)
             if m is None:
-                raise RuntimeError(f'{name} is not part of the ESPResSo FetchContent workflow')
+                raise EasyBuildError(f'{name} is not part of the ESPResSo FetchContent workflow')
             content = re.sub(pattern, f'FetchContent_Declare({name} URL {local_uri}', content, flags=re.IGNORECASE)
         with open(cmakelists_path, 'w') as f:
             f.write(content)
@@ -87,48 +94,26 @@ class EB_ESPResSo(CMakeNinja):
         return version
 
     def _configure_step_release_420(self):
-        configopts = self.cfg.get('configopts', '')
-        dependencies = self.cfg.dependencies()
-        dependencies_names = {x.get('name', '') for x in dependencies}
-
-        def cmake_if_has(name):
-            return 'ON' if name in dependencies_names else 'OFF'
-
-        configopts += f' -DWITH_CUDA={cmake_if_has("CUDA")}'
-        configopts += f' -DWITH_GSL={cmake_if_has("GSL")}'
-        configopts += ' -DWITH_FFTW=ON'
-        configopts += ' -DWITH_PYTHON=ON'
-        configopts += ' -DWITH_SCAFACOS=OFF'
-        configopts += ' -DWITH_STOKESIAN_DYNAMICS=OFF'
-        configopts += ' -DWITH_TESTS=ON'
-
-        self.cfg['configopts'] = configopts
+        for dep in ['CUDA', 'GSL', 'FFTW', 'PYTHON', 'SCAFACOS']:
+            dep_flag = 'OFF'
+            if get_software_root(dep):
+                dep_flag = 'ON'
+            self.cfg.update('configopts', f"-DWITH_{dep.upper()}={dep_flag}")
+        self.cfg.update('configopts', ' -DWITH_STOKESIAN_DYNAMICS=OFF')
+        self.cfg.update('configopts', ' -DWITH_TESTS=ON')
 
     def _configure_step_release_500(self):
-        configopts = self.cfg.get('configopts', '')
-        dependencies = self.cfg.dependencies()
-        dependencies_names = {x.get('name', '') for x in dependencies}
-
-        def cmake_if_has(name):
-            return 'ON' if name in dependencies_names else 'OFF'
-
         cpu_features = get_cpu_features()
-
-        configopts += f' -DESPRESSO_BUILD_WITH_CUDA={cmake_if_has("CUDA")}'
-        configopts += f' -DESPRESSO_BUILD_WITH_HDF5={cmake_if_has("HDF5")}'
-        configopts += f' -DESPRESSO_BUILD_WITH_GSL={cmake_if_has("GSL")}'
-        configopts += f' -DESPRESSO_BUILD_WITH_NLOPT={cmake_if_has("NLopt")}'
-        configopts += ' -DESPRESSO_BUILD_WITH_SHARED_MEMORY_PARALLELISM=ON'
-        configopts += ' -DESPRESSO_BUILD_WITH_WALBERLA=ON'
+        for dep in ['CUDA', 'GSL', 'FFTW', 'PYTHON', 'SCAFACOS', 'HDF5', 'NLOPT']:
+            dep_flag = 'OFF'
+            if get_software_root(dep):
+                dep_flag = 'ON'
+            self.cfg.update('configopts', f"-DESPRESSO_BUILD_WITH_{dep.upper()}={dep_flag}")
+        self.cfg.update('configopts', ' -DESPRESSO_BUILD_WITH_STOKESIAN_DYNAMICS=OFF')
+        self.cfg.update('configopts', ' -DESPRESSO_BUILD_WITH_WALBERLA=ON')
         if get_cpu_architecture() == X86_64 and 'avx2' in cpu_features:
-            configopts += ' -DESPRESSO_BUILD_WITH_WALBERLA_AVX=ON'
-        configopts += ' -DESPRESSO_BUILD_WITH_FFTW=ON'
-        configopts += ' -DESPRESSO_BUILD_WITH_PYTHON=ON'
-        configopts += ' -DESPRESSO_BUILD_WITH_SCAFACOS=OFF'
-        configopts += ' -DESPRESSO_BUILD_WITH_STOKESIAN_DYNAMICS=OFF'
-        configopts += ' -DESPRESSO_BUILD_TESTS=ON '
-
-        self.cfg['configopts'] = configopts
+            self.cfg.update('configopts', ' -DESPRESSO_BUILD_WITH_WALBERLA_AVX=ON')
+        self.cfg.update('configopts', ' -DESPRESSO_BUILD_TESTS=ON')
 
     def configure_step(self):
         # patch FetchContent to avoid re-downloading dependencies
@@ -142,7 +127,7 @@ class EB_ESPResSo(CMakeNinja):
         elif version[:2] >= (4, 2):
             self._configure_step_release_420()
         else:
-            raise NotImplementedError(
+            raise EasyBuildError(
                 f'EasyBlock {self.__class__.__name__} doesn\'t implement the '
                 f'configure step for ESPResSo {self.version}')
 


### PR DESCRIPTION
Provide an easyblock to manage CMake flags for each minor release of ESPResSo and automatically download dependencies included via the FetchContent mechanism.