### PR TITLE
enhance `run_pip_list` function to print warning for mismatched Python package names or versions

### DIFF
--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -247,7 +247,7 @@ class PythonBundle(Bundle):
             run_pip_check(python_cmd=self.python_cmd)
             pkgs = [(x.name, x.version) for x in py_exts]
             run_pip_list(pkgs, python_cmd=self.python_cmd, unversioned_packages=all_unversioned_packages,
-                         check_names_versions=params['sanity_check_pip_list'])
+                         strict_check=params['sanity_check_pip_list'])
 
     def make_module_footer(self):
         """

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -1304,7 +1304,7 @@ class PythonPackage(ExtensionEasyBlock):
             unversioned_packages = self.cfg.get('unversioned_packages', [])
             pkgs = [(self.name, self.version)]
             run_pip_list(pkgs, python_cmd=python_cmd, unversioned_packages=unversioned_packages,
-                         check_names_versions=params['sanity_check_pip_list'])
+                         strict_check=params['sanity_check_pip_list'])
 
         # ExtensionEasyBlock handles loading modules correctly for multi_deps, so we clean up fake_mod_data
         # and let ExtensionEasyBlock do its job

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -509,8 +509,9 @@ class PythonPackage(ExtensionEasyBlock):
             'max_py_minver': [None, "Maximum minor Python version (only relevant when using system Python)", CUSTOM],
             'sanity_pip_check': [True, "Run 'python -m pip check' to ensure all required Python packages are "
                                        "installed and check for any package with an invalid (0.0.0) version.", CUSTOM],
-            'sanity_check_pip_list': [None, "Run 'python -m pip list' to ensure specified package names and versions "
-                                            "are correct.", CUSTOM],
+            'sanity_check_pip_list': [None, "Fail if specified package names and versions do not match "
+                                            "'python -m pip list' output. Defaults to True if --upload-test-report is "
+                                            "set. The check only runs if 'sanity_pip_check' is True.", CUSTOM],
             'runtest': [True, "Run unit tests.", CUSTOM],  # overrides default
             'testinstall': [False, "Install into temporary directory prior to running the tests.", CUSTOM],
             'unpack_sources': [None, "Unpack sources prior to build/install. Defaults to 'True' except for whl files",

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -233,14 +233,16 @@ def normalize_pip(name):
     return REGEX_PIP_NORMALIZE.sub('-', name).lower()
 
 
-def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None, strict_check=None):
+def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None, check_names_versions=True, strict_check=None):
     """
     Run pip list to verify normalized names and versions of installed Python packages
 
     :param pkgs: list of package tuples (name, version) as specified in the easyconfig
     :param python_cmd: Python command to use (if None, 'python' is used)
     :param unversioned_packages: set of Python packages to exclude in the version existence check
