### PR TITLE
Consistently use `get_cuda_cc_template_value` instead of raw values.

### DIFF
--- a/easybuild/easyblocks/a/aomp.py
+++ b/easybuild/easyblocks/a/aomp.py
@@ -33,7 +33,6 @@ import os
 from easybuild.easyblocks.generic.binary import Binary
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError, print_warning
-from easybuild.tools.config import build_option
 from easybuild.tools.filetools import move_file, remove_file
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.systemtools import AARCH64, POWER, X86_64
@@ -87,29 +86,12 @@ class EB_AOMP(Binary):
         ]
         install_options.append(f'NUM_THREADS={self.cfg.parallel}')
         # Check if CUDA is loaded and alternatively build CUDA backend
-        if get_software_root('CUDA') or get_software_root('CUDAcore'):
-            cuda_root = get_software_root('CUDA') or get_software_root('CUDAcore')
+        cuda_root = get_software_root('CUDA') or get_software_root('CUDAcore')
+        if cuda_root:
             install_options.append('AOMP_BUILD_CUDA=1')
-            install_options.append('CUDA="{!s}"'.format(cuda_root))
-            # list of CUDA compute capabilities to use can be specifed in two ways (where (2) overrules (1)):
-            # (1) in the easyconfig file, via the custom cuda_compute_capabilities;
-            # (2) in the EasyBuild configuration, via --cuda-compute-capabilities configuration option;
-            ec_cuda_cc = self.cfg['cuda_compute_capabilities']
-            cfg_cuda_cc = build_option('cuda_compute_capabilities')
-            cuda_cc = cfg_cuda_cc or ec_cuda_cc or []
-            if cfg_cuda_cc and ec_cuda_cc:
-                warning_msg = "cuda_compute_capabilities specified in easyconfig (%s) are overruled by " % ec_cuda_cc
-                warning_msg += "--cuda-compute-capabilities configuration option (%s)" % cfg_cuda_cc
-                print_warning(warning_msg)
-            if not cuda_cc:
-                raise EasyBuildError("CUDA module was loaded, "
-                                     "indicating a build with CUDA, "
-                                     "but no CUDA compute capability "
-                                     "was specified!")
-            # Convert '7.0' to '70' format
-            cuda_cc = [cc.replace('.', '') for cc in cuda_cc]
-            cuda_str = ",".join(cuda_cc)
-            install_options.append('NVPTXGPUS="{!s}"'.format(cuda_str))
+            install_options.append(f'CUDA="{cuda_root}"')
+            cuda_str = self.cfg.get_cuda_cc_template_value('cuda_int_comma_sep')
+            install_options.append(f'NVPTXGPUS="{cuda_str}"')
         else:
             # Explicitly disable CUDA
             install_options.append('AOMP_BUILD_CUDA=0')

--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -419,23 +419,14 @@ class EB_Clang(CMakeMake):
 
         # If 'NVPTX' is in the build targets we assume the user would like OpenMP offload support as well
         if 'NVPTX' in build_targets:
-            # list of CUDA compute capabilities to use can be specifed in two ways (where (2) overrules (1)):
-            # (1) in the easyconfig file, via the custom cuda_compute_capabilities;
-            # (2) in the EasyBuild configuration, via --cuda-compute-capabilities configuration option;
-            ec_cuda_cc = self.cfg['cuda_compute_capabilities']
-            cfg_cuda_cc = build_option('cuda_compute_capabilities')
-            cuda_cc = cfg_cuda_cc or ec_cuda_cc or []
-            if not cuda_cc:
-                raise EasyBuildError("Can't build Clang with CUDA support "
-                                     "without specifying 'cuda-compute-capabilities'")
-            default_cc = self.cfg['default_cuda_capability'] or min(cuda_cc)
+            cuda_cc = self.cfg.get_cuda_cc_template_value('cuda_int_comma_sep')
+            default_cc = self.cfg['default_cuda_capability'] or min(cuda_cc.split(), key=int)
             if not self.cfg['default_cuda_capability']:
                 print_warning("No default CUDA capability defined! "
                               "Using '%s' taken as minimum from 'cuda_compute_capabilities'" % default_cc)
