### PR TITLE
add `$CUDNN_HOME` and `$CUDNN_PATH` as extra environment variables to be set by cuDNN easyblock

### DIFF
--- a/easybuild/easyblocks/c/cudnn.py
+++ b/easybuild/easyblocks/c/cudnn.py
@@ -82,11 +82,6 @@ class EB_cuDNN(Tarball):
     def make_module_extra(self):
         """Set the install directory as CUDNN_HOME, CUDNN_PATH."""
 
-        # avoid adding of installation directory to $PATH (cfr. Binary easyblock) since that may cause trouble,
-        # for example when there's a clash between command name and a subdirectory in the installation directory
-        # (like compute-sanitizer)
-        self.cfg['prepend_to_path'] = False
-
         txt = super().make_module_extra()
         txt += self.module_generator.set_environment('CUDNN_HOME', self.installdir)
         txt += self.module_generator.set_environment('CUDNN_PATH', self.installdir)

--- a/easybuild/easyblocks/c/cudnn.py
+++ b/easybuild/easyblocks/c/cudnn.py
@@ -68,6 +68,7 @@ class EB_cuDNN(Tarball):
         self.cfg['keepsymlinks'] = True
         self.cfg.template_values['cudnnarch'] = cudnnarch
         self.cfg.generate_template_values()
+        self.cfg.update('modextravars', {'CUDNN_HOME': self.installdir})
 
     def fetch_step(self, *args, **kwargs):
         """Check for EULA acceptance prior to getting sources."""

--- a/easybuild/easyblocks/c/cudnn.py
+++ b/easybuild/easyblocks/c/cudnn.py
@@ -68,7 +68,6 @@ class EB_cuDNN(Tarball):
         self.cfg['keepsymlinks'] = True
         self.cfg.template_values['cudnnarch'] = cudnnarch
         self.cfg.generate_template_values()
-        self.cfg.update('modextravars', {'CUDNN_HOME': self.installdir})
 
     def fetch_step(self, *args, **kwargs):
         """Check for EULA acceptance prior to getting sources."""
@@ -79,3 +78,17 @@ class EB_cuDNN(Tarball):
             more_info='https://docs.nvidia.com/deeplearning/cudnn/latest/reference/eula.html'
         )
         return super().fetch_step(*args, **kwargs)
+
+    def make_module_extra(self):
+        """Set the install directory as CUDNN_HOME, CUDNN_PATH."""
+
+        # avoid adding of installation directory to $PATH (cfr. Binary easyblock) since that may cause trouble,
+        # for example when there's a clash between command name and a subdirectory in the installation directory
+        # (like compute-sanitizer)
+        self.cfg['prepend_to_path'] = False
+
+        txt = super().make_module_extra()
+        txt += self.module_generator.set_environment('CUDNN_HOME', self.installdir)
+        txt += self.module_generator.set_environment('CUDNN_PATH', self.installdir)
+        self.log.debug("make_module_extra added this: %s", txt)
+        return txt


### PR DESCRIPTION
Helps some software to build and find libcudnn at runtime.

Like `CUDA_HOME`, but for `cuDNN`.