-    :param strict_check: boolean to indicate whether to raise an error if package names or versions don’t match
+    :param check_names_versions: boolean to indicate whether name and versions of Python packages should be checked
+    :param strict_check: boolean to indicate whether to raise an error if package names or versions don’t match,
+                       or emit a warning
     """
 
     log = fancylogger.getLogger('run_pip_list', fname=False)
@@ -318,54 +320,55 @@ def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None, strict_check=
         msg += "required (check the source for a pyproject.toml and see PEP517 for details on that)."
         pip_list_errors.append(msg)
 
-    normalized_pkgs = [(normalize_pip(name), version) for name, version in pkgs]
+    if check_names_versions:
+        normalized_pkgs = [(normalize_pip(name), version) for name, version in pkgs]
 
-    missing_names = []
-    missing_versions = []
+        missing_names = []
+        missing_versions = []
 
-    for name, version in normalized_pkgs:
-        # Skip packages in the unversioned list: they have already been checked
-        if name in normalized_unversioned:
-            continue
+        for name, version in normalized_pkgs:
+            # Skip packages in the unversioned list: they have already been checked
+            if name in normalized_unversioned:
+                continue
 
-        # Skip packages in the zero_pkg_names list: they have already been added to pip_list_errors
-        if name in zero_pkg_names:
-            continue
+            # Skip packages in the zero_pkg_names list: they have already been added to pip_list_errors
+            if name in zero_pkg_names:
+                continue
 
-        # Check for missing (likely wrong) packages names and propose close matches
-        if name not in normalized_pip_pkgs:
-            close_matches = difflib.get_close_matches(name, normalized_pip_pkgs.keys())
-            if close_matches:
-                msg = f"{name} (close matches in 'pip list' output: " + ', '.join(close_matches) + ")"
+            # Check for missing (likely wrong) packages names and propose close matches
+            if name not in normalized_pip_pkgs:
+                close_matches = difflib.get_close_matches(name, normalized_pip_pkgs.keys())
+                if close_matches:
+                    msg = f"{name} (close matches in 'pip list' output: " + ', '.join(close_matches) + ")"
+                else:
+                    msg = f"{name} (no close matches found in 'pip list' output)"
+                missing_names.append(msg)
+
+            # Check for missing (likely wrong) package versions
+            elif version != normalized_pip_pkgs[name]:
+                missing_versions.append(f"{name} {version} (version in 'pip list' output: {normalized_pip_pkgs[name]})")
+
+        log.info(f"Found {len(missing_names)} missing names and {len(missing_versions)} missing versions "
+                 f"out of {len(pkgs)} packages")
+
+        if missing_names:
+            missing_names_str = '\n'.join(missing_names)
+            msg = "The following Python packages were likely specified with a wrong name because they are missing "
+            msg += f"in the 'pip list' output (causes failure if --upload-test-report is set):\n{missing_names_str}"
+            if strict_check:
+                pip_list_errors.append(msg)
             else:
-                msg = f"{name} (no close matches found in 'pip list' output)"
-            missing_names.append(msg)
+                pip_list_warnings.append(msg)
 
-        # Check for missing (likely wrong) package versions
-        elif version != normalized_pip_pkgs[name]:
-            missing_versions.append(f"{name} {version} (version in 'pip list' output: {normalized_pip_pkgs[name]})")
-
-    log.info(f"Found {len(missing_names)} missing names and {len(missing_versions)} missing versions "
-             f"out of {len(pkgs)} packages")
-
-    if missing_names:
-        missing_names_str = '\n'.join(missing_names)
-        msg = "The following Python packages were likely specified with a wrong name because they are missing "
-        msg += f"in the 'pip list' output (causes failure if --upload-test-report is set):\n{missing_names_str}"
-        if strict_check:
-            pip_list_errors.append(msg)
-        else:
-            pip_list_warnings.append(msg)
-
-    if missing_versions:
-        missing_versions_str = '\n'.join(missing_versions)
-        msg = "The following Python packages were likely specified with a wrong version because they have "
-        msg += "another version in the 'pip list' output (causes failure if --upload-test-report is set):\n"
-        msg += missing_versions_str
-        if strict_check:
-            pip_list_errors.append(msg)
-        else:
-            pip_list_warnings.append(msg)
+        if missing_versions:
+            missing_versions_str = '\n'.join(missing_versions)
+            msg = "The following Python packages were likely specified with a wrong version because they have "
+            msg += "another version in the 'pip list' output (causes failure if --upload-test-report is set):\n"
+            msg += missing_versions_str
+            if strict_check:
+                pip_list_errors.append(msg)
+            else:
+                pip_list_warnings.append(msg)
 
     if pip_list_warnings:
         print_warning(msg, log=log)

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -347,7 +347,7 @@ def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None, strict_check=
     if missing_names:
         missing_names_str = '\n'.join(missing_names)
         msg = "The following Python packages were likely specified with a wrong name because they are missing "
-        msg += f"in the 'pip list' output:\n{missing_names_str}"
+        msg += f"in the 'pip list' output (causes failure if --upload-test-report is set):\n{missing_names_str}"
         if strict_check:
             pip_list_errors.append(msg)
         else:
@@ -356,7 +356,8 @@ def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None, strict_check=
     if missing_versions:
         missing_versions_str = '\n'.join(missing_versions)
         msg = "The following Python packages were likely specified with a wrong version because they have "
-        msg += f"another version in the 'pip list' output:\n{missing_versions_str}"
+        msg += "another version in the 'pip list' output (causes failure if --upload-test-report is set):\n"
+        msg += missing_versions_str
         if strict_check:
             pip_list_errors.append(msg)
         else:

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -371,7 +371,7 @@ def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None, check_names_v
                 pip_list_warnings.append(msg)
 
     if pip_list_warnings:
-        print_warning(msg, log=log)
+        print_warning('\n'.join(pip_list_warnings), log=log)
 
     if pip_list_errors:
         raise EasyBuildError('\n' + '\n'.join(pip_list_errors))

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -233,14 +233,14 @@ def normalize_pip(name):
     return REGEX_PIP_NORMALIZE.sub('-', name).lower()
 
 
-def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None, check_names_versions=None):
+def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None, strict_check=None):
     """
     Run pip list to verify normalized names and versions of installed Python packages
 
     :param pkgs: list of package tuples (name, version) as specified in the easyconfig
     :param python_cmd: Python command to use (if None, 'python' is used)
     :param unversioned_packages: set of Python packages to exclude in the version existence check
