### PR TITLE
add search paths to CUPTI in installations of nvidia-compilers with CUDA

### DIFF
--- a/easybuild/easyblocks/generic/nvidiabase.py
+++ b/easybuild/easyblocks/generic/nvidiabase.py
@@ -367,6 +367,11 @@ class NvidiaBase(PackedBinary):
             self.module_load_environment.LD_LIBRARY_PATH.append(os.path.join(cuda_basedir, 'lib64'))
             for cpp_header in self.module_load_environment.alias(MODULE_LOAD_ENV_HEADERS):
                 cpp_header.append(os.path.join(cuda_basedir, 'include'))
+            # add CUPTI
+            cupti_basedir = os.path.join(cuda_basedir, str(self.active_cuda_version), 'extras', 'CUPTI')
+            self.module_load_environment.LD_LIBRARY_PATH.append(os.path.join(cupti_basedir, 'lib64'))
+            for cpp_header in self.module_load_environment.alias(MODULE_LOAD_ENV_HEADERS):
+                cpp_header.append(os.path.join(cupti_basedir, 'include'))
             # emulate environment from standalone CUDA
             cuda_home = os.path.join(self.installdir, cuda_basedir)
             self.cfg.update('modextravars', {


### PR DESCRIPTION
This PR changes `CPATH`, `LD_LIBRARY_PATH` and `LIBRARY_PATH` in the module files of `nvidia-compilers` as follows:

```
prepend_path("CPATH", pathJoin(root, "Linux_x86_64", "25.1", "cuda", "12.6", "targets", "x86_64-linux", "include"))
+ prepend_path("CPATH", pathJoin(root, "Linux_x86_64", "25.1", "cuda", "12.6", "extras", "CUPTI", "include"))
prepend_path("LD_LIBRARY_PATH", pathJoin(root, "Linux_x86_64", "25.1", "compilers", "lib"))
prepend_path("LD_LIBRARY_PATH", pathJoin(root, "Linux_x86_64", "25.1", "cuda", "12.6", "targets", "x86_64-linux", "lib"))
+ prepend_path("LD_LIBRARY_PATH", pathJoin(root, "Linux_x86_64", "25.1", "cuda", "12.6", "extras", "CUPTI", "lib64"))
prepend_path("LIBRARY_PATH", pathJoin(root, "Linux_x86_64", "25.1", "compilers", "lib"))
prepend_path("LIBRARY_PATH", pathJoin(root, "Linux_x86_64", "25.1", "cuda", "12.6", "targets", "x86_64-linux", "lib"))
+ prepend_path("LIBRARY_PATH", pathJoin(root, "Linux_x86_64", "25.1", "cuda", "12.6", "extras", "CUPTI", "lib64"))
```