-            cuda_cc = [cc.replace('.', '') for cc in cuda_cc]
-            default_cc = default_cc.replace('.', '')
+            cuda_cc = self.cfg.get_cuda_cc_template_value('cuda_int_comma_sep')
             self.cfg.update('configopts', '-DCLANG_OPENMP_NVPTX_DEFAULT_ARCH=sm_%s' % default_cc)
-            self.cfg.update('configopts', '-DLIBOMPTARGET_NVPTX_COMPUTE_CAPABILITIES=%s' % ','.join(cuda_cc))
+            self.cfg.update('configopts', f'-DLIBOMPTARGET_NVPTX_COMPUTE_CAPABILITIES={cuda_cc}')
         # If we don't want to build with CUDA (not in dependencies) trick CMakes FindCUDA module into not finding it by
         # using the environment variable which is used as-is and later checked for a falsy value when determining
         # whether CUDA was found
@@ -720,26 +711,22 @@ class EB_Clang(CMakeMake):
             # The static 'nvptx.a' library is not built from version 12 onwards
             if version < '12.0':
                 custom_paths['files'].append("lib/libomptarget-nvptx.a")
-            ec_cuda_cc = self.cfg['cuda_compute_capabilities']
-            cfg_cuda_cc = build_option('cuda_compute_capabilities')
-            cuda_cc = cfg_cuda_cc or ec_cuda_cc or []
-            # We need the CUDA capability in the form of '75' and not '7.5'
-            cuda_cc = [cc.replace('.', '') for cc in cuda_cc]
+            cuda_sm = self.cfg.get_cuda_cc_template_value('cuda_sm_space_sep').split()
             if '12.0' < version < '13.0':
-                custom_paths['files'].extend(["lib/libomptarget-nvptx-cuda_%s-sm_%s.bc" % (x, y)
-                                             for x in CUDA_TOOLKIT_SUPPORT for y in cuda_cc])
+                custom_paths['files'].extend([f"lib/libomptarget-nvptx-cuda_{x}-{sm}.bc"
+                                             for x in CUDA_TOOLKIT_SUPPORT for sm in cuda_sm])
             # libomptarget-nvptx-sm*.bc is not there for Clang 14.x;
             elif version < '14.0' or version >= '15.0':
-                custom_paths['files'].extend(["lib/libomptarget-nvptx-sm_%s.bc" % cc
-                                             for cc in cuda_cc])
+                custom_paths['files'].extend([f"lib/libomptarget-nvptx-{sm}.bc"
+                                             for sm in cuda_sm])
             # From version 13, and hopefully onwards, the naming of the CUDA
             # '.bc' files became a bit simpler and now we don't need to take
             # into account the CUDA version Clang was compiled with, making it
             # easier to check for the bitcode files we expect;
             # libomptarget-new-nvptx-sm*.bc is only there in Clang 13.x and 14.x;
             if version >= '13.0' and version < '15.0':
-                custom_paths['files'].extend(["lib/libomptarget-new-nvptx-sm_%s.bc" % cc
-                                              for cc in cuda_cc])
+                custom_paths['files'].extend([f"lib/libomptarget-new-nvptx-{sm}.bc"
+                                              for sm in cuda_sm])
         # If building for AMDGPU check that OpenMP target library was created
         if 'AMDGPU' in self.cfg['build_targets']:
             custom_paths['files'].append("lib/libLLVMAMDGPUCodeGen.a")

--- a/easybuild/easyblocks/e/elpa.py
+++ b/easybuild/easyblocks/e/elpa.py
@@ -194,20 +194,13 @@ class EB_ELPA(ConfigureMake):
             self.cfg.update('configopts', '--with-cuda-path=%s' % cuda_root)
             self.cfg.update('configopts', '--with-cuda-sdk-path=%s' % cuda_root)
 
