### PR TITLE
`JuliaPackage`: Allow running tests in a dedicated test_step

### DIFF
--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -31,6 +31,7 @@ import ast
 import glob
 import os
 import re
+import tempfile
 
 from easybuild.tools import LooseVersion
 
@@ -272,8 +273,47 @@ class JuliaPackage(ExtensionEasyBlock):
         pass
 
     def test_step(self):
-        """No separate (standard) test procedure for JuliaPackage."""
-        pass
+        """
+        Test the built Julia package.
+
+        :param return_output: return output and exit code of test command
+        """
+        testcmd = None
+        if isinstance(self.cfg['runtest'], str):
+            testcmd = self.cfg['runtest']
+
+        if self.cfg['runtest']:
+            if testcmd is None:
+                testcmd = f"julia -e 'using Pkg; Pkg.test(\"{self.name}\")'"
+
+            try:
+                tmpdir = tempfile.mkdtemp()
+            except OSError as err:
+                raise EasyBuildError("Failed to create test install dir: %s", err)
+
+            depot_path = self.get_julia_env("DEPOT_PATH")
+            load_path = self.get_julia_env("LOAD_PATH")
+            self.log.info("Original DEPOT_PATH for testing: %s", os.pathsep.join(depot_path))
+            self.log.info("Original LOAD_PATH for testing: %s", os.pathsep.join(load_path))
+
+            depot_path = os.pathsep.join([tmpdir] + depot_path)
+
+            extrapath = " && ".join([
+                f"export JULIA_DEPOT_PATH=\"{depot_path}\"",
+                # Ensure TEST dependencies can be downloaded
+                # The alternative is to install them as normal dependencies of the package
+                "export JULIA_PKG_OFFLINE=false",
+                ""
+            ])
+
+            cmd = ' '.join([
+                extrapath,
+                self.cfg['pretestopts'],
+                testcmd,
+                self.cfg['testopts'],
+            ])
+
+            run_shell_cmd(cmd)
 
     def install_step(self):
         """Prepare installation environment and install Julia package."""
@@ -293,6 +333,7 @@ class JuliaPackage(ExtensionEasyBlock):
 
         self.prepare_julia_env()
         self.install_pkg()
+        self._test_step()
 
     def sanity_check_step(self, *args, **kwargs):
         """Custom sanity check for JuliaPackage"""


### PR DESCRIPTION
Currently the only way to run the testsuite of a Julia package is to do so in the `sanity_check_commands`

This PR adds a way to use `runtest` and `testcmd` in the extension options to run the test suite of the package after installation.

## To discuss

- Currently the test is ran allowing installation of online packages. This is done because tests can require extra dependencies that are not installed with the package.
  The alternative currently would be to install the test dependencies as normal one so that they are available to the test step. Alternatively we would need to add a new `test_dep` flag to Julia package so that the extension can be downloaded and added to the test_dir during test but would require altering the current logic a lot
- Possibly add a `julia_cmd` detection similar to `python_cmd` for `PythonPackage`