### PR TITLE
add `exts_formatter` easyconfig paramter to `PythonPackage` easyblock to do formatting extension names in module files

### DIFF
--- a/easybuild/easyblocks/generic/pythonbundle.py
+++ b/easybuild/easyblocks/generic/pythonbundle.py
@@ -211,9 +211,10 @@ class PythonBundle(Bundle):
         """Run the pip check for extensions if enabled"""
         super()._sanity_check_step_extensions()
 
-        params = {
+        toplevel_params = {
             'sanity_pip_check': self.cfg['sanity_pip_check'],
             'sanity_check_pip_list': self.cfg['sanity_check_pip_list'],
+            'exts_formatter': self.cfg['exts_formatter'],
         }
         unversioned_packages = set(self.cfg['unversioned_packages'])
 
@@ -226,14 +227,14 @@ class PythonBundle(Bundle):
         mismatched_params = set()
 
         for ext in py_exts:
-            for param, value in params.items():
+            for param, value in toplevel_params.items():
                 if ext.cfg[param] != value:
                     mismatched_params.add(param)
             all_unversioned_packages.update(ext.cfg['unversioned_packages'])
 
-        for param in params:
+        for param in toplevel_params:
             if param in mismatched_params:
-                params[param] = True  # Either the main set it or any extension enabled it
+                toplevel_params[param] = True  # Either the main set it or any extension enabled it
 
         if all_unversioned_packages != unversioned_packages:
             mismatched_params.add('unversioned_packages')
@@ -243,11 +244,11 @@ class PythonBundle(Bundle):
                    "must be set at the top level, outside of exts_list")
             self.log.deprecated(msg, '6.0')
 
-        if params['sanity_pip_check']:
+        if toplevel_params['sanity_pip_check']:
             run_pip_check(python_cmd=self.python_cmd)
             pkgs = [(x.name, x.version) for x in py_exts]
             run_pip_list(pkgs, python_cmd=self.python_cmd, unversioned_packages=all_unversioned_packages,
-                         check_names_versions=params['sanity_check_pip_list'])
+                         check_names_versions=toplevel_params['sanity_check_pip_list'])
 
     def make_module_footer(self):
         """

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -42,8 +42,10 @@ from sysconfig import get_config_vars
 
 import easybuild.tools.environment as env
 from easybuild.base import fancylogger
-from easybuild.easyblocks.python import EXTS_FILTER_DUMMY_PACKAGES, EXTS_FILTER_PYTHON_PACKAGES, set_py_env_vars
-from easybuild.easyblocks.python import det_installed_python_packages, det_pip_version, run_pip_check, run_pip_list
+from easybuild.easyblocks.python import det_installed_python_packages, det_pip_version, EXTS_FILTER_DUMMY_PACKAGES
+from easybuild.easyblocks.python import EXTS_FILTER_PYTHON_PACKAGES, partial_normalize_pip, run_pip_check, run_pip_list
+from easybuild.easyblocks.python import set_py_env_vars
+
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.easyconfig.default import DEFAULT_CONFIG
 from easybuild.framework.easyconfig.templates import PYPI_SOURCE
@@ -491,6 +493,7 @@ class PythonPackage(ExtensionEasyBlock):
                                   CUSTOM],
             'dummy_package': [None, "Install a dummy package empty in contents but visible by Python package managers "
                                     "such as pip", CUSTOM],
+            'exts_formatter': [partial_normalize_pip, "Function to format extension names in module file", CUSTOM],
             'fix_python_shebang_for': [['bin/*'], "List of files for which Python shebang should be fixed "
                                                   "to '#!/usr/bin/env python' (glob patterns supported) "
                                                   "(default: ['bin/*'])", CUSTOM],
@@ -1274,21 +1277,22 @@ class PythonPackage(ExtensionEasyBlock):
         # inject extra '%(python)s' template value for use by sanity check commands
         self.cfg.template_values['python'] = python_cmd
 
-        params = {
+        toplevel_params = {
             'sanity_pip_check': self.cfg.get('sanity_pip_check', True),
             'sanity_check_pip_list': self.cfg.get('sanity_check_pip_list'),
+            'exts_formatter': self.cfg.get('exts_formatter'),
         }
 
         if self.is_extension:
-            for key in params:
+            for key in toplevel_params:
                 if self.master.cfg.get(key) is not None:
                     # If the main easyblock (e.g. PythonBundle) defines the variable
                     # we trust it does the 'pip check' or 'pip list' if requested and checks for mismatches
-                    params[key] = False
+                    toplevel_params[key] = False
                     self.log.info(f"'{key}' disabled for {self.name} extension, "
                                   f"assuming that parent will take care of it")
 
-        if params['sanity_pip_check']:
+        if toplevel_params['sanity_pip_check']:
             if not self.is_extension:
                 # for stand-alone Python package installations (not part of a bundle of extensions),
                 # the (fake or real) module file must be loaded at this point,
@@ -1304,7 +1308,7 @@ class PythonPackage(ExtensionEasyBlock):
             unversioned_packages = self.cfg.get('unversioned_packages', [])
             pkgs = [(self.name, self.version)]
             run_pip_list(pkgs, python_cmd=python_cmd, unversioned_packages=unversioned_packages,
-                         check_names_versions=params['sanity_check_pip_list'])
+                         check_names_versions=toplevel_params['sanity_check_pip_list'])
 
         # ExtensionEasyBlock handles loading modules correctly for multi_deps, so we clean up fake_mod_data
         # and let ExtensionEasyBlock do its job

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -77,6 +77,7 @@ PY_ENV_VARS = {
 }
 
 REGEX_PIP_NORMALIZE = re.compile(r"[-_.]+")
+REGEX_PIP_PARTIAL_NORMALIZE = re.compile(r"_+")
 
 # We want the following import order:
 # 1. Packages installed into VirtualEnv
@@ -231,6 +232,13 @@ def normalize_pip(name):
     https://packaging.python.org/en/latest/specifications/name-normalization/
     """
     return REGEX_PIP_NORMALIZE.sub('-', name).lower()
