### PR TITLE
update test command in custom easyblock for scipy easyblock for scipy >= 1.17

### DIFF
--- a/easybuild/easyblocks/s/scipy.py
+++ b/easybuild/easyblocks/s/scipy.py
@@ -193,7 +193,7 @@ class EB_scipy(FortranPythonPackage, PythonPackage, MesonNinja):
 
             tmp_pylibdir = os.path.join(tmp_installdir, det_pylibdir())
             self.prepare_python()
-            
+
             pytest_filter = ""
             if LooseVersion(self.version) >= LooseVersion('1.17') and not self.cfg['enable_slow_tests']:
                 pytest_filter = " -m 'not slow'"

--- a/easybuild/easyblocks/s/scipy.py
+++ b/easybuild/easyblocks/s/scipy.py
@@ -85,7 +85,15 @@ class EB_scipy(FortranPythonPackage, PythonPackage, MesonNinja):
             # see https://github.com/easybuilders/easybuild-easyblocks/issues/2237
             self.testcmd = "cd .. && %(python)s -c 'import numpy; import scipy; scipy.test(verbose=2)'"
         else:
-            if LooseVersion(self.version) >= LooseVersion('1.11'):
+            if LooseVersion(self.version) >= LooseVersion('1.17'):
+                # SciPy >= 1.17 no longer ships dev.py; EasyBuild already installs
+                # SciPy into a temporary prefix for testing, so run pytest directly
+                # against that installed tree.
+                self.testcmd = " && ".join([
+                    "cd %(tmp_pylibdir)s",
+                    "%(python)s -m pytest -v%(pytest_filter)s scipy",
+                ])
+            elif LooseVersion(self.version) >= LooseVersion('1.11'):
                 self.testcmd = " && ".join([
                     "cd ..",
                     # note: beware of adding --parallel here to speed up running the tests:
@@ -100,7 +108,7 @@ class EB_scipy(FortranPythonPackage, PythonPackage, MesonNinja):
                     "%(python)s %(srcdir)s/runtests.py -v --no-build --parallel %(parallel)s",
                 ])
 
-            if self.cfg['enable_slow_tests']:
+            if LooseVersion(self.version) < LooseVersion('1.17') and self.cfg['enable_slow_tests']:
                 self.testcmd += " -m full "
 
     def configure_step(self):
@@ -185,6 +193,10 @@ class EB_scipy(FortranPythonPackage, PythonPackage, MesonNinja):
 
             tmp_pylibdir = os.path.join(tmp_installdir, det_pylibdir())
             self.prepare_python()
+            
+            pytest_filter = ""
+            if LooseVersion(self.version) >= LooseVersion('1.17') and not self.cfg['enable_slow_tests']:
+                pytest_filter = " -m 'not slow'"
 
             self.cfg['pretestopts'] = " && ".join([
                 # LDFLAGS should not be set when testing numpy/scipy, because it overwrites whatever numpy/scipy sets
@@ -196,8 +208,10 @@ class EB_scipy(FortranPythonPackage, PythonPackage, MesonNinja):
             self.cfg['runtest'] = self.testcmd % {
                 'python': self.python_cmd,
                 'srcdir': self.cfg['start_dir'],
+                'tmp_pylibdir': tmp_pylibdir,
                 'installdir': tmp_installdir,
                 'parallel': self.cfg.parallel,
+                'pytest_filter': pytest_filter,
             }
 
             MesonNinja.test_step(self)
@@ -208,6 +222,7 @@ class EB_scipy(FortranPythonPackage, PythonPackage, MesonNinja):
                 'srcdir': self.cfg['start_dir'],
                 'installdir': '',
                 'parallel': self.cfg.parallel,
+                'pytest_filter': '',
             }
             FortranPythonPackage.test_step(self)
 


### PR DESCRIPTION
Update the SciPy easyblock to support SciPy 1.17 and newer.

SciPy 1.17 no longer ships `dev.py`, so the existing test command fails when trying to run `python dev.py ... test`. The updated easyblock keeps the existing Meson/Ninja temporary-install workflow, but for SciPy >= 1.17 runs `pytest` directly against the temporarily installed SciPy tree instead.

For SciPy < 1.17, the existing `dev.py`/`runtests.py` test logic is kept unchanged.
