### PR TITLE
Update `Boost` sanity checks for versions 1.89 and newer

### DIFF
--- a/easybuild/easyblocks/b/boost.py
+++ b/easybuild/easyblocks/b/boost.py
@@ -348,10 +348,12 @@ class EB_Boost(EasyBlock):
                         os.path.join('lib', 'libboost_python%s%s.%s' % (suffix, lib_mt_suffix, shlib_ext)))
 
         else:
-            custom_paths['files'].append(os.path.join('lib', 'libboost_system.%s' % shlib_ext))
+            if LooseVersion(self.version) <= LooseVersion("1.88.0"):
+                custom_paths['files'].append(os.path.join('lib', 'libboost_system.%s' % shlib_ext))
 
             if self.cfg['tagged_layout']:
-                custom_paths['files'].append(os.path.join('lib', 'libboost_system%s.%s' % (lib_mt_suffix, shlib_ext)))
+                if LooseVersion(self.version) <= LooseVersion("1.88.0"):
+                    custom_paths['files'].append(os.path.join('lib', 'libboost_system%s.%s' % (lib_mt_suffix, shlib_ext)))
                 custom_paths['files'].append(os.path.join('lib', 'libboost_thread%s.%s' % (lib_mt_suffix, shlib_ext)))
 
             if self.cfg['boost_mpi']:

--- a/easybuild/easyblocks/b/boost.py
+++ b/easybuild/easyblocks/b/boost.py
@@ -353,7 +353,8 @@ class EB_Boost(EasyBlock):
 
             if self.cfg['tagged_layout']:
                 if LooseVersion(self.version) <= LooseVersion("1.88.0"):
-                    custom_paths['files'].append(os.path.join('lib', 'libboost_system%s.%s' % (lib_mt_suffix, shlib_ext)))
+                    p = os.path.join('lib', 'libboost_system%s.%s' % (lib_mt_suffix, shlib_ext))
+                    custom_paths['files'].append(p)
                 custom_paths['files'].append(os.path.join('lib', 'libboost_thread%s.%s' % (lib_mt_suffix, shlib_ext)))
 
             if self.cfg['boost_mpi']:


### PR DESCRIPTION
…igher

 See https://github.com/boostorg/system/commit/7a495bb46d7ccd808e4be2a6589260839b0fd3a3
 
 Else, sanity checks fails with 
 ```
 ERROR: Installation of Boost-1.90.0-GCCcore-12.3.0-core.eb failed: Sanity check failed: no file found at 'lib/libboost_system.so' in .local/easybuild/software/2023/x86-64-v3/Compiler/gcccore/boost-core/1.90.0
 ```