-            cuda_cc = build_option('cuda_compute_capabilities') or self.cfg['cuda_compute_capabilities']
-            if not cuda_cc:
-                raise EasyBuildError('List of CUDA compute capabilities must be specified, either via '
-                                     'cuda_compute_capabilities easyconfig parameter or via '
-                                     '--cuda-compute-capabilities')
-
+            cuda_cc = self.cfg.get_cuda_cc_template_value('cuda_cc_space_sep')
             # ELPA's --with-NVIDIA-GPU-compute-capability only accepts a single architecture
-            if len(cuda_cc) != 1:
+            if len(cuda_cc.split(',')) != 1:
                 raise EasyBuildError('ELPA currently only supports specifying one CUDA architecture when '
                                      'building. You specified cuda-compute-capabilities: %s', cuda_cc)
-            cuda_cc = cuda_cc[0]
-            cuda_cc_string = cuda_cc.replace('.', '')
-            self.cfg.update('configopts', '--with-NVIDIA-GPU-compute-capability=sm_%s' % cuda_cc_string)
-            self.log.info("Enabling nvidia GPU support for compute capability: %s", cuda_cc_string)
+            self.cfg.update('configopts', '--with-NVIDIA-GPU-compute-capability=sm_%s' % cuda_cc.replace('.', ''))
+            self.log.info("Enabling nvidia GPU support for compute capability: %s", cuda_cc)
             # There is a dedicated kernel for sm80, but only from version 2021.11.001 onwards
             # Trying to use these kernels for GPUs newer than sm80 will fail ELPA configure
             if float(cuda_cc) == 8.0 and LooseVersion(self.version) >= LooseVersion('2021.11.001'):