+
+
+def partial_normalize_pip(name):
+    """
+    Partially normalize pip package name: substitute underscores with hyphens and convert to lower case
+    """
+    return REGEX_PIP_PARTIAL_NORMALIZE.sub('-', name).lower()
 
 
 def run_pip_list(pkgs, python_cmd=None, unversioned_packages=None, check_names_versions=None):
@@ -393,6 +401,7 @@ class EB_Python(ConfigureMake):
         """Add extra config options specific to Python."""
         extra_vars = {
             'ebpythonprefixes': [True, "Create sitecustomize.py and allow use of $EBPYTHONPREFIXES", CUSTOM],
+            'exts_formatter': [partial_normalize_pip, "Function to format extension names in module file", CUSTOM],
             'fix_python_shebang_for': [['bin/*'], "List of files for which Python shebang should be fixed "
                                                   "to '#!/usr/bin/env python' (glob patterns supported) "
                                                   "(default: ['bin/*'])", CUSTOM],

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -77,7 +77,7 @@ PY_ENV_VARS = {
 }
 
 REGEX_PIP_NORMALIZE = re.compile(r"[-_.]+")
-REGEX_PIP_PARTIAL_NORMALIZE = re.compile(r"_+")
+REGEX_PIP_PARTIAL_NORMALIZE = re.compile(r"[-_]+")
 
 # We want the following import order:
 # 1. Packages installed into VirtualEnv

--- a/test/easyblocks/easyblock_specific.py
+++ b/test/easyblocks/easyblock_specific.py
@@ -495,6 +495,20 @@ class EasyBlockSpecificTest(TestCase):
         local_test_py = os.path.join(libdir, 'python' + pyshortver, 'site-packages', 'test.py')
         self.assertTrue(os.path.exists(local_test_py))
 
+    def test_partial_normalize_pip(self):
+        """Test partial_normalize_pip function provided by EB_Python easyblock."""
+
+        self.assertEqual(python.partial_normalize_pip('friendly-bard'), 'friendly-bard')  # normalized form
+        self.assertEqual(python.partial_normalize_pip('Friendly-Bard'), 'friendly-bard')  # uppercase -> lowercase
+        self.assertEqual(python.partial_normalize_pip('friendly_bard'), 'friendly-bard')  # underscore -> hyphen
+        self.assertEqual(python.partial_normalize_pip('friendly.bard'), 'friendly.bard')  # dots are not normalized
+        # multiple consecutive hyphens are merged into a single hyphen
+        self.assertEqual(python.partial_normalize_pip('friendly--bard'), 'friendly-bard')
+        # multiple consecutive underscores are merged and converted into a single hyphen
+        self.assertEqual(python.partial_normalize_pip('friendly__bard'), 'friendly-bard')
+        # multiple consecutive underscores and hyphens are merged and converted into a single hyphen
+        self.assertEqual(python.partial_normalize_pip('FrIeNdLy--__--bArD'), 'friendly-bard')
+
     def test_run_pip_check(self):
         """Test run_pip_check function provided by EB_Python easyblock."""
 

--- a/test/easyblocks/easyblock_specific.py
+++ b/test/easyblocks/easyblock_specific.py
@@ -495,6 +495,20 @@ class EasyBlockSpecificTest(TestCase):
         local_test_py = os.path.join(libdir, 'python' + pyshortver, 'site-packages', 'test.py')
         self.assertTrue(os.path.exists(local_test_py))
 
+    def test_partial_normalize_pip(self):
+        """Test partial_normalize_pip function provided by EB_Python easyblock."""
+
+        self.assertEqual(python.partial_normalize_pip('friendly-bard', 'friendly-bard'))  # normalized form
+        self.assertEqual(python.partial_normalize_pip('Friendly-Bard', 'friendly-bard'))  # uppercase -> lowercase
+        self.assertEqual(python.partial_normalize_pip('friendly_bard', 'friendly-bard'))  # underscore -> hyphen
+        self.assertEqual(python.partial_normalize_pip('friendly.bard', 'friendly.bard'))  # dots are not normalized
+        # multiple consecutive hyphens are merged
+        self.assertEqual(python.partial_normalize_pip('friendly--bard', 'friendly-bard'))
+        # multiple consecutive underscores are merged and converted to hyphen
+        self.assertEqual(python.partial_normalize_pip('friendly__bard', 'friendly-bard'))
+        # multiple consecutive underscores and hyphens are merged and converted to hyphen
+        self.assertEqual(python.partial_normalize_pip('FrIeNdLy--__--bArD', 'friendly-bard'))
+
     def test_run_pip_check(self):
         """Test run_pip_check function provided by EB_Python easyblock."""
 


### PR DESCRIPTION
param `exts_formatter` allows to format extension names in module files for PythonPackage, PythonBundle, and Python easyblocks.

by default, partially normalize the names: replace `_` with `-`, but keep `.`, as was agreed during a previous conf call: https://github.com/easybuilders/easybuild/wiki/Conference-call-notes-20260211

will do nothing without companion framework PR (so can be safely merged)
- https://github.com/easybuilders/easybuild-framework/pull/5186