### PR TITLE
add guard to sanity check in custom easyblock for Stata to avoid running `ldd` on non ELF executable

### DIFF
--- a/easybuild/easyblocks/s/stata.py
+++ b/easybuild/easyblocks/s/stata.py
@@ -71,14 +71,14 @@ class EB_Stata(PackedBinary):
 
         stata_bin = os.path.join(self.installdir, "stata")
 
-        res = run_shell_cmd("file %s" % stata_bin)
+        res = run_shell_cmd(f"file {stata_bin}")
         # guard against installations using a wrapper for stata
         if 'ELF' in res.output:
             # make sure required libpng library is there for Stata
             # Stata depends on a very old version of libpng, so we need to provide it
-            res = run_shell_cmd("ldd %s" % os.path.join(self.installdir, 'stata'))
+            res = run_shell_cmd(f"ldd {stata_bin}")
             regex = re.compile('libpng.*not found', re.M)
             if regex.search(res.output):
                 raise EasyBuildError("Required libpng library for 'stata' is not available")
         else:
-            self.log.info("sanity_check_step: %s is not an ELF binary, skipping ldd check" % stata_bin)
+            self.log.info(f"sanity_check_step: {stata_bin} is not an ELF binary, skipping ldd check")


### PR DESCRIPTION
If "stata" program is not an ELF executable, don't run the ldd check.


Used in combination with a hook that creates a wrapper for stata
(the hook code was generated by Claude)

```
def post_install_hook_stata(self, *args, **kwargs):
    self.log.info(f"post_install_hook_stata: STARTED for {self.name} in {self.installdir}")
    if self.name.lower() == "stata":
        try:
            binaries = ['stata', 'stata-se', 'stata-mp']
            orig_dir = os.path.join(self.installdir, '.stata-orig')
            os.makedirs(orig_dir, exist_ok=True)

            # --- Resolve dependency lib paths ---
            lib_paths = []
            deps = self.cfg['dependencies']
            for dep in deps:
                dep_name = dep["name"]
                dep_root = get_software_root(dep_name)
                if not dep_root:
                    software_base = os.path.dirname(os.path.dirname(self.installdir))
                    dep_version = dep.get("version", "")
                    dep_root = os.path.join(software_base, dep_name, dep_version)

                lib_path = os.path.join(dep_root, "lib")
                if os.path.isdir(lib_path):
                    lib_paths.append(lib_path)
                    self.log.info(f"post_install_hook_stata: found lib path {lib_path}")
                else:
                    self.log.warning(f"post_install_hook_stata: {lib_path} not found, skipping")

            # --- EESSI compat layer paths ---
            eessi_compat = "/cvmfs/software.eessi.io/versions/2025.06/compat/linux/x86_64"
            eessi_linker = os.path.join(eessi_compat, "lib64", "ld-linux-x86-64.so.2")
            for lib_dir in ["lib64", "lib"]:
                p = os.path.join(eessi_compat, lib_dir)
                if os.path.isdir(p):
                    lib_paths.append(p)

            ld_library_path = ":".join(lib_paths)

            # --- Move originals and create wrappers ---
            for binary in binaries:
                binary_path = os.path.join(self.installdir, binary)
                if not os.path.isfile(binary_path):
                    self.log.warning(f"post_install_hook_stata: {binary} not found, skipping")
                    continue

                # Move original binary to .stata-orig/
                orig_path = os.path.join(orig_dir, binary)
                os.rename(binary_path, orig_path)
                self.log.info(f"post_install_hook_stata: moved {binary_path} -> {orig_path}")

                # Write wrapper script in its place
                wrapper = f"""#!/usr/bin/env bash
STATA_DIR="$(dirname "$(readlink -f "$0")")"
export LD_LIBRARY_PATH="{ld_library_path}${{LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}}"
exec "{eessi_linker}" "${{STATA_DIR}}/.stata-orig/{binary}" "$@"
"""
                with open(binary_path, 'w') as f:
                    f.write(wrapper)
                # rwxr-xr-x
                os.chmod(binary_path,
                         stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP |
                         stat.S_IROTH | stat.S_IXOTH)
                self.log.info(f"post_install_hook_stata: created wrapper at {binary_path}")

        except Exception as e:
            self.log.error(f"post_install_hook_stata: Error: {e}")
            raise
    else:
        raise EasyBuildError("stata-specific hook triggered for non-stata easyconfig?!")
```