--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -386,15 +386,14 @@ class EB_GCC(ConfigureMake):
         and extract the supported architectures and their mapping. Based on the result, determine the lowest
         architecture required to support all 'cuda_compute_capabilities' and return this value.
         """
-        cuda_cc_list = build_option('cuda_compute_capabilities') or self.cfg['cuda_compute_capabilities']
         architecture_mappings_file = os.path.join(self.cfg['start_dir'], 'gcc', 'config', 'nvptx', 'nvptx.opt')
         architecture_mappings_flag = "march-map="
         architecture_mappings_replacement = "misa=,"
 
         # Determine which compute capabilities are configured. If there are none, return immediately.
-        if not cuda_cc_list:
+        cuda_sm_list = self.cfg.get_cuda_cc_template_value('cuda_sm_space_sep', required=False).split()
+        if not cuda_sm_list:
             return None
-        cuda_sm_list = [f"sm_{cc.replace('.', '')}" for cc in cuda_cc_list]
 
         if not os.path.exists(architecture_mappings_file):
             warn_msg = f"Tried to parse nvptx.opt but file {architecture_mappings_file} was not found. " \

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -384,13 +384,7 @@ class CMakeMake(ConfigureMake):
         if cuda_root:
             options['CMAKE_CUDA_HOST_COMPILER'] = which(os.getenv('CXX', 'g++'))
             options['CMAKE_CUDA_COMPILER'] = which('nvcc')
-            cuda_cc = build_option('cuda_compute_capabilities') or self.cfg['cuda_compute_capabilities']
-            if cuda_cc:
-                options['CMAKE_CUDA_ARCHITECTURES'] = self.list_to_cmake_arg(cc.replace('.', '') for cc in cuda_cc)
-            else:
-                raise EasyBuildError('List of CUDA compute capabilities must be specified, either via '
-                                     'cuda_compute_capabilities easyconfig parameter or via '
-                                     '--cuda-compute-capabilities')
+            options['CMAKE_CUDA_ARCHITECTURES'] = self.cfg.get_cuda_cc_template_value('cuda_cc_cmake')
 
         if not self.cfg.get('allow_system_boost', False):
             boost_root = get_software_root('Boost')

--- a/easybuild/easyblocks/generic/nvidiabase.py
+++ b/easybuild/easyblocks/generic/nvidiabase.py
@@ -47,7 +47,6 @@ from easybuild.easyblocks.generic.packedbinary import PackedBinary
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools import LooseVersion
 from easybuild.tools.build_log import EasyBuildError, print_warning
-from easybuild.tools.config import build_option
 from easybuild.tools.filetools import adjust_permissions, remove, symlink
 from easybuild.tools.filetools import write_file, apply_regex_substitutions, resolve_path
 from easybuild.tools.modules import MODULE_LOAD_ENV_HEADERS, get_software_root, get_software_version
@@ -219,21 +218,15 @@ class NvidiaBase(PackedBinary):
         if nvcomp_cuda_cc:
             nvcomp_cuda_cc = nvcomp_cuda_cc.split(',')
         # CUDA compute capability defined by easyconfig/cli
-        cfg_compute_capability = self.cfg['cuda_compute_capabilities']
-        opt_compute_capability = build_option('cuda_compute_capabilities')
-        user_cuda_cc = opt_compute_capability if opt_compute_capability else cfg_compute_capability
-        if user_cuda_cc and isinstance(user_cuda_cc, str):
-            user_cuda_cc = [user_cuda_cc]  # keep compatibility with pre-nvidia-compilers NVHPC easyconfigs
+        user_cuda_cc = self.cfg.get_cuda_cc_template_value('cuda_cc_space_sep', required=False).split()
 
-        if nvcomp_cuda_cc and user_cuda_cc and nvcomp_cuda_cc != user_cuda_cc:
+        if nvcomp_cuda_cc and user_cuda_cc and set(nvcomp_cuda_cc) != set(user_cuda_cc):
             raise EasyBuildError(
                 f"Given CUDA compute capabilities {user_cuda_cc} in {self.name}-{self.version} "
                 f"do not match those set by the NVHPC toolchain {nvcomp_cuda_cc}"
             )
 
-        default_compute_capability = user_cuda_cc
-        if nvcomp_cuda_cc:
-            default_compute_capability = nvcomp_cuda_cc
+        default_compute_capability = nvcomp_cuda_cc if nvcomp_cuda_cc else user_cuda_cc
 
         if default_compute_capability:
             self.log.info(f"CUDA compute capabilities used by default in NVHPC: '{default_compute_capability}'")

--- a/easybuild/easyblocks/h/hypre.py
+++ b/easybuild/easyblocks/h/hypre.py
@@ -33,8 +33,6 @@ EasyBuild support for Hypre, implemented as an easyblock
 import os
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
-from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.config import build_option
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.systemtools import get_shared_lib_ext
 
@@ -73,15 +71,8 @@ class EB_Hypre(ConfigureMake):
 
         if get_software_root('CUDA'):
             self.cfg.update('configopts', '--with-cuda')
-
-            cuda_cc = build_option('cuda_compute_capabilities') or self.cfg['cuda_compute_capabilities']
-            if not cuda_cc:
-                raise EasyBuildError('List of CUDA compute capabilities must be specified, either via '
-                                     'cuda_compute_capabilities easyconfig parameter or via '
-                                     '--cuda-compute-capabilities')
-
-            cuda_cc_string = ' '.join([x.replace('.', '') for x in cuda_cc])
-            self.cfg.update('configopts', '--with-gpu-arch="%s"' % cuda_cc_string)
+            cuda_cc_string = self.cfg.get_cuda_cc_template_value('cuda_int_space_sep')
+            self.cfg.update('configopts', f'--with-gpu-arch="{cuda_cc_string}"')
 
         super().configure_step()
 

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -270,7 +270,7 @@ class EB_LAMMPS(CMakeMake):
         if LooseVersion(self.cur_version) >= LooseVersion(translate_lammps_version('22Jul2025')):
             self.kokkos_cpu_mapping['zen5'] = 'ZEN5'
 
-    def get_kokkos_arch(self, cuda_cc, kokkos_arch):
+    def get_kokkos_arch(self):
         """
         Return KOKKOS ARCH in LAMMPS required format, which is 'CPU_ARCH' and 'GPU_ARCH'.
 
@@ -281,6 +281,7 @@ class EB_LAMMPS(CMakeMake):
         # to the compiler flags, which may override the ones set by EasyBuild.
         # https://github.com/lammps/lammps/blob/stable_29Aug2024/lib/kokkos/cmake/kokkos_arch.cmake#L228-L531
         processor_arch = None