-    :param check_names_versions: boolean to indicate whether name and versions of Python packages should be checked
+    :param strict_check: boolean to indicate whether to raise an error if package names or versions don’t match
     """
 
     log = fancylogger.getLogger('run_pip_list', fname=False)
@@ -256,15 +256,16 @@ def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None, check_names_v
     if build_option('ignore_pip_unversioned_pkgs'):
         unversioned_packages.update(build_option('ignore_pip_unversioned_pkgs'))
 
-    if check_names_versions is None:
-        # by default only check names and versions if --upload-test-report is used,
-        # so we can enforce that extension names/versions are correct for contributions
+    if strict_check is None:
+        # by default only raise an error for mismatched names or versions if --upload-test-report is used,
+        # to enforce correct extension names/versions for contributions
         if build_option('upload_test_report'):
-            check_names_versions = True
+            strict_check = True
         else:
-            check_names_versions = False
+            strict_check = False
 
     pip_list_errors = []
+    pip_list_warnings = []
 
     msg = "Check on installed Python package names and versions with 'pip list': "
     try:
@@ -317,44 +318,52 @@ def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None, check_names_v
         msg += "required (check the source for a pyproject.toml and see PEP517 for details on that)."
         pip_list_errors.append(msg)
 
-    if check_names_versions:
-        normalized_pkgs = [(normalize_pip(name), version) for name, version in pkgs]
+    normalized_pkgs = [(normalize_pip(name), version) for name, version in pkgs]
 
-        missing_names = []
-        missing_versions = []
+    missing_names = []
+    missing_versions = []
 
-        for name, version in normalized_pkgs:
-            # Skip packages in the unversioned list: they have already been checked
-            if name in normalized_unversioned:
-                continue
+    for name, version in normalized_pkgs:
+        # Skip packages in the unversioned list: they have already been checked
+        if name in normalized_unversioned:
+            continue
 
-            # Skip packages in the zero_pkg_names list: they have already been added to pip_list_errors
-            if name in zero_pkg_names:
-                continue
+        # Skip packages in the zero_pkg_names list: they have already been added to pip_list_errors
+        if name in zero_pkg_names:
+            continue
 
-            # Check for missing (likely wrong) packages names and propose close matches
-            if name not in normalized_pip_pkgs:
-                close_matches = difflib.get_close_matches(name, normalized_pip_pkgs.keys())
-                missing_names.append(f"{name} (close matches in 'pip list' output: " + ', '.join(close_matches))
+        # Check for missing (likely wrong) packages names and propose close matches
+        if name not in normalized_pip_pkgs:
+            close_matches = difflib.get_close_matches(name, normalized_pip_pkgs.keys())
+            missing_names.append(f"{name} (close matches in 'pip list' output: " + ', '.join(close_matches))
 
-            # Check for missing (likely wrong) package versions
-            elif version != normalized_pip_pkgs[name]:
-                missing_versions.append(f"{name} {version} (version in 'pip list' output: {normalized_pip_pkgs[name]})")
+        # Check for missing (likely wrong) package versions
+        elif version != normalized_pip_pkgs[name]:
+            missing_versions.append(f"{name} {version} (version in 'pip list' output: {normalized_pip_pkgs[name]})")
 
-        log.info(f"Found {len(missing_names)} missing names and {len(missing_versions)} missing versions "
-                 f"out of {len(pkgs)} packages")
+    log.info(f"Found {len(missing_names)} missing names and {len(missing_versions)} missing versions "
+             f"out of {len(pkgs)} packages")
 
-        if missing_names:
-            missing_names_str = '\n'.join(missing_names)
-            msg = "The following Python packages were likely specified with a wrong name because they are missing "
-            msg += f"in the 'pip list' output:\n{missing_names_str}"
+    if missing_names:
+        missing_names_str = '\n'.join(missing_names)
+        msg = "The following Python packages were likely specified with a wrong name because they are missing "
+        msg += f"in the 'pip list' output:\n{missing_names_str}"
+        if strict_check:
             pip_list_errors.append(msg)
+        else:
+            pip_list_warnings.append(msg)
 
-        if missing_versions:
-            missing_versions_str = '\n'.join(missing_versions)
-            msg = "The following Python packages were likely specified with a wrong version because they have "
-            msg += f"another version in the 'pip list' output:\n{missing_versions_str}"
+    if missing_versions:
+        missing_versions_str = '\n'.join(missing_versions)
+        msg = "The following Python packages were likely specified with a wrong version because they have "
+        msg += f"another version in the 'pip list' output:\n{missing_versions_str}"
+        if strict_check:
             pip_list_errors.append(msg)
+        else:
+            pip_list_warnings.append(msg)
+
+    if pip_list_warnings:
+        print_warning(msg, log=log)
 
     if pip_list_errors:
         raise EasyBuildError('\n' + '\n'.join(pip_list_errors))

--- a/test/easyblocks/easyblock_specific.py
+++ b/test/easyblocks/easyblock_specific.py
@@ -627,7 +627,7 @@ class EasyBlockSpecificTest(TestCase):
         with self.mocked_stdout_stderr():
             self.assertErrorRegex(EasyBuildError, error_pattern, python.run_pip_list,
                                   [('wrong_name', '1.2.3'), ('wrong_version', '5.6.7')],
-                                  python_cmd=sys.executable, check_names_versions=True)
+                                  python_cmd=sys.executable, strict_check=True)
 
     def test_symlink_dist_site_packages(self):
         """Test symlink_dist_site_packages provided by PythonPackage easyblock."""


### PR DESCRIPTION
follow up on https://github.com/easybuilders/easybuild-easyblocks/pull/4049

- always run the `pip list` sanity check on package names and versions
- upon failure, print a warning if `--upload-test-report` is not used