### PR TITLE
Add functions to generate `exts_list` for a `JuliaBundle` starting from a `Manifest.toml`

### DIFF
--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -395,6 +395,7 @@ def generate_exts_list(sourcedir, tab_depth=4):
         if isinstance(url, IsJuliaPackage):
             continue
         exts_list.append(tab + f"('{name}', '{version}', {{")
+        exts_list.append(tab*2 + f"'easyblock': 'JuliaPackage',")
         exts_list.append(tab*2 + f"'source_urls': ['{url}'],")
         if sources is not None:
             exts_list.append(tab*2 + f"'sources': {sources},")

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -26,8 +26,16 @@
 EasyBuild support for bundles of Julia packages, implemented as an easyblock
 
 @author: Alex Domingo (Vrije Universiteit Brussel)
+@author: Davide Grassano (CECAM, EPFL)
 """
 import os
+import requests
+import subprocess
+import sys
+import tempfile
+import time
+import toml
+from collections import defaultdict
 
 from easybuild.easyblocks.generic.bundle import Bundle
 from easybuild.easyblocks.generic.juliapackage import EXTS_FILTER_JULIA_PACKAGES, JuliaPackage
@@ -96,3 +104,280 @@ class JuliaBundle(Bundle, JuliaPackage):
     def make_module_extra(self, *args, **kwargs):
         """Custom module environment from JuliaPackage"""
         return super().make_module_extra(*args, **kwargs)
+
+
+IsJuliaPackage = type('IsJuliaPackage', (), {})  # sentinel value to indicate package is part of Julia stdlib
+
+
+def get_commit_from_git_tree_sha1(repo, git_tree_sha1):
+    """"Determine commit corresponding to git tree SHA1 by cloning the repo and searching the git log"""
+    git_exec = subprocess.run(['which', 'git'], capture_output=True, text=True).stdout.strip()
+    if not git_exec:
+        print("No git executable found in PATH, cannot determine commit from git tree SHA1")
+        return None
+
+    commit = None
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        print(
+            f'Attempting to determine commit for git tree SHA1 by cloning repo {repo} '
+            f'into temporary directory {tmpdir}...'
+        )
+        try:
+            print('Running git clone command...')
+            subprocess.run(
+                [git_exec, 'clone', repo, tmpdir],
+                capture_output=True, text=True, check=True
+            )
+            print('Running git log command to find commit for git tree SHA1...')
+            result = subprocess.run(
+                [git_exec, '-C', tmpdir, 'log', '--all', '--pretty=format:"%T %H"'],
+                capture_output=True, text=True, check=True
+            )
+            output = result.stdout.strip().replace('"', '')
+            for line in output.splitlines():
+                if line.startswith(git_tree_sha1 + ' '):
+                    commit = line.split()[1]
+                    break
+            else:
+                print(f"WARNING: Could not find commit for git tree SHA1 {git_tree_sha1} in repo {repo}")
+                print(f"Git log output:\n{output}")
+        except subprocess.CalledProcessError as e:
+            print(f"Error running git command: {e}")
+
+    return commit
+
+
+def get_url_from_general(pkg, git_tree_sha1, max_retries=3):
+    """Get the package info from the General registry"""
+    if pkg.endswith('_jll'):
+        base_url = "https://github.com/JuliaRegistries/General/raw/refs/heads/master/jll/{}/{}/"
+    else:
+        base_url = "https://github.com/JuliaRegistries/General/raw/refs/heads/master/{}/{}/"
+    base_url = base_url.format(pkg[0].upper(), pkg)
+    package_url = base_url + "Package.toml"
+
+    sleep_time = 1
+
+    while max_retries > 0:
+        time.sleep(sleep_time)
+        sleep_time *= 2  # exponential backoff
+        try:
+            package_data = requests.get(package_url).text
+        except requests.RequestException as e:
+            print(f"Error fetching package data from General registry: {e}")
+            max_retries -= 1
+            continue
+        else:
+            try:
+                package_info = toml.loads(package_data)
+                break
+            except toml.TomlDecodeError as e:
+                print(f"Error parsing Package.toml for package {pkg} from General registry: {e}")
+                max_retries -= 1
+    else:
+        print(f"Failed to fetch and parse package data for {pkg} from General registry after multiple attempts")
+        print(f"Last error fetching package data from General registry: {e}")
+        print(f"Last package data that caused the error:\n{package_data}")
+        raise RuntimeError(
+            f"Failed to fetch and parse package data for {pkg} from General registry after multiple attempts"
+        )
+
+    repo = package_info['repo']
+    url = repo.rstrip('/')
+    if url.endswith('.git'):
+        url = url[:-4]
+
+    if 'github.com' in url:
+        url = url + "/archive/"
+        filename = f'{git_tree_sha1}.tar.gz'
+
+    if 'gitlab.com' in url:
+        # https://gitlab.com/ExpandingMan/ShowCases.jl/-/archive/1ea211f349b40165a2b5fbbc80f771d6dcb725ad/ShowCases.jl-1ea211f349b40165a2b5fbbc80f771d6dcb725ad.tar.gz
+        commit = get_commit_from_git_tree_sha1(repo, git_tree_sha1)
+        if commit:
+            url = url + f"/-/archive/{commit}/"
+            filename = f'{pkg}.jl-{commit[:8]}.tar.gz'
+        else:
+            url = None
+            filename = None
+            print(f"WARNING: Could not determine commit for git tree SHA1 {git_tree_sha1} in GITLAB repo {repo}")
+
+    return url, filename
+
+
+def generate_package_data(sourcedir):
+    """Extract package data from Manifest.toml, including determining source URLs for
+    packages based on available information"""
+    manifest_toml = toml.load(os.path.join(sourcedir, 'Manifest.toml'))
+
+    julia_exec = subprocess.run(['which', 'julia'], capture_output=True, text=True).stdout.strip()
+    if julia_exec:
+        print(f"Found Julia executable at: {julia_exec}")
+    else:
+        print("No Julia executable found in PATH, skipping checks for standard library packages")
+
+    packages_data = {}
+
+    deps = manifest_toml.get('deps', {})
+    for pkg_name, pkg_data in deps.items():
+        if len(pkg_data) != 1:
+            raise ValueError(
+                f"Expected exactly one entry for package {pkg_name} in Manifest.toml deps, "
+                f"got {len(pkg_data)}: {pkg_data}"
+            )
+        pkg_data = pkg_data[0]
+        version = pkg_data.get('version')
+        git_tree_sha1 = pkg_data.get('git-tree-sha1', None)
+
+        url = None
+        item = {
+            'name': pkg_name,
+            'version': version,
+            'checksum': None,
+        }
+
+        if url is None and 'repo-url' in pkg_data:
+            url = pkg_data['repo-url']
+            print(f"Found package {pkg_name:>30s} with explicit repo URL: {url}")
+
+        if url is None and git_tree_sha1 is not None:
+            url, download_filename = get_url_from_general(pkg_name, git_tree_sha1)
+            filename = f'{pkg_name}-{version}.tar.gz'
+            item['sources'] = [{
+                'download_filename': download_filename,
+                'filename': filename,
+            }]
+            print(f"Found package {pkg_name:>30s} with git tree SHA1, determined URL from General registry: {url}")
+
+        # Check if the package is part of the Julia standard library, if so we don't need a source URL
+        if url is None and julia_exec:
+            req = subprocess.run(
+                [julia_exec, '-e', f'import Base; println(Base.find_package("{pkg_name}"))'],
+                capture_output=True, text=True
+            )
+            path = req.stdout.strip()
+            if path and path != "nothing":
+                print(f"Found Package {pkg_name:>30s} is part of the Julia standard library, no source URL needed")
+                url = IsJuliaPackage()
+
+        if url is None:
+            print(f"WARNING: Could not determine source URL for package {pkg_name} (version {version})")
+
+        item['url'] = url
+        packages_data[pkg_name] = item
+
+    return packages_data
+
+
+def get_package_dep_graph(sourcedir):
+    """Helper for generating package dependency graph from Manifest.toml
+
+    Parameters:
+        - sourcedir: path to folder containing Manifest.toml
+
+    Returns:
+        - nodes: set of package names
+        - graph: dict mapping package name to set of packages that depend on it
+    """
+    manifest_toml = toml.load(os.path.join(sourcedir, 'Manifest.toml'))
+
+    nodes = set()
+    graph = defaultdict(set)
+
+    deps = manifest_toml.get('deps', {})
+    for pkg_name, pkg_data in deps.items():
+        if len(pkg_data) != 1:
+            raise ValueError(
+                f"Expected exactly one entry for package {pkg_name} in Manifest.toml deps, "
+                f"got {len(pkg_data)}: {pkg_data}"
+            )
+        pkg_data = pkg_data[0]
+        nodes.add(pkg_name)
+        sub_deps = set(pkg_data.get('deps', []))
+        nodes |= sub_deps
+        for sub_dep in sub_deps:
+            graph[sub_dep].add(pkg_name)
+
+    return nodes, graph
+
+
+def topological_sort(nodes, graph):
+    """Sort packages deps in topological order to ensure dependencies are installed before dependents
+
+    Parameters:
+        - nodes: set of package names
+        - graph: dict mapping package name to set of packages that depend on it
+
+    Returns:
+        - sorted_list: list of package names sorted in topological order
+    """
+    incoming_count = {node: 0 for node in nodes}
+    for parents in graph.values():
+        for parent in parents:
+            incoming_count[parent] += 1
+
+    sorted_list = []
+    while nodes:
+        no_incoming = [node for node in nodes if incoming_count[node] == 0]
+        if not no_incoming:
+            raise ValueError("Graph has a cycle, cannot perform topological sort")
+        no_incoming.sort()  # sort alphabetically
+        sorted_list.extend(no_incoming)
+        for node in no_incoming:
+            nodes.remove(node)
+            for parent in graph[node]:
+                incoming_count[parent] -= 1
+
+    return sorted_list
+
+
+def generate_exts_list(sourcedir, tab_depth=4):
+    """Helper for generating exts_list with Julia packages in topological order"""
+    nodes, graph = get_package_dep_graph(sourcedir)
+    sorted_packages = topological_sort(nodes, graph)
+    package_data = generate_package_data(sourcedir)
+
+    tab = ' ' * tab_depth
+
+    exts_list = []
+
+    exts_list.append('exts_list = [')
+    for pkg_name in sorted_packages:
+        pkg_info = package_data[pkg_name]
+        name = pkg_info['name']
+        version = pkg_info['version']
+        url = pkg_info['url']
+        sources = pkg_info.get('sources', None)
+        checksum = pkg_info['checksum']
+        if checksum is not None:
+            checksum = f"'{checksum}'"
+        if isinstance(url, IsJuliaPackage):
+            continue
+        exts_list.append(tab   + f"('{name}', '{version}', {{")
+        exts_list.append(tab*2 + f"'source_urls': ['{url}'],")
+        if sources is not None:
+            exts_list.append(tab*2 + f"'sources': {sources},")
+        exts_list.append(tab*2 + f"'checksums': [{checksum}],")
+        exts_list.append(tab   + '}),')
+    exts_list.append(']')
+
+    return '\n'.join(exts_list)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print('Expected path to folder containing Manifest.toml')
+        sys.exit(1)
+    if len(sys.argv) > 2:
+        tab_depth = int(sys.argv[2])
+    else:
+        tab_depth = 4
+    if len(sys.argv) > 3:
+        print('Ignoring extra arguments: %s' % sys.argv[3:])
+
+    print(generate_exts_list(sys.argv[1], tab_depth=tab_depth))
+
+
+if __name__ == '__main__':
+    main()

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -33,7 +33,6 @@ import subprocess
 import sys
 import tempfile
 import time