+        kokkos_arch = self.cfg['kokkos_arch']
         if kokkos_arch:
             # If someone is trying a manual override for this case, let them
             if kokkos_arch not in KOKKOS_CPU_ARCH_LIST:
@@ -321,27 +322,28 @@ class EB_LAMMPS(CMakeMake):
 
         # arch names changed between some releases :(
         if LooseVersion(self.cur_version) < LooseVersion(translate_lammps_version('29Oct2020')):
-            if processor_arch in KOKKOS_LEGACY_ARCH_MAPPING.keys():
-                processor_arch = KOKKOS_LEGACY_ARCH_MAPPING[processor_arch]
+            processor_arch = KOKKOS_LEGACY_ARCH_MAPPING.get(processor_arch, processor_arch)
 
         # GPU arch
         gpu_arch = None
         if self.cuda:
+            cuda_ccs = self.cfg.get_cuda_cc_template_value('cuda_cc_space_sep').split()
             # CUDA below
-            for cc in sorted(cuda_cc, reverse=True):
-                gpu_arch = KOKKOS_GPU_ARCH_TABLE.get(str(cc))
-                if gpu_arch:
-                    print_warning(
-                        "LAMMPS will be built _only_ for the latest CUDA compute capability known to Kokkos: "
-                        "%s" % gpu_arch
-                    )
+            for cc in cuda_ccs[::-1]:
+                try:
+                    gpu_arch = KOKKOS_GPU_ARCH_TABLE[cc]
+                    if len(cuda_ccs) > 1:
+                        print_warning(
+                            "LAMMPS will be built _only_ for the latest CUDA compute capability known to Kokkos: "
+                            "%s" % gpu_arch
+                        )
                     break
-                else:
+                except KeyError:
                     warning_msg = "(%s) GPU ARCH was not found in listed options." % cc
                     print_warning(warning_msg)
 
             if not gpu_arch:
-                error_msg = "Specified GPU ARCH (%s) " % cuda_cc
+                error_msg = "Specified GPU ARCH (%s) " % cuda_ccs
                 error_msg += "was not found in listed options [%s]." % KOKKOS_GPU_ARCH_TABLE
                 raise EasyBuildError(error_msg)
 
@@ -411,15 +413,10 @@ class EB_LAMMPS(CMakeMake):
             # In "recent versions" of LAMMPS there is no distinction
             self.cfg['general_packages'] = [x for x in self.cfg['general_packages'] if x != 'SCAFACOS']
 
-        # list of CUDA compute capabilities to use can be specifed in two ways (where (2) overrules (1)):
-        # (1) in the easyconfig file, via the custom cuda_compute_capabilities;
-        # (2) in the EasyBuild configuration, via --cuda-compute-capabilities configuration option;
-        ec_cuda_cc = self.cfg['cuda_compute_capabilities']
-        cfg_cuda_cc = build_option('cuda_compute_capabilities')
-        if cfg_cuda_cc and not isinstance(cfg_cuda_cc, list):
-            raise EasyBuildError("cuda_compute_capabilities in easyconfig should be provided as list of strings, " +
-                                 "(for example ['8.0', '7.5']). Got %s" % cfg_cuda_cc)
-        cuda_cc = check_cuda_compute_capabilities(cfg_cuda_cc, ec_cuda_cc, cuda=self.cuda)
+        if not self.cuda and self.cfg.get_cuda_cc_template_value('cuda_compute_capabilities', required=False):
+            warning_msg = "Missing CUDA package (in dependencies), "
+            warning_msg += "but 'cuda_compute_capabilities' option was specified."
+            print_warning(warning_msg)
 
         # cmake has its own folder
         self.cfg['srcdir'] = os.path.join(self.start_dir, 'cmake')
@@ -515,7 +512,7 @@ class EB_LAMMPS(CMakeMake):
                 self.cfg.update('configopts', '-DFFT_PACK=array')
 
         # detect the CPU and GPU architecture (used for Intel and Kokkos packages below)
