### PR TITLE
[GROMACS] Support PLUMED for versions 2025 and newer

### DIFF
--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -76,6 +76,9 @@ class EB_GROMACS(CMakeMake):
             'ignore_plumed_version_check': [False, "Ignore the version compatibility check for PLUMED", CUSTOM],
             'plumed': [None, "Try to apply PLUMED patches. None (default) is auto-detect. " +
                        "True or False forces behaviour.", CUSTOM],
+            'parallel_test': [None, "Number of tests to run in parallel. Can help with hanging tests caused by " +
+                              "oversubscribed MPI processes. With None (default) the value of the parallel value " +
+                              "is used.", CUSTOM],
         })
         return extra_vars
 
@@ -564,7 +567,10 @@ class EB_GROMACS(CMakeMake):
 
                 # run 'make check' or whatever the easyconfig specifies
                 # in parallel since it involves more compilation
-                self.cfg.update('runtest', f"-j {self.cfg.parallel}")
+                if self.parallel_test:
+                    self.cfg.update('runtest', f"-j {self.parallel_test}")
+                else:
+                    self.cfg.update('runtest', f"-j {self.cfg.parallel}")
                 super().test_step()
 
                 if build_option('rpath'):

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -164,6 +164,8 @@ class EB_GROMACS(CMakeMake):
         gromacs_version = LooseVersion(self.version)
 
         if gromacs_version >= '2025':
+            # Build gromacs with PLUMED support
+            # https://manual.gromacs.org/documentation/2025.0/install-guide/index.html#building-with-plumed-support
             self.cfg.update('configopts', "-DGMX_USE_PLUMED=ON")
             return
 


### PR DESCRIPTION
This modification allows building versions of GROMACS newer than 2025.0 with support for PLUMED.

Any version of PLUMED is supported. From the [official documentation](https://manual.gromacs.org/documentation/2025.0/install-guide/index.html#building-with-plumed-support):

> GROMACS bundles the interface from version 2.10 of the [PLUMED library](https://www.plumed.org/) in its source distribution. The interface is compatible with any PLUMED version.

So in theory there is no need to check compatibility between versions of GROMACS and PLUMED in this new mechanism.