-import toml
 from collections import defaultdict
 
 from easybuild.easyblocks.generic.bundle import Bundle

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -299,7 +299,9 @@ def is_system_package(pkg_name):
 def generate_package_data(sourcedir):
     """Extract package data from Manifest.toml, including determining source URLs for
     packages based on available information"""
-    manifest_toml = toml.load(os.path.join(sourcedir, 'Manifest.toml'))
+    with open(os.path.join(sourcedir, 'Manifest.toml'), 'r') as f:
+        content = f.read()
+        manifest_toml = toml.loads(content)
 
     packages_data = {}
 
@@ -358,7 +360,9 @@ def get_package_dep_graph(sourcedir):
         - nodes: set of package names
         - graph: dict mapping package name to set of packages that depend on it
     """
-    manifest_toml = toml.load(os.path.join(sourcedir, 'Manifest.toml'))
+    with open(os.path.join(sourcedir, 'Manifest.toml'), 'r') as f:
+        content = f.read()
+        manifest_toml = toml.loads(content)
 
     nodes = set()
     graph = defaultdict(set)

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -126,15 +126,26 @@ class JuliaBundle(Bundle, JuliaPackage):
 
 IsJuliaPackage = type('IsJuliaPackage', (), {})  # sentinel value to indicate package is part of Julia stdlib
 
+JULIA_EXEC = None
+GIT_EXEC = None
+SYSTEM_PACKAGES = set()
+SYSTEM_PACKAGES_TESTED = set()
+
 
 def get_git_exec():
     """Get path to git executable"""
-    return subprocess.run(['which', 'git'], capture_output=True, text=True).stdout.strip()
+    global GIT_EXEC
+    if GIT_EXEC is None:
+        GIT_EXEC = subprocess.run(['which', 'git'], capture_output=True, text=True).stdout.strip()
+    return GIT_EXEC
 
 
 def get_julia_exec():
     """Get path to Julia executable"""
-    return subprocess.run(['which', 'julia'], capture_output=True, text=True).stdout.strip()
+    global JULIA_EXEC
+    if JULIA_EXEC is None:
+        JULIA_EXEC = subprocess.run(['which', 'julia'], capture_output=True, text=True).stdout.strip()
+    return JULIA_EXEC
 
 
 def check_needed_tools():
@@ -265,12 +276,31 @@ def get_url_from_general(pkg, git_tree_sha1, max_retries=3):
     return url, filename
 
 
+def is_system_package(pkg_name):
+    """Helper to determine if a package is part of the Julia standard library"""
+    if pkg_name in SYSTEM_PACKAGES_TESTED:
+        return pkg_name in SYSTEM_PACKAGES
+
+    SYSTEM_PACKAGES_TESTED.add(pkg_name)
+    julia_exec = get_julia_exec()
+    if not julia_exec:
+        return False
+
+    req = subprocess.run(
+        [julia_exec, '-e', f'import Base; println(Base.find_package("{pkg_name}"))'],
+        capture_output=True, text=True
+    )
+    path = req.stdout.strip()
+    res = bool(path and path != "nothing")
+    if res:
+        SYSTEM_PACKAGES.add(pkg_name)
+    return res
+
+
 def generate_package_data(sourcedir):
     """Extract package data from Manifest.toml, including determining source URLs for
     packages based on available information"""
     manifest_toml = toml.load(os.path.join(sourcedir, 'Manifest.toml'))
-
-    julia_exec = get_julia_exec()
 
     packages_data = {}
 
@@ -306,15 +336,9 @@ def generate_package_data(sourcedir):
             print(f"Found package {pkg_name:>30s} with git tree SHA1, determined URL from General registry: {url}")
 
         # Check if the package is part of the Julia standard library, if so we don't need a source URL
-        if url is None and julia_exec:
-            req = subprocess.run(
-                [julia_exec, '-e', f'import Base; println(Base.find_package("{pkg_name}"))'],
-                capture_output=True, text=True
-            )
-            path = req.stdout.strip()
-            if path and path != "nothing":
-                print(f"Found Package {pkg_name:>30s} is part of the Julia standard library, no source URL needed")
-                url = IsJuliaPackage()
+        if url is None and is_system_package(pkg_name):
+            print(f"Found Package {pkg_name:>30s} is part of the Julia standard library, no source URL needed")
+            url = IsJuliaPackage()
 
         if url is None:
             print(f"WARNING: Could not determine source URL for package {pkg_name} (version {version})")
@@ -387,18 +411,42 @@ def topological_sort(nodes, graph):
     return sorted_list
 
 
-def generate_exts_list(sourcedir, tab_depth=4):
+def print_dep_graph(pkg_name, graph=None, graph_inv=None, level=0, prefix='| ', hide_system=True):
+    """Helper for printing package dependency graph"""
+    if graph:
+        graph_inv = defaultdict(set)
+        for node, parents in graph.items():
+            for parent in parents:
+                graph_inv[parent].add(node)
+
+        dependent_count = {node: len(parents) for node, parents in graph.items()}
+        print("Packages sorted by number of dependents (packages that depend on them):")
+        for item in sorted((v,k) for k,v in dependent_count.items())[::-1]:
+            print(f"{item[1]:>40s}: {item[0]:>4d} dependents")
+        with_str = "with" if not hide_system else "without"
+        print(f"\nDependency graph ({with_str} system packages):")
+
+    if hide_system and is_system_package(pkg_name):
+        return
+
+    print(f"{prefix*level}{pkg_name}")
+    for dep in sorted(graph_inv.get(pkg_name, [])):
+        print_dep_graph(dep, graph_inv=graph_inv, level=level+1, prefix=prefix, hide_system=hide_system)
+
+
+def generate_exts_list(sourcedir, packages, tab_depth=4):
     """Helper for generating exts_list with Julia packages in topological order"""
-    nodes, graph = get_package_dep_graph(sourcedir)
-    sorted_packages = topological_sort(nodes, graph)
     package_data = generate_package_data(sourcedir)
 
     tab = ' ' * tab_depth
 
     exts_list = []
 
+    exts_list.append(
+        '# Order is important as all dependencies of a package must be installed before the package itself'
+    )
     exts_list.append('exts_list = [')
-    for pkg_name in sorted_packages:
+    for pkg_name in packages:
         pkg_info = package_data[pkg_name]
         name = pkg_info['name']
         version = pkg_info['version']
@@ -413,7 +461,12 @@ def generate_exts_list(sourcedir, tab_depth=4):
         exts_list.append(tab*2 + f"'easyblock': 'JuliaPackage',")
         exts_list.append(tab*2 + f"'source_urls': ['{url}'],")
         if sources is not None:
-            exts_list.append(tab*2 + f"'sources': {sources},")
+            # exts_list.append(tab*2 + f"'sources': {sources},")
+            exts_list.append(tab*2 + "'sources': [{")
+            for key, value in sources[0].items():
+                exts_list.append(tab*3 + f"'{key}': '{value}',")
+            exts_list.append(tab*2 + "}],")
+
         exts_list.append(tab*2 + f"'checksums': [{checksum}],")
         exts_list.append(tab + '}),')
     exts_list.append(']')
@@ -425,15 +478,26 @@ def main():
     if len(sys.argv) < 2:
         print('Expected path to folder containing Manifest.toml')
         sys.exit(1)
+
+    sourcedir = sys.argv[1]
+    tab_depth = 4
+    print_graph_info = False
+
     if len(sys.argv) > 2:
         tab_depth = int(sys.argv[2])
-    else:
-        tab_depth = 4
     if len(sys.argv) > 3:
+        print_graph_info = bool(sys.argv[3].lower() in ['true', '1', 'yes'])
+    if len(sys.argv) > 4:
         print('Ignoring extra arguments: %s' % sys.argv[3:])
 
     check_needed_tools()
-    print(generate_exts_list(sys.argv[1], tab_depth=tab_depth))
+
+    nodes, graph = get_package_dep_graph(sourcedir)
+    sorted_packages = topological_sort(nodes, graph)
+    if print_graph_info:
+        print_dep_graph(sorted_packages[-1], graph=graph, hide_system=True)
+
+    print(generate_exts_list(sourcedir, sorted_packages, tab_depth=tab_depth))
 
 
 if __name__ == '__main__':

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -159,7 +159,6 @@ def check_needed_tools():
     if not HAS_REQUESTS:
         print("WARNING: requests library not available, cannot fetch package data from General registry")
 
-
 def get_commit_from_git_tree_sha1(repo, git_tree_sha1):
     """"Determine commit corresponding to git tree SHA1 by cloning the repo and searching the git log"""
     git_exec = get_git_exec()