-        processor_arch, gpu_arch = self.get_kokkos_arch(cuda_cc, self.cfg['kokkos_arch'])
+        processor_arch, gpu_arch = self.get_kokkos_arch()
 
         # INTEL package
         if processor_arch in INTEL_PACKAGE_ARCH_LIST or \
@@ -571,7 +568,9 @@ class EB_LAMMPS(CMakeMake):
             print_msg("Using GPU package (not Kokkos) with arch: CPU - %s, GPU - %s" % (processor_arch, gpu_arch))
             self.cfg.update('configopts', '-D%sGPU=on' % self.pkg_prefix)
             self.cfg.update('configopts', '-DGPU_API=cuda')
-            self.cfg.update('configopts', '-DGPU_ARCH=%s' % get_cuda_gpu_arch(cuda_cc))
+            # Largest CUDA SM value
+            self.cfg.update('configopts',
+                            '-DGPU_ARCH=%s' % self.cfg.get_cuda_cc_template_value('cuda_sm_space_sep').split()[-1])
 
         # Make sure that all libraries end up in the same folder (python libs seem to default to lib, everything else
         # to lib64)
@@ -798,47 +797,6 @@ class EB_LAMMPS(CMakeMake):
             custom_paths['dirs'].append(pythonpath)
 
         return super().sanity_check_step(custom_commands=custom_commands, custom_paths=custom_paths)
-
-
-def get_cuda_gpu_arch(cuda_cc):
-    """Return CUDA gpu ARCH in LAMMPS required format. Example: 'sm_32' """
-    # Get largest cuda supported
-    return 'sm_%s' % str(sorted(cuda_cc, reverse=True)[0]).replace(".", "")
-
-
-def check_cuda_compute_capabilities(cfg_cuda_cc, ec_cuda_cc, cuda=None):
-    """
-    Checks if cuda-compute-capabilities is set and prints warning if it gets declared on multiple places.
-
-    :param cfg_cuda_cc: cuda-compute-capabilities from cli config
-    :param ec_cuda_cc: cuda-compute-capabilities from easyconfig
-    :param cuda: boolean to check if cuda should be enabled or not
-    :return: returns preferred cuda-compute-capabilities
-    """
-
-    if cuda is None or not isinstance(cuda, bool):
-        cuda = get_software_root('CUDA')
-
-    cuda_cc = cfg_cuda_cc or ec_cuda_cc or []
-
-    if cuda:
-        if cfg_cuda_cc and ec_cuda_cc:
-            warning_msg = "cuda_compute_capabilities specified in easyconfig (%s)" % ec_cuda_cc
-            warning_msg += " are overruled by "
-            warning_msg += "--cuda-compute-capabilities configuration option (%s)" % cfg_cuda_cc
-            print_warning(warning_msg)
-        elif not cuda_cc:
-            error_msg = "No CUDA compute capabilities specified.\nTo build LAMMPS with Cuda you need to use"
-            error_msg += "the --cuda-compute-capabilities configuration option or the cuda_compute_capabilities "
-            error_msg += "easyconfig parameter to specify a list of CUDA compute capabilities to compile with."
-            raise EasyBuildError(error_msg)
-
-    elif cuda_cc:
-        warning_msg = "Missing CUDA package (in dependencies), "
-        warning_msg += "but 'cuda_compute_capabilities' option was specified."
-        print_warning(warning_msg)
-
-    return cuda_cc
 
 
 def get_cpu_arch():

--- a/easybuild/easyblocks/l/llvm.py
+++ b/easybuild/easyblocks/l/llvm.py
@@ -438,7 +438,7 @@ class EB_LLVM(CMakeMake):
         # (1) in the easyconfig file, via the custom cuda_compute_capabilities;
         # (2) in the EasyBuild configuration, via --cuda-compute-capabilities configuration option;
         # Similar rules apply for AMDGCN capabilities
