### PR TITLE
Fix for running `--sanity-check-only` for a `JuliaBundle`

### DIFF
--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -38,7 +38,7 @@ import easybuild.tools.environment as env
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.modules import get_software_root, get_software_version
+from easybuild.tools.modules import get_software_root
 from easybuild.tools.filetools import copy_dir, mkdir
 from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.utilities import trace_msg

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -118,11 +118,31 @@ class JuliaPackage(ExtensionEasyBlock):
 
         return parsed_var
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._julia_version = None
+
+    @property
+    def julia_version(self) -> str:
+        """Needs to get Julia version from dependencies to allow --sanity-check-only to generate the fake module"""
+        if self._julia_version is None:
+            deps = self.cfg.dependencies(runtime_only=True)
+            for dep in deps:
+                if dep['name'] == 'Julia':
+                    self._julia_version = dep['version']
+                    break
+            else:
+                raise EasyBuildError(
+                    "Julia not included as dependency, cannot determine Julia version for installation of: %s",
+                    self.name
+                )
+        return self._julia_version
+
     def julia_env_path(self, absolute=True, base=True):
         """
         Return path to installation environment file.
         """
-        julia_version = get_software_version('Julia').split('.')
+        julia_version = self.julia_version.split('.')
         env_dir = "v{}.{}".format(*julia_version[:2])
         project_env = os.path.join("environments", env_dir, "Project.toml")
 
@@ -137,8 +157,7 @@ class JuliaPackage(ExtensionEasyBlock):
         """Enable offline mode of Julia Pkg"""
 
         if not self.cfg['download_pkg_deps']:
-            julia_version = get_software_version('Julia')
-            if LooseVersion(julia_version) >= LooseVersion('1.5'):
+            if LooseVersion(self.julia_version) >= LooseVersion('1.5'):
                 # Enable offline mode of Julia Pkg
                 # https://pkgdocs.julialang.org/v1/api/#Pkg.offline
                 env.setvar('JULIA_PKG_OFFLINE', 'true')
@@ -148,7 +167,7 @@ class JuliaPackage(ExtensionEasyBlock):
                     "Enable easyconfig option 'download_pkg_deps' to allow installation "
                     "with any extra downloaded dependencies."
                 )
-                raise EasyBuildError(errmsg, julia_version)
+                raise EasyBuildError(errmsg, self.julia_version)
 
     def prepare_julia_env(self):
         """
@@ -304,14 +323,6 @@ class JuliaPackage(ExtensionEasyBlock):
             'dirs': [pkg_dir],
         }
         kwargs.update({'custom_paths': custom_paths})
-
-        # load module early ourselves rather than letting parent sanity_check_step method do so,
-        # since custom actions taken below require that environment is set up properly already
-        # (especially when using --sanity-check-only)
-        if not self.sanity_check_module_loaded:
-            extension = self.is_extension or kwargs.get('extension', False)
-            extra_modules = kwargs.get('extra_modules', None)
-            self.sanity_check_load_module(extension=extension, extra_modules=extra_modules)
 
         return ExtensionEasyBlock.sanity_check_step(self, EXTS_FILTER_JULIA_PACKAGES, *args, **kwargs)
 

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -305,6 +305,14 @@ class JuliaPackage(ExtensionEasyBlock):
         }
         kwargs.update({'custom_paths': custom_paths})
 
+        # load module early ourselves rather than letting parent sanity_check_step method do so,
+        # since custom actions taken below require that environment is set up properly already
+        # (especially when using --sanity-check-only)
+        if not self.sanity_check_module_loaded:
+            extension = self.is_extension or kwargs.get('extension', False)
+            extra_modules = kwargs.get('extra_modules', None)
+            self.sanity_check_load_module(extension=extension, extra_modules=extra_modules)
+
         return ExtensionEasyBlock.sanity_check_step(self, EXTS_FILTER_JULIA_PACKAGES, *args, **kwargs)
 
     def make_module_extra(self, *args, **kwargs):

--- a/test/easyblocks/module.py
+++ b/test/easyblocks/module.py
@@ -451,7 +451,7 @@ def suite(loader):
         write_file(os.path.join(TMPDIR, 'modules', 'all', prgenv, '1.2.3'), "#%Module")
 
     # add empty module files for dependencies that are required for testing easyblocks
-    for dep_mod_name in ('foo/1.2.3.4.5', 'PyTorch/1.12.1'):
+    for dep_mod_name in ('foo/1.2.3.4.5', 'PyTorch/1.12.1', "Julia/1.6.7"):
         write_file(os.path.join(TMPDIR, 'modules', 'all', dep_mod_name), "#%Module")
 
     for easyblock in easyblocks:
@@ -505,6 +505,10 @@ def suite(loader):
         elif eb_fn in ['python.py', 'tkinter.py']:
             # custom easyblock for Python (ensurepip) requires version >= 3.4.0
             innertest = make_inner_test(easyblock, name=eb_fn.replace('_', '-')[:-3], version='3.4.0')
+        elif eb_fn in ['juliapackage.py', 'juliabundle.py']:
+            # Building a Julia package/bundle requires Julia as a dependency
+            extra_txt = 'dependencies = [("Julia", "1.6.7")]'
+            innertest = make_inner_test(easyblock, name='julia-stuff', extra_txt=extra_txt)
         elif eb_fn == 'torchvision.py':
             # torchvision easyblock requires that PyTorch is listed as dependency
             extra_txt = "dependencies = [('PyTorch', '1.12.1')]"


### PR DESCRIPTION
Currently trying to run `--sanity-check-only` on a `JuliaBundle`-based EC fails due to the dependencies not being loaded when the main package is tested

```
  File "/home/crivella/Documents/GIT/easybuild-easyblocks/easybuild/easyblocks/generic/juliapackage.py", line 138, in julia_env_path
    julia_version = get_software_version('Julia').split('.')
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'split'
```

This in particular happens due to `get_software_version('Julia')` being called before the module is loaded

This PR adds same section as for `PythonPackage` to `JuliaPackage` to load module early