### PR TITLE
Add new generic EasyBlock HuggingFaceDataset

### DIFF
--- a/easybuild/easyblocks/generic/huggingfacedataset.py
+++ b/easybuild/easyblocks/generic/huggingfacedataset.py
@@ -79,7 +79,7 @@ class HuggingFaceDataset(Dataset):
             ).output.strip()
 
         for src_spec in self.cfg['data_sources']:
-            _url = f"hf://datasets/{self.cfg['hf_name']}@{self.cfg['hf_revision']}/{src_spec['filename']}"
+            _url = f"hf://datasets/{self.cfg['hf_name']}@{self.cfg['hf_revision']}/{src_spec['download_filename']}"
             hash_filename = os.path.join(
                 _hf_cache_download_dir,
                 _hash_url_to_filename(_url)

--- a/easybuild/easyblocks/generic/huggingfacedataset.py
+++ b/easybuild/easyblocks/generic/huggingfacedataset.py
@@ -28,11 +28,13 @@ EasyBuild support for installing datasets
 @author: Viktor Rehnberg (Chalmers University of Technology)
 """
 import os
+from tempfile import TemporaryDirectory
 
 from easybuild.easyblocks.generic.dataset import Dataset
 from easybuild.framework.easyconfig import CUSTOM, MANDATORY
-from easybuild.tools.filetools import change_dir, clean_dir, expand_glob_paths, find_glob_pattern, mkdir, move_file
-from easybuild.tools.filetools import write_file
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.filetools import change_dir, clean_dir, dir_contains_files, expand_glob_paths, find_glob_pattern
+from easybuild.tools.filetools import mkdir, move_file, write_file
 from easybuild.tools.run import run_shell_cmd
 
 
@@ -50,6 +52,10 @@ class HuggingFaceDataset(Dataset):
         })
         return extra_vars
 
+    @property
+    def _build_dataset_dir(self):
+        return os.path.join(self.builddir, "saved_dataset")
+
     def __init__(self, *args, **kwargs):
         '''Initialize HuggingFaceDataset-specific variables.'''
         super().__init__(*args, **kwargs)
@@ -58,15 +64,20 @@ class HuggingFaceDataset(Dataset):
     def build_step(self):
         '''Build up cache_dir with dataset'''
 
-        # Prepare download directory of cache_dir
         change_dir(self.builddir)
-        _hf_cache_download_dir = os.path.join(self.builddir, 'downloads')
+        _hf_home_dir = os.path.join(self.builddir, 'hf_home')
+        _hf_cache_dir = os.path.join(self.builddir, 'hf_cache')
+        _hf_cache_download_dir = os.path.join(_hf_cache_dir, 'downloads')
+
+        mkdir(_hf_home_dir)
+        mkdir(_hf_cache_dir)
         mkdir(_hf_cache_download_dir)
 
+        # Prepare download directory of cache_dir
         def _hash_url_to_filename(url):
             return run_shell_cmd(
                 f'python -c "import datasets; print(datasets.utils.file_utils.hash_url_to_filename(\'{url}\'))"'
-            ).output
+            ).output.strip()
 
         for src_spec in self.cfg['data_sources']:
             _url = f"hf://datasets/{self.cfg['hf_name']}@{self.cfg['hf_revision']}/{src_spec['filename']}"
@@ -77,38 +88,58 @@ class HuggingFaceDataset(Dataset):
             move_file(src_spec['filename'],  hash_filename)
             write_file(f"{hash_filename}.json", f'{{"url": "{_url}", "etag": null}}'.encode('utf-8'))
 
-        # Build actual dataset
-        _hf_home_dir = os.path.join(self.builddir, "hf_home")
-        load_arg_str = ", ".join([
-            f"{key}='{val}'"
-            for key, val in {
-                'path': self.cfg['hf_name'],
-                'revision': self.cfg['hf_revision'],
-                'cache_dir': self.builddir,
-                'download_mode': 'reuse_cache_if_exists',
-                'verification_mode': 'all_checks',
-            }.items()
-        ])
-        run_shell_cmd(f'HF_HOME={_hf_home_dir} python -c "from datasets import load_dataset; load_dataset({load_arg_str})"')
+        self.log.info(f"Successfully populated {_hf_cache_download_dir} from source files")
 
-        # Clean-up
-        clean_dir(_hf_home_dir)
-        clean_dir(_hf_cache_download_dir)
+        # Build actual dataset
+        py_script = '; '.join([
+            "import datasets",
+            f"""ds = datasets.load_dataset({
+                ', '.join([
+                    f"path='{self.cfg['hf_name']}'",
+                    f"revision='{self.cfg['hf_revision']}'",
+                    f"cache_dir='{_hf_cache_dir}'",
+                    "download_mode='reuse_cache_if_exists'",
+                    "verification_mode='all_checks'",
+                    "num_proc=1",
+                ])
+            })""",
+            f"ds.save_to_disk('{self._build_dataset_dir}')"
+        ])
+        result = run_shell_cmd(f'HF_HOME={_hf_home_dir} python -c "{py_script}"')
+
+        if any(
+            line.startswith(f"Downloading data:")
+            for line in result.output.splitlines()
+        ):
+            raise EasyBuildError('Unexpected download detected when loading dataset during build.')
+        else:
+            self.log.info(f"Successfully built dataset into {self._build_dataset_dir}")
+
+    def test_step(self):
+        '''Try loading dataset'''
+        with TemporaryDirectory(prefix=self.builddir) as _hf_home_dir:
+            py_script = '; '.join([
+                "from datasets import load_from_disk",
+                f"load_from_disk('{self._build_dataset_dir}')",
+            ])
+            run_shell_cmd(f'HF_HOME="{_hf_home_dir}" python -c "{py_script}"')
+
+            if dir_contains_files(_hf_home_dir):
+                report_test_failure(f'HF_HOME populated on load_dataset({dataset_dir}) call')
 
     def install_step(self):
         '''Move actual dataset directory to installdir'''
         change_dir(self.installdir)
-        dataset_dir = os.path.dirname(
-            find_glob_pattern(
-                os.path.join(
-                    self.builddir,
-                    self.cfg['hf_name'].replace('/', '___'),
-                    '*',  # default
-                    '*',  # version string
-                    '*',  # commit hash
-                    'dataset_info.json',
-                )
-            )
-        )
-        for dataset_file in expand_glob_paths([os.path.join(dataset_dir, '*')]):
-            move_file(dataset_file, os.path.join(self.installdir, os.path.basename(dataset_file)))
+        clean_dir(self.installdir)  # can't move dataset if dir already exists
+        move_file(self._build_dataset_dir, self.installdir)
+        if not dir_contains_files(self.installdir):
+            raise EasyBuildError('Install directory is empty, something has gone wrong.')
+        else:
+            self.log.info("Successfully moved dataset from builddir")
+        change_dir(self.installdir)
+
+    def post_processing_step(self):
+        # only for debugging
+        change_dir(self.installdir)
+        self.log.info("CWD = " + os.path.abspath(os.curdir))
+        super().post_processing_step()

--- a/easybuild/easyblocks/generic/huggingfacedataset.py
+++ b/easybuild/easyblocks/generic/huggingfacedataset.py
@@ -28,15 +28,14 @@ EasyBuild support for installing datasets
 @author: Viktor Rehnberg (Chalmers University of Technology)
 """
 import os
-import hashlib
 
 from easybuild.easyblocks.generic.dataset import Dataset
 from easybuild.framework.easyconfig import CUSTOM, MANDATORY
-from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.environment import restore_env_vars, setvar, unset_env_vars
-from easybuild.tools.filetools import change_dir, clean_dir, copy_file, expand_glob_paths, find_glob_pattern, mkdir
-from easybuild.tools.filetools import move_file, write_file
+from easybuild.tools.filetools import change_dir, clean_dir, expand_glob_paths, find_glob_pattern, mkdir, move_file
+from easybuild.tools.filetools import write_file
 from easybuild.tools.run import run_shell_cmd
+
 
 class HuggingFaceDataset(Dataset):
     '''Support for installing datasets from huggingface.co'''
@@ -59,7 +58,7 @@ class HuggingFaceDataset(Dataset):
 
     def build_step(self):
         '''Build up cache_dir with dataset'''
-        
+
         # Prepare download directory of cache_dir
         change_dir(self.builddir)
         mkdir('downloads')
@@ -68,7 +67,7 @@ class HuggingFaceDataset(Dataset):
             return run_shell_cmd(
                 f'python -c "import datasets; print(datasets.utils.file_utils.hash_url_to_filename(\'{url}\'))"'
             ).output
-            
+
         for src_spec in self.cfg['data_sources']:
             _url = f"hf://datasets/{self.cfg['hf_name']}@{self.cfg['hf_revision']}/{src_spec['filename']}"
             hash_filename = os.path.join(
@@ -80,7 +79,7 @@ class HuggingFaceDataset(Dataset):
 
         # Build actual dataset
         old_env = unset_env_vars(['HF_HOME'])
-        setvar('HF_HOME', os.path.join(self.builddir,' hf_home'))
+        setvar('HF_HOME', os.path.join(self.builddir, 'hf_home'))
         try:
             load_arg_str = ", ".join([
                 f"{key}='{val}'"

--- a/easybuild/easyblocks/generic/huggingfacedataset.py
+++ b/easybuild/easyblocks/generic/huggingfacedataset.py
@@ -33,8 +33,7 @@ from tempfile import TemporaryDirectory
 from easybuild.easyblocks.generic.dataset import Dataset
 from easybuild.framework.easyconfig import CUSTOM, MANDATORY
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import change_dir, clean_dir, dir_contains_files, expand_glob_paths, find_glob_pattern
-from easybuild.tools.filetools import mkdir, move_file, write_file
+from easybuild.tools.filetools import change_dir, clean_dir, dir_contains_files, mkdir, move_file, write_file
 from easybuild.tools.run import run_shell_cmd
 
 
@@ -125,7 +124,7 @@ class HuggingFaceDataset(Dataset):
             run_shell_cmd(f'HF_HOME="{_hf_home_dir}" python -c "{py_script}"')
 
             if dir_contains_files(_hf_home_dir):
-                report_test_failure(f'HF_HOME populated on load_dataset({dataset_dir}) call')
+                report_test_failure(f'HF_HOME populated on load_dataset({self._build_dataset_dir}) call')
 
     def install_step(self):
         '''Move actual dataset directory to installdir'''
@@ -137,9 +136,3 @@ class HuggingFaceDataset(Dataset):
         else:
             self.log.info("Successfully moved dataset from builddir")
         change_dir(self.installdir)
-
-    def post_processing_step(self):
-        # only for debugging
-        change_dir(self.installdir)
-        self.log.info("CWD = " + os.path.abspath(os.curdir))
-        super().post_processing_step()

--- a/easybuild/easyblocks/generic/huggingfacedataset.py
+++ b/easybuild/easyblocks/generic/huggingfacedataset.py
@@ -60,6 +60,10 @@ class HuggingFaceDataset(Dataset):
         super().__init__(*args, **kwargs)
         self.build_in_installdir = False
 
+        # The exact filename is important during build so we will use download_filename instead of possibly modified filename
+        if any('download_filename' not in src_spec for src_spec in self.cfg['data_sources']):
+            raise EasyBuildError("Expected 'download_filename' to be known for all data_sources")
+
     def build_step(self):
         '''Build up cache_dir with dataset'''
 
@@ -69,7 +73,8 @@ class HuggingFaceDataset(Dataset):
             _hf_home_dir,
             'hub',
             f'datasets--{self.cfg["hf_name"].replace("/", "--")}',
-            'snapshots'
+            'snapshots',
+            self.cfg['hf_revision'],
         )
 
         # Fill snapshosts dir (we're abusing the fallback for no-symlinks to simplify the logic)
@@ -78,7 +83,7 @@ class HuggingFaceDataset(Dataset):
         mkdir(_hf_snapshots_dir, parents=True)
 
         for src_spec in self.cfg['data_sources']:
-            move_file(src_spec['filename'],  os.path.join(_hf_snapshots_dir, src_spec['filename']))
+            move_file(src_spec['filename'],  os.path.join(_hf_snapshots_dir, src_spec['download_filename']))
 
         self.log.info(f"Successfully populated {_hf_snapshots_dir} from source files")
 

--- a/easybuild/easyblocks/generic/huggingfacedataset.py
+++ b/easybuild/easyblocks/generic/huggingfacedataset.py
@@ -1,0 +1,119 @@
+##
+# Copyright 2009-2026 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for installing datasets
+
+@author: Viktor Rehnberg (Chalmers University of Technology)
+"""
+import os
+import hashlib
+
+from easybuild.easyblocks.generic.dataset import Dataset
+from easybuild.framework.easyconfig import CUSTOM, MANDATORY
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.environment import restore_env_vars, setvar, unset_env_vars
+from easybuild.tools.filetools import change_dir, clean_dir, copy_file, expand_glob_paths, find_glob_pattern, mkdir
+from easybuild.tools.filetools import move_file, write_file
+from easybuild.tools.run import run_shell_cmd
+
+class HuggingFaceDataset(Dataset):
+    '''Support for installing datasets from huggingface.co'''
+
+    @staticmethod
+    def extra_options(extra_vars=None):
+        """Extra easyconfig parameters specific to Data easyblock."""
+        extra_vars = Dataset.extra_options(extra_vars)
+        extra_vars.update({
+            'hf_name': [None, "Name of dataset on huggingface.co e.g. `uoft-cs/cifar10`", MANDATORY],
+            'hf_revision': [None, "Version tag or commit hash on huggingface.co", MANDATORY],
+            'extract_sources': [False, "Whether or not to extract data sources", CUSTOM],
+        })
+        return extra_vars
+
+    def __init__(self, *args, **kwargs):
+        '''Initialize HuggingFaceDataset-specific variables.'''
+        super().__init__(*args, **kwargs)
+        self.build_in_installdir = False
+
+    def build_step(self):
+        '''Build up cache_dir with dataset'''
+        
+        # Prepare download directory of cache_dir
+        change_dir(self.builddir)
+        mkdir('downloads')
+
+        def _hash_url_to_filename(url):
+            return run_shell_cmd(
+                f'python -c "import datasets; print(datasets.utils.file_utils.hash_url_to_filename(\'{url}\'))"'
+            ).output
+            
+        for src_spec in self.cfg['data_sources']:
+            _url = f"hf://datasets/{self.cfg['hf_name']}@{self.cfg['hf_revision']}/{src_spec['filename']}"
+            hash_filename = os.path.join(
+                'downloads',
+                _hash_url_to_filename(_url)
+            )
+            move_file(src_spec['filename'],  hash_filename)
+            write_file(f"{hash_filename}.json", f'{{"url": "{_url}", "etag": null}}'.encode('utf-8'))
+
+        # Build actual dataset
+        old_env = unset_env_vars(['HF_HOME'])
+        setvar('HF_HOME', os.path.join(self.builddir,' hf_home'))
+        try:
+            load_arg_str = ", ".join([
+                f"{key}='{val}'"
+                for key, val in {
+                    'path': self.cfg['hf_name'],
+                    'revision': self.cfg['hf_revision'],
+                    'cache_dir': self.builddir,
+                    'download_mode': 'reuse_cache_if_exists',
+                    'verification_mode': 'all_checks',
+                }.items()
+            ])
+            run_shell_cmd(f'python -c "from datasets import load_dataset; load_dataset({load_arg_str})"')
+        finally:
+            restore_env_vars(old_env)
+
+        # Clean-up
+        clean_dir('hf_home')
+        clean_dir('downloads')
+
+    def install_step(self):
+        '''Move actual dataset directory to installdir'''
+        change_dir(self.installdir)
+        dataset_dir = os.path.dirname(
+            find_glob_pattern(
+                os.path.join(
+                    self.builddir,
+                    self.cfg['hf_name'].replace('/', '___'),
+                    '*',  # default
+                    '*',  # version string
+                    '*',  # commit hash
+                    'dataset_info.json',
+                )
+            )
+        )
+        for dataset_file in expand_glob_paths([os.path.join(dataset_dir, '*')]):
+            move_file(dataset_file, os.path.join(self.installdir, os.path.basename(dataset_file)))

--- a/easybuild/easyblocks/generic/huggingfacedataset.py
+++ b/easybuild/easyblocks/generic/huggingfacedataset.py
@@ -65,29 +65,25 @@ class HuggingFaceDataset(Dataset):
 
         change_dir(self.builddir)
         _hf_home_dir = os.path.join(self.builddir, 'hf_home')
-        _hf_cache_dir = os.path.join(self.builddir, 'hf_cache')
-        _hf_cache_download_dir = os.path.join(_hf_cache_dir, 'downloads')
+        _hf_snapshots_dir = os.path.join(
+            _hf_home_dir,
+            'hub',
+            f'datasets--{self.cfg["hf_name"].replace("/", "--")}',
+            'snapshots'
+        )
 
+        # Fill snapshosts dir (we're abusing the fallback for no-symlinks to simplify the logic)
+        # https://huggingface.co/docs/huggingface_hub/guides/manage-cache#limitations
         mkdir(_hf_home_dir)
-        mkdir(_hf_cache_dir)
-        mkdir(_hf_cache_download_dir)
-
-        # Prepare download directory of cache_dir
-        def _hash_url_to_filename(url):
-            return run_shell_cmd(
-                f'python -c "import datasets; print(datasets.utils.file_utils.hash_url_to_filename(\'{url}\'))"'
-            ).output.strip()
+        mkdir(_hf_snapshots_dir, parents=True)
 
         for src_spec in self.cfg['data_sources']:
-            _url = f"hf://datasets/{self.cfg['hf_name']}@{self.cfg['hf_revision']}/{src_spec['download_filename']}"
-            hash_filename = os.path.join(
-                _hf_cache_download_dir,
-                _hash_url_to_filename(_url)
-            )
-            move_file(src_spec['filename'],  hash_filename)
-            write_file(f"{hash_filename}.json", f'{{"url": "{_url}", "etag": null}}'.encode('utf-8'))
+            move_file(src_spec['filename'],  os.path.join(_hf_snapshots_dir, src_spec['filename']))
 
-        self.log.info(f"Successfully populated {_hf_cache_download_dir} from source files")
+        self.log.info(f"Successfully populated {_hf_snapshots_dir} from source files")
+
+        # There might be a possibility to add an extra check with `hf cache verify`
+        # https://huggingface.co/docs/huggingface_hub/package_reference/cli#hf-cache-verify
 
         # Build actual dataset
         py_script = '; '.join([
@@ -96,8 +92,6 @@ class HuggingFaceDataset(Dataset):
                 ', '.join([
                     f"path='{self.cfg['hf_name']}'",
                     f"revision='{self.cfg['hf_revision']}'",
-                    f"cache_dir='{_hf_cache_dir}'",
-                    "download_mode='reuse_cache_if_exists'",
                     "verification_mode='all_checks'",
                     "num_proc=1",
                 ])
@@ -106,13 +100,7 @@ class HuggingFaceDataset(Dataset):
         ])
         result = run_shell_cmd(f'HF_HOME={_hf_home_dir} python -c "{py_script}"')
 
-        if any(
-            line.startswith("Downloading data:")
-            for line in result.output.splitlines()
-        ):
-            raise EasyBuildError('Unexpected download detected when loading dataset during build.')
-        else:
-            self.log.info(f"Successfully built dataset into {self._build_dataset_dir}")
+        self.log.info(f"Successfully built dataset into {self._build_dataset_dir}")
 
     def test_step(self):
         '''Try loading dataset'''

--- a/easybuild/easyblocks/generic/huggingfacedataset.py
+++ b/easybuild/easyblocks/generic/huggingfacedataset.py
@@ -107,7 +107,7 @@ class HuggingFaceDataset(Dataset):
         result = run_shell_cmd(f'HF_HOME={_hf_home_dir} python -c "{py_script}"')
 
         if any(
-            line.startswith(f"Downloading data:")
+            line.startswith("Downloading data:")
             for line in result.output.splitlines()
         ):
             raise EasyBuildError('Unexpected download detected when loading dataset during build.')

--- a/easybuild/easyblocks/generic/huggingfacedataset.py
+++ b/easybuild/easyblocks/generic/huggingfacedataset.py
@@ -31,7 +31,6 @@ import os
 
 from easybuild.easyblocks.generic.dataset import Dataset
 from easybuild.framework.easyconfig import CUSTOM, MANDATORY
-from easybuild.tools.environment import restore_env_vars, setvar, unset_env_vars
 from easybuild.tools.filetools import change_dir, clean_dir, expand_glob_paths, find_glob_pattern, mkdir, move_file
 from easybuild.tools.filetools import write_file
 from easybuild.tools.run import run_shell_cmd
@@ -61,7 +60,8 @@ class HuggingFaceDataset(Dataset):
 
         # Prepare download directory of cache_dir
         change_dir(self.builddir)
-        mkdir('downloads')
+        _hf_cache_download_dir = os.path.join(self.builddir, 'downloads')
+        mkdir(_hf_cache_download_dir)
 
         def _hash_url_to_filename(url):
             return run_shell_cmd(
@@ -71,33 +71,29 @@ class HuggingFaceDataset(Dataset):
         for src_spec in self.cfg['data_sources']:
             _url = f"hf://datasets/{self.cfg['hf_name']}@{self.cfg['hf_revision']}/{src_spec['filename']}"
             hash_filename = os.path.join(
-                'downloads',
+                _hf_cache_download_dir,
                 _hash_url_to_filename(_url)
             )
             move_file(src_spec['filename'],  hash_filename)
             write_file(f"{hash_filename}.json", f'{{"url": "{_url}", "etag": null}}'.encode('utf-8'))
 
         # Build actual dataset
-        old_env = unset_env_vars(['HF_HOME'])
-        setvar('HF_HOME', os.path.join(self.builddir, 'hf_home'))
-        try:
-            load_arg_str = ", ".join([
-                f"{key}='{val}'"
-                for key, val in {
-                    'path': self.cfg['hf_name'],
-                    'revision': self.cfg['hf_revision'],
-                    'cache_dir': self.builddir,
-                    'download_mode': 'reuse_cache_if_exists',
-                    'verification_mode': 'all_checks',
-                }.items()
-            ])
-            run_shell_cmd(f'python -c "from datasets import load_dataset; load_dataset({load_arg_str})"')
-        finally:
-            restore_env_vars(old_env)
+        _hf_home_dir = os.path.join(self.builddir, "hf_home")
+        load_arg_str = ", ".join([
+            f"{key}='{val}'"
+            for key, val in {
+                'path': self.cfg['hf_name'],
+                'revision': self.cfg['hf_revision'],
+                'cache_dir': self.builddir,
+                'download_mode': 'reuse_cache_if_exists',
+                'verification_mode': 'all_checks',
+            }.items()
+        ])
+        run_shell_cmd(f'HF_HOME={_hf_home_dir} python -c "from datasets import load_dataset; load_dataset({load_arg_str})"')
 
         # Clean-up
-        clean_dir('hf_home')
-        clean_dir('downloads')
+        clean_dir(_hf_home_dir)
+        clean_dir(_hf_cache_download_dir)
 
     def install_step(self):
         '''Move actual dataset directory to installdir'''

--- a/easybuild/easyblocks/generic/huggingfacedataset.py
+++ b/easybuild/easyblocks/generic/huggingfacedataset.py
@@ -33,7 +33,7 @@ from tempfile import TemporaryDirectory
 from easybuild.easyblocks.generic.dataset import Dataset
 from easybuild.framework.easyconfig import CUSTOM, MANDATORY
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import change_dir, clean_dir, dir_contains_files, mkdir, move_file, write_file
+from easybuild.tools.filetools import change_dir, clean_dir, dir_contains_files, mkdir, move_file
 from easybuild.tools.run import run_shell_cmd
 
 
@@ -98,7 +98,7 @@ class HuggingFaceDataset(Dataset):
             })""",
             f"ds.save_to_disk('{self._build_dataset_dir}')"
         ])
-        result = run_shell_cmd(f'HF_HOME={_hf_home_dir} python -c "{py_script}"')
+        run_shell_cmd(f'HF_HOME={_hf_home_dir} python -c "{py_script}"')
 
         self.log.info(f"Successfully built dataset into {self._build_dataset_dir}")
 

--- a/easybuild/easyblocks/generic/huggingfacedataset.py
+++ b/easybuild/easyblocks/generic/huggingfacedataset.py
@@ -124,7 +124,7 @@ class HuggingFaceDataset(Dataset):
             run_shell_cmd(f'HF_HOME="{_hf_home_dir}" python -c "{py_script}"')
 
             if dir_contains_files(_hf_home_dir):
-                report_test_failure(f'HF_HOME populated on load_dataset({self._build_dataset_dir}) call')
+                self.report_test_failure(f'HF_HOME populated on load_dataset({self._build_dataset_dir}) call')
 
     def install_step(self):
         '''Move actual dataset directory to installdir'''

--- a/easybuild/easyblocks/generic/huggingfacedataset.py
+++ b/easybuild/easyblocks/generic/huggingfacedataset.py
@@ -98,7 +98,13 @@ class HuggingFaceDataset(Dataset):
             })""",
             f"ds.save_to_disk('{self._build_dataset_dir}')"
         ])
-        run_shell_cmd(f'HF_HOME={_hf_home_dir} python -c "{py_script}"')
+
+        cmd = " ".join([
+            self.cfg['prebuildopts'],
+            f'HF_HOME={_hf_home_dir} python -c "{py_script}"',
+            self.cfg['buildopts'],
+        ])
+        run_shell_cmd(cmd)
 
         self.log.info(f"Successfully built dataset into {self._build_dataset_dir}")
 

--- a/easybuild/easyblocks/generic/huggingfacedataset.py
+++ b/easybuild/easyblocks/generic/huggingfacedataset.py
@@ -60,7 +60,8 @@ class HuggingFaceDataset(Dataset):
         super().__init__(*args, **kwargs)
         self.build_in_installdir = False
 
-        # The exact filename is important during build so we will use download_filename instead of possibly modified filename
+        # The exact filename is important during build when creating the snapshot directory
+        # so we will use download_filename instead of a possibly modified filename
         if any('download_filename' not in src_spec for src_spec in self.cfg['data_sources']):
             raise EasyBuildError("Expected 'download_filename' to be known for all data_sources")
 


### PR DESCRIPTION
Extends the generic Dataset easyblock for any dataset from <https://huggingface.co>. Currently only handles datasets (not models etc), but I imagine it wouldn't be too hard to extend it.