### PR TITLE
Make sure that netcdf easyblock picks up the EB-provided libxml2 and bzip2

### DIFF
--- a/easybuild/easyblocks/n/netcdf.py
+++ b/easybuild/easyblocks/n/netcdf.py
@@ -68,8 +68,8 @@ class EB_netCDF(CMakeMake):
             ConfigureMake.configure_step(self)
 
         else:
-            for (dep, libname) in [('cURL', 'curl'), ('HDF5', 'hdf5'), ('Szip', 'sz'), ('zlib', 'z'),
-                                   ('PnetCDF', 'pnetcdf')]:
+            for (dep, libname) in [('cURL', 'curl'), ('HDF5', 'hdf5'), ('libxml2', 'xml2'), ('PnetCDF', 'pnetcdf'),
+                                   ('Szip', 'sz'), ('zlib', 'z')]:
                 dep_root = get_software_root(dep)
                 dep_libdir = get_software_libdir(dep)
 

--- a/easybuild/easyblocks/n/netcdf.py
+++ b/easybuild/easyblocks/n/netcdf.py
@@ -68,8 +68,8 @@ class EB_netCDF(CMakeMake):
             ConfigureMake.configure_step(self)
 
         else:
-            for (dep, libname) in [('cURL', 'curl'), ('HDF5', 'hdf5'), ('libxml2', 'xml2'), ('PnetCDF', 'pnetcdf'),
-                                   ('Szip', 'sz'), ('zlib', 'z')]:
+            for (dep, libname) in [('bzip2', 'bz2'), ('cURL', 'curl'), ('HDF5', 'hdf5'), ('libxml2', 'xml2'),
+                                   ('PnetCDF', 'pnetcdf'), ('Szip', 'sz'), ('zlib', 'z')]:
                 dep_root = get_software_root(dep)
                 dep_libdir = get_software_libdir(dep)
 


### PR DESCRIPTION
bzip2 and libxml2 were added as dependencies in easyconfigs for netCDF 4.9.0 and later, but in EESSI we noticed that it picked up the ones from the compat/OS layer. The easyblock already passes the paths to other dependencies with CMake variables, let's do the same for bzip2 and libxml2. Hat tip @julianmorillo.

See https://github.com/EESSI/dev.eessi.io-riscv/pull/72 and https://github.com/EESSI/software-layer/pull/1432.