-        cuda_cc_list = self.cfg.get_cuda_cc_template_value("cuda_cc_space_sep", required=False).split()
+        cuda_cc_list = self.cfg.get_cuda_cc_template_value("cuda_int_space_sep", required=False).split()
         cuda_toolchain = hasattr(self.toolchain, 'COMPILER_CUDA_FAMILY')
         amd_gfx_list = self.cfg.get_amdgcn_cc_template_value("amdgcn_cc_space_sep", required=False).split()
         if self.cfg['amd_gfx_list'] is not None:
@@ -523,7 +523,7 @@ class EB_LLVM(CMakeMake):
                     raise EasyBuildError(
                         f"LLVM < 20 requires 'cuda_compute_capabilities' to build with {BUILD_TARGET_NVPTX}"
                     )
-                self.cuda_cc = [cc.replace('.', '') for cc in cuda_cc_list]
+                self.cuda_cc = cuda_cc_list
                 self.offload_targets += ['cuda']
                 self.log.debug("Enabling `cuda` offload target")
             if self.amdgpu_target_cond:

--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -495,20 +495,13 @@ class EB_PyTorch(PythonPackage):
                 options.append('USE_SYSTEM_NCCL=1')
                 options.append('NCCL_INCLUDE_DIR=' + os.path.join(nccl_root, 'include'))
 
-            # list of CUDA compute capabilities to use can be specifed in two ways (where (2) overrules (1)):
-            # (1) in the easyconfig file, via the custom cuda_compute_capabilities;
-            # (2) in the EasyBuild configuration, via --cuda-compute-capabilities configuration option;
-            cuda_cc = build_option('cuda_compute_capabilities') or self.cfg['cuda_compute_capabilities']
-            if not cuda_cc:
-                raise EasyBuildError('List of CUDA compute capabilities must be specified, either via '
-                                     'cuda_compute_capabilities easyconfig parameter or via '
-                                     '--cuda-compute-capabilities')
-
-            self.log.info('Compiling with specified list of CUDA compute capabilities: %s', ', '.join(cuda_cc))
+            cuda_arch_list = self.cfg.get_cuda_cc_template_value('cuda_cc_semicolon_sep')
+            self.log.info('Compiling with specified list of CUDA compute capabilities: %s',
+                          ', '.join(cuda_arch_list.split(';')))
             # This variable is also used at runtime (e.g. for tests) and if it is not set PyTorch will automatically
             # determine the compute capability of a GPU in the system and use that which may fail tests if
             # it is to new for the used nvcc
-            env.setvar('TORCH_CUDA_ARCH_LIST', ';'.join(cuda_cc))
+            env.setvar('TORCH_CUDA_ARCH_LIST', cuda_arch_list)
         else:
             # Disable CUDA
             options.append('USE_CUDA=0')

--- a/easybuild/easyblocks/t/torchvision.py
+++ b/easybuild/easyblocks/t/torchvision.py
@@ -32,7 +32,6 @@ import os
 
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage, det_pylibdir
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.config import build_option
 from easybuild.tools.modules import get_software_version, get_software_root
 import easybuild.tools.environment as env
 
@@ -67,9 +66,9 @@ class EB_torchvision(PythonPackage):
             # make sure that torchvision is installed with CUDA support by setting $FORCE_CUDA
             env.setvar('FORCE_CUDA', '1')
             # specify CUDA compute capabilities via $TORCH_CUDA_ARCH_LIST
-            cuda_cc = self.cfg['cuda_compute_capabilities'] or build_option('cuda_compute_capabilities')
-            if cuda_cc:
-                env.setvar('TORCH_CUDA_ARCH_LIST', ';'.join(cuda_cc))
+            cuda_arch_list = self.cfg.get_cuda_cc_template_value('cuda_cc_semicolon_sep')
+            if cuda_arch_list:
+                env.setvar('TORCH_CUDA_ARCH_LIST', cuda_arch_list)
 
         includes = []
         for lib in ['libjpeg-turbo', 'libwebp']:


### PR DESCRIPTION
This avoids a lot of code duplication where we do the same checks in man easyblocks.

It is especially important to get the order correct/consistent. For those using the highest/lowest CUDA CC this fixes behavior for Blackwell (CUDA CC 10.0).

Requires:
- [ ] https://github.com/easybuilders/easybuild-framework/pull/5144