### PR TITLE
Adapt easyblocks for HIP

### DIFF
--- a/easybuild/easyblocks/u/ucx_plugins.py
+++ b/easybuild/easyblocks/u/ucx_plugins.py
@@ -62,7 +62,7 @@ class EB_UCX_Plugins(ConfigureMake):
                 if 'GDRCopy' in dep_names:
                     plugins['uct_cuda'].append('gdrcopy')
 
-            if 'ROCm' in dep_names:
+            if 'HIP' in dep_names or 'ROCm-LLVM' in dep_names:
                 for key in ('ucm', 'uct', 'ucx_perftest'):
                     plugins[key].append('rocm')
 
@@ -94,7 +94,7 @@ class EB_UCX_Plugins(ConfigureMake):
 
             self.makefile_dirs.extend(os.path.join(x, 'cuda') for x in ('uct', 'ucm', 'tools/perf'))
 
-        rocmroot = get_software_root('ROCm')
+        rocmroot = get_software_root('HIP') or get_software_root('ROCm-LLVM')
         if rocmroot:
             configopts += '--with-rocm=%s ' % rocmroot
             self.makefile_dirs.extend(os.path.join(x, 'rocm') for x in ('uct', 'ucm', 'tools/perf'))


### PR DESCRIPTION
- [UCX-ROCm](https://github.com/easybuilders/easybuild-easyconfigs/pull/25902/changes#diff-01fc14f3babdf3f264fae8f3fafd74e09368a0b013d546d649e83a15c144b2e5) can be configured for rocm with the options passed in the easyblock. This change in EB_UCX_Plugins makes the software_root check aligned with the checks used in [ROCmComponent](https://github.com/easybuilders/easybuild-easyblocks/blob/develop/easybuild/easyblocks/generic/rocmcomponent.py)