### PR TITLE
Add PTX code for (highest) CUDA compute capability in PyTorch & torchvision

### DIFF
--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -503,20 +503,16 @@ class EB_PyTorch(PythonPackage):
                 options.append('USE_SYSTEM_NCCL=1')
                 options.append('NCCL_INCLUDE_DIR=' + os.path.join(nccl_root, 'include'))
 
-            # list of CUDA compute capabilities to use can be specifed in two ways (where (2) overrules (1)):
-            # (1) in the easyconfig file, via the custom cuda_compute_capabilities;
-            # (2) in the EasyBuild configuration, via --cuda-compute-capabilities configuration option;
-            cuda_cc = build_option('cuda_compute_capabilities') or self.cfg['cuda_compute_capabilities']
-            if not cuda_cc:
-                raise EasyBuildError('List of CUDA compute capabilities must be specified, either via '
-                                     'cuda_compute_capabilities easyconfig parameter or via '
-                                     '--cuda-compute-capabilities')
-
-            self.log.info('Compiling with specified list of CUDA compute capabilities: %s', ', '.join(cuda_cc))
+            cuda_arch_list = self.cfg.get_cuda_cc_template_value('cuda_cc_semicolon_sep')
+            self.log.info('Compiling with specified list of CUDA compute capabilities: %s',
+                          ', '.join(cuda_arch_list.split(';')))
+            if cuda_arch_list:
+                self.log.info('Also creating PTX code for architecture ' + cuda_arch_list.split(';')[-1])
+                cuda_arch_list += '+PTX'
             # This variable is also used at runtime (e.g. for tests) and if it is not set PyTorch will automatically
             # determine the compute capability of a GPU in the system and use that which may fail tests if
             # it is to new for the used nvcc
-            env.setvar('TORCH_CUDA_ARCH_LIST', ';'.join(cuda_cc))
+            env.setvar('TORCH_CUDA_ARCH_LIST', cuda_arch_list)
         else:
             # Disable CUDA
             options.append('USE_CUDA=0')

--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -493,15 +493,15 @@ class EB_PyTorch(PythonPackage):
 
         if get_software_root('CUDA'):
             options.append('USE_CUDA=1')
-            cudnn_root = get_software_root('cuDNN')
+            cudnn_root, cudnn_var = get_software_root('cuDNN', True)
             if cudnn_root:
-                options.append('CUDNN_LIB_DIR=' + os.path.join(cudnn_root, 'lib64'))
-                options.append('CUDNN_INCLUDE_DIR=' + os.path.join(cudnn_root, 'include'))
+                options.append('CUDNN_LIB_DIR=' + os.path.join(f'${cudnn_var}', 'lib64'))
+                options.append('CUDNN_INCLUDE_DIR=' + os.path.join(f'${cudnn_var}', 'include'))
 
-            nccl_root = get_software_root('NCCL')
+            nccl_root, nccl_var = get_software_root('NCCL', True)
             if nccl_root:
                 options.append('USE_SYSTEM_NCCL=1')
-                options.append('NCCL_INCLUDE_DIR=' + os.path.join(nccl_root, 'include'))
+                options.append('NCCL_INCLUDE_DIR=' + os.path.join(f'${nccl_var}', 'include'))
 
             cuda_arch_list = self.cfg.get_cuda_cc_template_value('cuda_cc_semicolon_sep')
             self.log.info('Compiling with specified list of CUDA compute capabilities: %s',

--- a/easybuild/easyblocks/t/torchvision.py
+++ b/easybuild/easyblocks/t/torchvision.py
@@ -32,7 +32,6 @@ import os
 
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage, det_pylibdir
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.config import build_option
 from easybuild.tools.modules import get_software_version, get_software_root
 import easybuild.tools.environment as env
 
@@ -66,10 +65,9 @@ class EB_torchvision(PythonPackage):
         if self.with_cuda:
             # make sure that torchvision is installed with CUDA support by setting $FORCE_CUDA
             env.setvar('FORCE_CUDA', '1')
-            # specify CUDA compute capabilities via $TORCH_CUDA_ARCH_LIST
-            cuda_cc = self.cfg['cuda_compute_capabilities'] or build_option('cuda_compute_capabilities')
-            if cuda_cc:
-                env.setvar('TORCH_CUDA_ARCH_LIST', ';'.join(cuda_cc))
+            cuda_arch_list = self.cfg.get_cuda_cc_template_value('cuda_cc_semicolon_sep')
+            if cuda_arch_list:
+                env.setvar('TORCH_CUDA_ARCH_LIST', cuda_arch_list + '+PTX')
 
         includes = []
         for lib in ['libjpeg-turbo', 'libwebp']:


### PR DESCRIPTION
E.g. "5.0+PTX" makes PyTorch add PTX code.
We can simply add it to the list in `TORCH_CUDA_ARCH_LIST` to add PTX code for the last architecture.

Uses parts of #4092. So with https://github.com/easybuilders/easybuild-framework/pull/5144 it will add PTX code for the highest arch