@@ -273,13 +272,16 @@ def get_url_from_general(pkg, version, git_tree_sha1, max_retries=3):
             is_default_filename = True
             filename = default_filename
         else:
-            commit = get_commit_from_git_tree_sha1(repo, git_tree_sha1)
-            if commit:
-                filename = f'{commit}.tar.gz'
-            else:
-                url = None
-                filename = None
-                print(f"WARNING: Could not determine commit for git tree SHA1 {git_tree_sha1} in GITHUB repo {repo}")
+            filename = f'{git_tree_sha1}.tar.gz'
+            # Tree SHAs can be associated to a subdirectory (not the root-directory) so one would need to traverse all
+            # the commits/tags and their associated root tree to find the commit that contains the given tree SHA1.
+            # commit = get_commit_from_git_tree_sha1(repo, git_tree_sha1)
+            # if commit:
+            #     filename = f'{commit}.tar.gz'
+            # else:
+            #     url = None
+            #     filename = None
+            #     print(f"WARNING: Could not determine commit for git tree SHA1 {git_tree_sha1} in GITHUB repo {repo}")
 
     if 'gitlab.com' in base_url:
         # https://gitlab.com/ExpandingMan/ShowCases.jl/-/archive/1ea211f349b40165a2b5fbbc80f771d6dcb725ad/ShowCases.jl-1ea211f349b40165a2b5fbbc80f771d6dcb725ad.tar.gz
@@ -345,6 +347,7 @@ def generate_package_data(sourcedir):
         version = pkg_data.get('version')
         git_tree_sha1 = pkg_data.get('git-tree-sha1', None)
 
+        is_default = False
         url = None
         item = {
             'name': pkg_name,
@@ -358,7 +361,7 @@ def generate_package_data(sourcedir):
 
         if url is None and git_tree_sha1 is not None:
             url, download_filename, is_default = get_url_from_general(pkg_name, version, git_tree_sha1)
-            filename = f'{pkg_name}-{version}.tar.gz'
+            filename = '%(name)s-%(version)s.tar.gz'
             if not is_default:
                 item['sources'] = [{
                     'download_filename': download_filename,
@@ -377,7 +380,8 @@ def generate_package_data(sourcedir):
         item['url'] = url
         packages_data[pkg_name] = item
 
-        if url is not None and isinstance(url, str) and download_filename is not None:
+        # Do not calculate checksum if is_default is False since tree-sha checksums are not stable
+        if url is not None and isinstance(url, str) and download_filename is not None and is_default:
             item['checksum'] = get_sha256_from_url(url + download_filename)
 
     return packages_data

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -29,7 +29,6 @@ EasyBuild support for bundles of Julia packages, implemented as an easyblock
 @author: Davide Grassano (CECAM, EPFL)
 """
 import os
-import requests
 import subprocess
 import sys
 import tempfile
@@ -39,6 +38,14 @@ from collections import defaultdict
 
 from easybuild.easyblocks.generic.bundle import Bundle
 from easybuild.easyblocks.generic.juliapackage import EXTS_FILTER_JULIA_PACKAGES, JuliaPackage
+
+
+HAS_REQUESTS = False
+try:
+    import requests
+    HAS_REQUESTS = True
+except ImportError:
+    pass
 
 
 class JuliaBundle(Bundle, JuliaPackage):
@@ -109,11 +116,42 @@ class JuliaBundle(Bundle, JuliaPackage):
 IsJuliaPackage = type('IsJuliaPackage', (), {})  # sentinel value to indicate package is part of Julia stdlib
 
 
+def get_git_exec():
+    """Get path to git executable"""
+    return subprocess.run(['which', 'git'], capture_output=True, text=True).stdout.strip()
+
+
+def get_julia_exec():
+    """Get path to Julia executable"""
+    return subprocess.run(['which', 'julia'], capture_output=True, text=True).stdout.strip()
+
+
+def check_needed_tools():
+    """Check if needed dependencies and executables are available for determining source URLs from git tree SHA1"""
+    julia_exec = get_julia_exec()
+    git_exec = get_git_exec()
+
+    if not julia_exec:
+        print("WARNING: No Julia executable found in PATH, cannot determine if packages are part of standard library")
+    else:
+        print(f"Found Julia executable at: {julia_exec}")
+
+    if not git_exec:
+        print(
+            "WARNING: No git executable found in PATH, cannot determine commit from git tree SHA1 for packages "
+            "hosted on GitLab"
+            )
+    else:
+        print(f"Found git executable at: {git_exec}")
+
+    if not HAS_REQUESTS:
+        print("WARNING: requests library not available, cannot fetch package data from General registry")
+
+
 def get_commit_from_git_tree_sha1(repo, git_tree_sha1):
     """"Determine commit corresponding to git tree SHA1 by cloning the repo and searching the git log"""
-    git_exec = subprocess.run(['which', 'git'], capture_output=True, text=True).stdout.strip()
+    git_exec = get_git_exec()
     if not git_exec:
-        print("No git executable found in PATH, cannot determine commit from git tree SHA1")
         return None
 
     commit = None
@@ -150,6 +188,9 @@ def get_commit_from_git_tree_sha1(repo, git_tree_sha1):
 
 def get_url_from_general(pkg, git_tree_sha1, max_retries=3):
     """Get the package info from the General registry"""
+    if not HAS_REQUESTS:
+        print("WARNING: requests library not available, cannot fetch package data from General registry")
+        return None, None
     if pkg.endswith('_jll'):
         base_url = "https://github.com/JuliaRegistries/General/raw/refs/heads/master/jll/{}/{}/"
     else:
@@ -214,11 +255,7 @@ def generate_package_data(sourcedir):
     packages based on available information"""
     manifest_toml = toml.load(os.path.join(sourcedir, 'Manifest.toml'))
 
-    julia_exec = subprocess.run(['which', 'julia'], capture_output=True, text=True).stdout.strip()
-    if julia_exec:
-        print(f"Found Julia executable at: {julia_exec}")
-    else:
-        print("No Julia executable found in PATH, skipping checks for standard library packages")
+    julia_exec = get_julia_exec()
 
     packages_data = {}
 
@@ -379,6 +416,7 @@ def main():
     if len(sys.argv) > 3:
         print('Ignoring extra arguments: %s' % sys.argv[3:])
 
+    check_needed_tools()
     print(generate_exts_list(sys.argv[1], tab_depth=tab_depth))
 
 

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -37,6 +37,7 @@ from collections import defaultdict
 
 from easybuild.easyblocks.generic.bundle import Bundle
 from easybuild.easyblocks.generic.juliapackage import EXTS_FILTER_JULIA_PACKAGES, JuliaPackage
+from easybuild.tools import tomllib as toml
 
 
 HAS_REQUESTS = False
@@ -45,17 +46,6 @@ try:
     HAS_REQUESTS = True
 except ImportError:
     pass
-
-HAS_TOML = False
-try:
-    import tomllib as toml
-    HAS_TOML = True
-except ImportError:
-    try:
-        import toml
-        HAS_TOML = True
-    except ImportError:
-        pass
 
 
 class JuliaBundle(Bundle, JuliaPackage):
@@ -152,11 +142,6 @@ def check_needed_tools():
     julia_exec = get_julia_exec()
     git_exec = get_git_exec()
 
-    if not HAS_TOML:
-        print("ERROR: No TOML library available, cannot parse Manifest.toml")
-        print("Either use Python 3.11+ or install `toml`")
-        sys.exit(1)
-
     if not julia_exec:
         print("WARNING: No Julia executable found in PATH, cannot determine if packages are part of standard library")
     else:
@@ -240,7 +225,7 @@ def get_url_from_general(pkg, version, git_tree_sha1, max_retries=3):
             try:
                 package_info = toml.loads(package_data)
                 break
-            except toml.TomlDecodeError as exc:
+            except toml.TOMLDecodeError as exc:
                 last_exception = exc
                 print(f"Error parsing Package.toml for package {pkg} from General registry: {exc}")
                 max_retries -= 1

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -159,25 +159,28 @@ def get_url_from_general(pkg, git_tree_sha1, max_retries=3):
 
     sleep_time = 1
 
+    last_exception = None
     while max_retries > 0:
         time.sleep(sleep_time)
         sleep_time *= 2  # exponential backoff
         try:
             package_data = requests.get(package_url).text
-        except requests.RequestException as e:
-            print(f"Error fetching package data from General registry: {e}")
+        except requests.RequestException as exc:
+            last_exception = exc
+            print(f"Error fetching package data from General registry: {exc}")
             max_retries -= 1
             continue
         else:
             try:
                 package_info = toml.loads(package_data)
                 break
-            except toml.TomlDecodeError as e:
-                print(f"Error parsing Package.toml for package {pkg} from General registry: {e}")
+            except toml.TomlDecodeError as exc:
+                last_exception = exc
+                print(f"Error parsing Package.toml for package {pkg} from General registry: {exc}")
                 max_retries -= 1
     else:
         print(f"Failed to fetch and parse package data for {pkg} from General registry after multiple attempts")
-        print(f"Last error fetching package data from General registry: {e}")
+        print(f"Last error fetching package data from General registry: {last_exception}")
         print(f"Last package data that caused the error:\n{package_data}")
         raise RuntimeError(
             f"Failed to fetch and parse package data for {pkg} from General registry after multiple attempts"
@@ -312,7 +315,7 @@ def topological_sort(nodes, graph):
     Returns:
         - sorted_list: list of package names sorted in topological order
     """
-    incoming_count = {node: 0 for node in nodes}
+    incoming_count = dict.fromkeys(nodes, 0)
     for parents in graph.values():
         for parent in parents:
             incoming_count[parent] += 1
@@ -354,12 +357,12 @@ def generate_exts_list(sourcedir, tab_depth=4):
             checksum = f"'{checksum}'"
         if isinstance(url, IsJuliaPackage):
             continue
-        exts_list.append(tab   + f"('{name}', '{version}', {{")
+        exts_list.append(tab + f"('{name}', '{version}', {{")
         exts_list.append(tab*2 + f"'source_urls': ['{url}'],")
         if sources is not None:
             exts_list.append(tab*2 + f"'sources': {sources},")
         exts_list.append(tab*2 + f"'checksums': [{checksum}],")
-        exts_list.append(tab   + '}),')
+        exts_list.append(tab + '}),')
     exts_list.append(']')
 
     return '\n'.join(exts_list)

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -253,16 +253,18 @@ def get_url_from_general(pkg, version, git_tree_sha1, max_retries=3):
         )
 
     repo = package_info['repo']
-    url = repo.rstrip('/')
-    if url.endswith('.git'):
-        url = url[:-4]
+    base_url = repo.rstrip('/')
+    if base_url.endswith('.git'):
+        base_url = base_url[:-4]
 
     filename = None
     is_default_filename = False
-    default_filename = f'v{version}.tar.gz'
+    default_tag = f'v{version}'
+    default_filename = f'{default_tag}.tar.gz'
 
-    if 'github.com' in url:
-        url = url + "/archive/"
+    if 'github.com' in base_url:
+        url = base_url + "/archive/"
+        # Test if downloading based on tag works
         res = requests.head(url + default_filename, allow_redirects=True)
         if res.status_code == 200:
             is_default_filename = True
@@ -270,16 +272,25 @@ def get_url_from_general(pkg, version, git_tree_sha1, max_retries=3):
         else:
             filename = f'{git_tree_sha1}.tar.gz'
 
-    if 'gitlab.com' in url:
+    if 'gitlab.com' in base_url:
         # https://gitlab.com/ExpandingMan/ShowCases.jl/-/archive/1ea211f349b40165a2b5fbbc80f771d6dcb725ad/ShowCases.jl-1ea211f349b40165a2b5fbbc80f771d6dcb725ad.tar.gz
-        commit = get_commit_from_git_tree_sha1(repo, git_tree_sha1)
-        if commit:
-            url = url + f"/-/archive/{commit}/"
-            filename = f'{pkg}.jl-{commit[:8]}.tar.gz'
+        # https://gitlab.com/QEF/q-e/-/archive/qe-7.5/q-e-qe-7.5.tar.gz
+        url = base_url + f"/-/archive/{default_tag}/"
+        # Test if downloading based on tag works
+        res = requests.head(url + f'{pkg}.jl-' + default_filename, allow_redirects=True)
+        if res.status_code == 200:
+            # is_default_filename = True
+            url = base_url + "/-/archive/v%(version)s/"
+            filename = f'{pkg}.jl-{default_tag}.tar.gz'
         else:
-            url = None
-            filename = None
-            print(f"WARNING: Could not determine commit for git tree SHA1 {git_tree_sha1} in GITLAB repo {repo}")
+            commit = get_commit_from_git_tree_sha1(repo, git_tree_sha1)
+            if commit:
+                url = base_url + f"/-/archive/{commit}/"
+                filename = f'{pkg}.jl-{commit[:8]}.tar.gz'
+            else:
+                url = None
+                filename = None
+                print(f"WARNING: Could not determine commit for git tree SHA1 {git_tree_sha1} in GITLAB repo {repo}")
 
     return url, filename, is_default_filename
 

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -273,7 +273,13 @@ def get_url_from_general(pkg, version, git_tree_sha1, max_retries=3):
             is_default_filename = True
             filename = default_filename
         else:
-            filename = f'{git_tree_sha1}.tar.gz'
+            commit = get_commit_from_git_tree_sha1(repo, git_tree_sha1)
+            if commit:
+                filename = f'{commit}.tar.gz'
+            else:
+                url = None
+                filename = None
+                print(f"WARNING: Could not determine commit for git tree SHA1 {git_tree_sha1} in GITHUB repo {repo}")
 
     if 'gitlab.com' in base_url:
         # https://gitlab.com/ExpandingMan/ShowCases.jl/-/archive/1ea211f349b40165a2b5fbbc80f771d6dcb725ad/ShowCases.jl-1ea211f349b40165a2b5fbbc80f771d6dcb725ad.tar.gz

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -212,10 +212,10 @@ def get_commit_from_git_tree_sha1(repo, git_tree_sha1):
     return commit
 
 
-def get_url_from_general(pkg, git_tree_sha1, max_retries=3):
+def get_url_from_general(pkg, version, git_tree_sha1, max_retries=3):
     """Get the package info from the General registry"""
     if not HAS_REQUESTS:
-        return None, None
+        return None, None, None
     if pkg.endswith('_jll'):
         base_url = "https://github.com/JuliaRegistries/General/raw/refs/heads/master/jll/{}/{}/"
     else:
@@ -257,9 +257,18 @@ def get_url_from_general(pkg, git_tree_sha1, max_retries=3):
     if url.endswith('.git'):
         url = url[:-4]
 
+    filename = None
+    is_default_filename = False
+    default_filename = f'v{version}.tar.gz'
+
     if 'github.com' in url:
         url = url + "/archive/"
-        filename = f'{git_tree_sha1}.tar.gz'
+        res = requests.head(url + default_filename, allow_redirects=True)
+        if res.status_code == 200:
+            is_default_filename = True
+            filename = default_filename
+        else:
+            filename = f'{git_tree_sha1}.tar.gz'
 
     if 'gitlab.com' in url:
         # https://gitlab.com/ExpandingMan/ShowCases.jl/-/archive/1ea211f349b40165a2b5fbbc80f771d6dcb725ad/ShowCases.jl-1ea211f349b40165a2b5fbbc80f771d6dcb725ad.tar.gz
@@ -272,7 +281,7 @@ def get_url_from_general(pkg, git_tree_sha1, max_retries=3):
             filename = None
             print(f"WARNING: Could not determine commit for git tree SHA1 {git_tree_sha1} in GITLAB repo {repo}")
 
-    return url, filename
+    return url, filename, is_default_filename
 
 
 def is_system_package(pkg_name):
@@ -328,12 +337,13 @@ def generate_package_data(sourcedir):
             print(f"Found package {pkg_name:>30s} with explicit repo URL: {url}")
 
         if url is None and git_tree_sha1 is not None:
-            url, download_filename = get_url_from_general(pkg_name, git_tree_sha1)
+            url, download_filename, is_default = get_url_from_general(pkg_name, version, git_tree_sha1)
             filename = f'{pkg_name}-{version}.tar.gz'
-            item['sources'] = [{
-                'download_filename': download_filename,
-                'filename': filename,
-            }]
+            if not is_default:
+                item['sources'] = [{
+                    'download_filename': download_filename,
+                    'filename': filename,
+                }]
             print(f"Found package {pkg_name:>30s} with git tree SHA1, determined URL from General registry: {url}")
 
         # Check if the package is part of the Julia standard library, if so we don't need a source URL
@@ -445,6 +455,18 @@ def generate_exts_list(sourcedir, packages, tab_depth=4):
 
     exts_list = []
 
+    exts_list.extend([
+        '',
+        '-' * 80,
+        '- Extensions list to copy in the JuliaBundle easyconfig:',
+        '# Default options for all extensions, can be overridden by individual packages if needed',
+        'exts_default_options = {',
+        tab + "# Some julia packages like LLVM and CUDA would default to the LLVM/CUDA EasyBlock respectively",
+        tab + "'easyblock': 'JuliaPackage',",
+        '}',
+        '',
+    ])
+
     exts_list.append(
         '# Order is important as all dependencies of a package must be installed before the package itself'
     )
@@ -461,7 +483,6 @@ def generate_exts_list(sourcedir, packages, tab_depth=4):
         if isinstance(url, IsJuliaPackage):
             continue
         exts_list.append(tab + f"('{name}', '{version}', {{")
-        exts_list.append(tab*2 + "'easyblock': 'JuliaPackage',")
         exts_list.append(tab*2 + f"'source_urls': ['{url}'],")
         if sources is not None:
             # exts_list.append(tab*2 + f"'sources': {sources},")

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -420,7 +420,7 @@ def print_dep_graph(pkg_name, graph=None, graph_inv=None, level=0, prefix='| ', 
 
         dependent_count = {node: len(parents) for node, parents in graph.items()}
         print("Packages sorted by number of dependents (packages that depend on them):")
-        for item in sorted((v,k) for k,v in dependent_count.items())[::-1]:
+        for item in sorted((v, k) for k, v in dependent_count.items())[::-1]:
             print(f"{item[1]:>40s}: {item[0]:>4d} dependents")
         with_str = "with" if not hide_system else "without"
         print(f"\nDependency graph ({with_str} system packages):")
@@ -457,7 +457,7 @@ def generate_exts_list(sourcedir, packages, tab_depth=4):
         if isinstance(url, IsJuliaPackage):
             continue
         exts_list.append(tab + f"('{name}', '{version}', {{")
-        exts_list.append(tab*2 + f"'easyblock': 'JuliaPackage',")
+        exts_list.append(tab*2 + "'easyblock': 'JuliaPackage',")
         exts_list.append(tab*2 + f"'source_urls': ['{url}'],")
         if sources is not None:
             # exts_list.append(tab*2 + f"'sources': {sources},")

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -189,7 +189,6 @@ def get_commit_from_git_tree_sha1(repo, git_tree_sha1):
 def get_url_from_general(pkg, git_tree_sha1, max_retries=3):
     """Get the package info from the General registry"""
     if not HAS_REQUESTS:
-        print("WARNING: requests library not available, cannot fetch package data from General registry")
         return None, None
     if pkg.endswith('_jll'):
         base_url = "https://github.com/JuliaRegistries/General/raw/refs/heads/master/jll/{}/{}/"

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -159,6 +159,7 @@ def check_needed_tools():
     if not HAS_REQUESTS:
         print("WARNING: requests library not available, cannot fetch package data from General registry")
 
+
 def get_commit_from_git_tree_sha1(repo, git_tree_sha1):
     """"Determine commit corresponding to git tree SHA1 by cloning the repo and searching the git log"""
     git_exec = get_git_exec()

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -28,6 +28,7 @@ EasyBuild support for bundles of Julia packages, implemented as an easyblock
 @author: Alex Domingo (Vrije Universiteit Brussel)
 @author: Davide Grassano (CECAM, EPFL)
 """
+import hashlib
 import os
 import subprocess
 import sys
@@ -197,6 +198,23 @@ def get_commit_from_git_tree_sha1(repo, git_tree_sha1):
     return commit
 
 
+def get_sha256_from_url(url):
+    """Helper to get SHA256 checksum from URL by downloading the file and calculating the checksum"""
+    if not HAS_REQUESTS:
+        return None
+
+    try:
+        response = requests.get(url, stream=True)
+        response.raise_for_status()
+        sha256_hash = hashlib.sha256()
+        for chunk in response.iter_content(chunk_size=8192):
+            sha256_hash.update(chunk)
+        return sha256_hash.hexdigest()
+    except requests.RequestException as exc:
+        print(f"Error fetching file from URL {url} to calculate SHA256 checksum: {exc}")
+        return None
+
+
 def get_url_from_general(pkg, version, git_tree_sha1, max_retries=3):
     """Get the package info from the General registry"""
     if not HAS_REQUESTS:
@@ -352,6 +370,9 @@ def generate_package_data(sourcedir):
 
         item['url'] = url
         packages_data[pkg_name] = item
+
+        if url is not None and isinstance(url, str) and download_filename is not None:
+            item['checksum'] = get_sha256_from_url(url + download_filename)
 
     return packages_data
 

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -47,6 +47,17 @@ try:
 except ImportError:
     pass
 
+HAS_TOML = False
+try:
+    import tomllib as toml
+    HAS_TOML = True
+except ImportError:
+    try:
+        import toml
+        HAS_TOML = True
+    except ImportError:
+        pass
+
 
 class JuliaBundle(Bundle, JuliaPackage):
     """
@@ -130,6 +141,11 @@ def check_needed_tools():
     """Check if needed dependencies and executables are available for determining source URLs from git tree SHA1"""
     julia_exec = get_julia_exec()
     git_exec = get_git_exec()
+
+    if not HAS_TOML:
+        print("ERROR: No TOML library available, cannot parse Manifest.toml")
+        print("Either use Python 3.11+ or install `toml`")
+        sys.exit(1)
 
     if not julia_exec:
         print("WARNING: No Julia executable found in PATH, cannot determine if packages are part of standard library")


### PR DESCRIPTION
Add a set of utility functions to the `juliabundle.py` similar to `cargo.py` to allow running 

```
python -m easybuild.easyblocks.generic.juliabundle PATH_TO_DIR_WITH_MANIFEST
```

from an installed package to generate the `exts_list` block to add to a JuliaBundle-based EC

## Notes

- The repo URL is fetched with the following order:
  - From the Manifest if explicitly present
  - From github/gitlab based on the `git-tree-sha1` if present
  - Check if it is not needed if the package is part of base packages already included with Julia
  - Leave it as a None for the user to check while printing a WARNING
- Extensions are sorted so that dependent packages are always installed after their dependencies

## Possible improvements

- [ ] Allow getting info from repositories other then `General`
- [ ] Maybe also automatically generate the checksums
- [ ] Is there a way to directly fetch from Gitlab from a given tree SHA