### PR TITLE
Rework of the `JuliaPackage` easyblock

### DIFF
--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -29,6 +29,7 @@ EasyBuild support for bundles of Julia packages, implemented as an easyblock
 """
 import os
 
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.easyblocks.generic.bundle import Bundle
 from easybuild.easyblocks.generic.juliapackage import EXTS_FILTER_JULIA_PACKAGES, JuliaPackage
 
@@ -80,6 +81,9 @@ class JuliaBundle(Bundle, JuliaPackage):
                         'filename': '%(name)s-%(version)s.tar.gz',
                     }
                 ]
+
+        if self.cfg['is_test_dependency']:
+            raise EasyBuildError("Test dependencies can only be defined as an extension, not as a bundle itself")
 
         self.log.info("exts_default_options: %s", self.cfg['exts_default_options'])
 

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -53,6 +53,12 @@ class JuliaBundle(Bundle, JuliaPackage):
         super().__init__(*args, **kwargs)
 
         self.cfg['exts_defaultclass'] = 'JuliaPackage'
+        # Ensure that Julia packages such as LLVM do not try to use the EB_LLVM easyblock
+        # many packages have names that overlap with EB easyblocks, and would end up using them as default class for extensions, which is not what we want here. We force to always use JuliaPackage unless explicitly specified
+        # otherwise in the easyconfig file.
+        self.cfg['exts_default_options'] = {
+            'easyblock': 'JuliaPackage',
+        }
         self.cfg['exts_filter'] = EXTS_FILTER_JULIA_PACKAGES
 
         # need to disable templating to ensure that actual value for exts_default_options is updated...

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -79,10 +79,6 @@ class JuliaBundle(Bundle, JuliaPackage):
     def prepare_step(self, *args, **kwargs):
         """Prepare for installing bundle of Julia packages."""
         super().prepare_step(*args, **kwargs)
-
-    def install_step(self):
-        """Prepare installation environment and dd all dependencies to project environment."""
-        self.prepare_julia_env()
         self.include_pkg_dependencies()
 
     def sanity_check_step(self, *args, **kwargs):

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -83,11 +83,6 @@ class JuliaBundle(Bundle, JuliaPackage):
 
         self.log.info("exts_default_options: %s", self.cfg['exts_default_options'])
 
-    def prepare_step(self, *args, **kwargs):
-        """Prepare for installing bundle of Julia packages."""
-        super().prepare_step(*args, **kwargs)
-        self.include_pkg_dependencies()
-
     def sanity_check_step(self, *args, **kwargs):
         """Custom sanity check for bundle of Julia packages"""
         custom_paths = {

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -54,7 +54,8 @@ class JuliaBundle(Bundle, JuliaPackage):
 
         self.cfg['exts_defaultclass'] = 'JuliaPackage'
         # Ensure that Julia packages such as LLVM do not try to use the EB_LLVM easyblock
-        # many packages have names that overlap with EB easyblocks, and would end up using them as default class for extensions, which is not what we want here. We force to always use JuliaPackage unless explicitly specified
+        # many packages have names that overlap with EB easyblocks, and would end up using them as default class for
+        # extensions, which is not what we want here. We force to always use JuliaPackage unless explicitly specified
         # otherwise in the easyconfig file.
         self.cfg['exts_default_options'] = {
             'easyblock': 'JuliaPackage',

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -26,6 +26,7 @@
 EasyBuild support for bundles of Julia packages, implemented as an easyblock
 
 @author: Alex Domingo (Vrije Universiteit Brussel)
+@author: Davide Grassano (CECAM, EPFL)
 """
 import os
 

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -28,8 +28,6 @@ EasyBuild support for bundles of Julia packages, implemented as an easyblock
 @author: Alex Domingo (Vrije Universiteit Brussel)
 @author: Davide Grassano (CECAM, EPFL)
 """
-import os
-
 from easybuild.easyblocks.generic.bundle import Bundle
 from easybuild.easyblocks.generic.juliapackage import JuliaPackage
 

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -31,7 +31,7 @@ import os
 
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.easyblocks.generic.bundle import Bundle
-from easybuild.easyblocks.generic.juliapackage import EXTS_FILTER_JULIA_PACKAGES, JuliaPackage
+from easybuild.easyblocks.generic.juliapackage import JuliaPackage
 
 
 class JuliaBundle(Bundle, JuliaPackage):
@@ -61,7 +61,6 @@ class JuliaBundle(Bundle, JuliaPackage):
         self.cfg['exts_default_options'] = {
             'easyblock': 'JuliaPackage',
         }
-        self.cfg['exts_filter'] = EXTS_FILTER_JULIA_PACKAGES
 
         # need to disable templating to ensure that actual value for exts_default_options is updated...
         with self.cfg.disable_templating():
@@ -94,7 +93,3 @@ class JuliaBundle(Bundle, JuliaPackage):
             'dirs': [os.path.join('packages', self.name)],
         }
         super().sanity_check_step(custom_paths=custom_paths)
-
-    def make_module_extra(self, *args, **kwargs):
-        """Custom module environment from JuliaPackage"""
-        return super().make_module_extra(*args, **kwargs)

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -81,12 +81,7 @@ class JuliaBundle(Bundle, JuliaPackage):
                     }
                 ]
 
-        self.log.info("exts_default_options: %s", self.cfg['exts_default_options'])
+        # The name of the bundle can be arbitrary and not necessarily a Julia package
+        self.cfg['exts_filter'] = None
 
-    def sanity_check_step(self, *args, **kwargs):
-        """Custom sanity check for bundle of Julia packages"""
-        custom_paths = {
-            'files': [],
-            'dirs': [os.path.join('packages', self.name)],
-        }
-        super().sanity_check_step(custom_paths=custom_paths)
+        self.log.info("exts_default_options: %s", self.cfg['exts_default_options'])

--- a/easybuild/easyblocks/generic/juliabundle.py
+++ b/easybuild/easyblocks/generic/juliabundle.py
@@ -30,7 +30,6 @@ EasyBuild support for bundles of Julia packages, implemented as an easyblock
 """
 import os
 
-from easybuild.tools.build_log import EasyBuildError
 from easybuild.easyblocks.generic.bundle import Bundle
 from easybuild.easyblocks.generic.juliapackage import JuliaPackage
 
@@ -81,9 +80,6 @@ class JuliaBundle(Bundle, JuliaPackage):
                         'filename': '%(name)s-%(version)s.tar.gz',
                     }
                 ]
-
-        if self.cfg['is_test_dependency']:
-            raise EasyBuildError("Test dependencies can only be defined as an extension, not as a bundle itself")
 
         self.log.info("exts_default_options: %s", self.cfg['exts_default_options'])
 

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -33,6 +33,8 @@ import os
 import re
 import tempfile
 
+from typing import List, Dict, Tuple, Union
+
 from easybuild.tools import LooseVersion
 
 import easybuild.tools.environment as env
@@ -170,50 +172,64 @@ class JuliaPackage(ExtensionEasyBlock):
         return self._julia_version
 
     @property
-    def conflicts(self):
-        """List of conflicting software."""
+    def conflicts(self) -> List[Tuple[str, str, str, str]]:
+        """List of 4-tuple conflicting software (same package included from multiple locations) including:
+        - extension name where conflict is found
+        - package name with conflict
+        - previous source of the package that caused the conflict
+        - new source of the package that caused the conflict
+        """
         if self.is_extension:
             return self.master.conflicts
         return self._conflicts
 
     @property
-    def is_last_extension(self):
-        """Whether this extension is the last one to be installed in the installation."""
+    def is_last_extension(self) -> bool:
+        """Whether this extension is the last one to be installed."""
         if not self.is_extension:
             return True
 
         return self.master.ext_instances and self.master.ext_instances[-1] is self
 
     @property
-    def julia_deps(self):
-        """List of Julia dependencies found in this installation excluding test dependencies."""
+    def julia_deps(self) -> Dict[str, str]:
+        """List of Julia dependencies found in this installation excluding test dependencies
+        - key: package name
+        - value: package source
+        """
         if self.is_extension:
             return self.master.julia_deps
         return self._julia_deps
 
     @property
-    def julia_deps_test(self):
-        """List of Julia dependencies found in this installation including test dependencies."""
+    def julia_deps_test(self) -> Dict[str, str]:
+        """List of Julia dependencies found in this installation including test dependencies
+        - key: package name
+        - value: package source
+        """
         if self.is_extension:
             return self.master.julia_deps_test
         return self._julia_deps_test
 
     @property
-    def pkg_deps(self):
-        """List of easybuild runtime dependencies that will need to be sanity-checked."""
+    def pkg_deps(self) -> List[Tuple[str, str]]:
+        """List of easybuild runtime dependencies that will need to be sanity-checked. 2-tuple including:
+        - dependency name
+        - dependency root (equivalent to get_software_root)
+        """
         if self.is_extension:
             return self.master.pkg_deps
         return self._pkg_deps
 
     @property
-    def pkgs_to_test(self):
-        """List extension with `runtest` set to true that should be tested."""
+    def pkgs_to_test(self) -> List[str]:
+        """List extension names with `runtest` set to True that should be tested."""
         if self.is_extension:
             return self.master.pkgs_to_test
         return self._pkgs_to_test
 
     @property
-    def tmp_test_dir(self):
+    def tmp_test_dir(self) -> str:
         """Temporary path used for running the test step."""
         if self.is_extension:
             return self.master.tmp_test_dir
@@ -225,9 +241,14 @@ class JuliaPackage(ExtensionEasyBlock):
                 raise EasyBuildError("Failed to create temporary directory for Julia package testing: %s", str(e))
         return self._tmp_test_dir
 
-    def julia_env_path(self, absolute=True, base=True, basedir=None):
+    def julia_env_path(self, absolute: bool = True, base: bool = True, basedir: Union[str, None] = None) -> str:
         """
         Return path to installation environment file.
+
+        :param absolute: whether to return absolute path to environment file or relative path to `basedir`
+        :param base: whether to return path to environment file or its parent directory
+        :param basedir: base directory for the environment, as in env=BASEDIR/environments/v#.#/Project.toml.
+        Defaults to installation directory of this package if not specified.
         """
         basedir = basedir or self.installdir
         julia_version = self.julia_version.split('.')
@@ -241,7 +262,7 @@ class JuliaPackage(ExtensionEasyBlock):
 
         return project_env
 
-    def set_pkg_remote(self, online=False):
+    def set_pkg_remote(self, online: bool = False):
         """Enable online/offline mode of Julia Pkg"""
 
         julia_version = get_software_version('Julia')
@@ -257,7 +278,7 @@ class JuliaPackage(ExtensionEasyBlock):
             )
             raise EasyBuildError(errmsg, julia_version)
 
-    def prepare_julia_env(self, basedir=None, online=False):
+    def prepare_julia_env(self, basedir: Union[str, None] = None, online: bool = False):
         """
         1. Remove user depot and prepend installation directory to DEPOT_PATH.
         Top directory in Julia DEPOT_PATH is the target installation directory.
@@ -272,6 +293,12 @@ class JuliaPackage(ExtensionEasyBlock):
         3. Enable offline mode in Julia to avoid automatic downloads of packages.
 
         4. Enable automatic precompilation of packages after each build.
+
+        5. Enable/disable debug mode in Julia to get more verbose output during installation and testing.
+
+        :param basedir: base directory for the environment, as in env=BASEDIR/environments/v#.#/Project.toml.
+        Defaults to installation directory of this package if not specified.
+        :param online: whether to allow online operations of Julia Pkg
         """
         basedir = basedir or self.installdir
         # Grab both DEPOT_PATH and LOAD_PATH before any changes are made
@@ -304,8 +331,7 @@ class JuliaPackage(ExtensionEasyBlock):
         # Enable/disable offline mode
         self.set_pkg_remote(online=online)
 
-        if self.cfg['julia_debug']:
-            env.setvar('JULIA_DEBUG', 'all')
+        env.setvar('JULIA_DEBUG', 'all' if self.cfg['julia_debug'] else '')
 
         # Set the maximum number of concurrent package builds
         env.setvar('JULIA_NUM_PRECOMPILE_TASKS', str(self.cfg.parallel))
@@ -313,6 +339,12 @@ class JuliaPackage(ExtensionEasyBlock):
         env.setvar('JULIA_PKG_PRECOMPILE_AUTO', 'true')
 
     def add_package(self, pkg_source, test_only=False):
+        """Add a Julia package to the list of dependencies to be installed.
+
+        :param pkg_source: path to the package source to be added as dependency
+        :param test_only: whether this package is only needed for testing and should not be added to installation
+        environment
+        """
         pkg_name = os.path.basename(pkg_source)
         if pkg_name in self.julia_deps:
             prev_source = self.julia_deps[pkg_name]
@@ -334,8 +366,12 @@ class JuliaPackage(ExtensionEasyBlock):
                 )
             raise EasyBuildError("Conflicts detected in Julia dependencies:\n" + "\n".join(conflict_msgs))
 
-    def install_pkg(self, basedir=None):
-        """Execute Julia.Pkg command to install package from its sources"""
+    def install_pkg(self, basedir: Union[str, None] = None):
+        """Execute Julia.Pkg command to install all packages in `self.julia_deps` in the install environment.
+
+        :param basedir: base directory for the environment, as in env=BASEDIR/environments/v#.#/Project.toml.
+        Defaults to installation directory of this package if not specified
+        """
         self._check_conflicts()
         basedir = basedir or self.installdir
         env = self.julia_env_path(basedir=basedir)
@@ -373,8 +409,11 @@ class JuliaPackage(ExtensionEasyBlock):
 
         return res.output
 
-    def _deps_from_project(self, environment):
-        """Get list of dependencies from a Project.toml file"""
+    def _deps_from_project(self, environment: str) -> List[str]:
+        """Get list of dependencies from a Julia environment
+
+        :param environment: path to Julia environment to query for dependencies
+        """
         julia_root = get_software_root('Julia')
         cmd = "; ".join([
             'using Pkg',
@@ -454,8 +493,12 @@ class JuliaPackage(ExtensionEasyBlock):
         move_file(self.start_dir, package_dir)
         self.add_package(package_dir, test_only=self.cfg['is_test_dependency'])
 
-    def _build_install_step(self, basedir=None):
-        """Install step commons between single-package and extensions based installs."""
+    def _build_install_step(self, basedir: Union[str, None] = None):
+        """Install step commons between single-package and extensions based installs.
+
+        :param basedir: base directory for the environment, as in env=BASEDIR/environments/v#.#/Project.toml.
+        Defaults to installation directory of this package if not specified.
+        """
         self.install_source()
         if self.is_last_extension:
             self.prepare_julia_env(basedir=basedir, online=self.cfg['download_pkg_deps'])
@@ -579,13 +622,9 @@ class JuliaPackage(ExtensionEasyBlock):
 
     def make_module_extra(self, *args, **kwargs):
         """
-        Module load initializes JULIA_DEPOT_PATH and JULIA_LOAD_PATH with default values if they are not set.
-
-        Path to installation directory is appended to JULIA_DEPOT_PATH.
-        Path to the environment file of this installation is prepended to JULIA_LOAD_PATH.
-        This configuration fulfils the rule that user depot has to be the first path in JULIA_DEPOT_PATH,
-        allowing user to add custom Julia packages while having packages in this installation available.
-        See issue easybuilders/easybuild-easyconfigs#17455
+        Set EB-specific PATH like variables `EB_JULIA_DEPOT_PATH` and `EB_JULIA_LOAD_PATH`.
+        These are then used by Easybuild's custom Julia startup script (etc/julia/startup.jl) to set JULIA_DEPOT_PATH
+        and JULIA_LOAD_PATH correctly at runtime.
         """
         mod = super().make_module_extra()
 

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -48,7 +48,7 @@ from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.utilities import trace_msg, print_msg
 from easybuild.tools.hooks import BUILD_STEP, TEST_STEP
 
-from easybuild.easyblocks.j.julia import EB_JULIA_DEPOT_PATH_VAR, EB_JULIA_LOAD_PATH_VAR
+from easybuild.easyblocks.julia import EB_JULIA_DEPOT_PATH_VAR, EB_JULIA_LOAD_PATH_VAR
 
 _COMPILECACHE_CHECK = ' | '.join([
     # "julia -E 'Base.compilecache_path(Base.identify_package(\"%(ext_name)s\"), Base.get_world_counter())'",

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -207,7 +207,7 @@ class JuliaPackage(ExtensionEasyBlock):
 
     @property
     def pkgs_to_test(self):
-        """List extension wiht `runtest` set to true that should be tested."""
+        """List extension with `runtest` set to true that should be tested."""
         if self.is_extension:
             return self.master.pkgs_to_test
         return self._pkgs_to_test

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -81,8 +81,8 @@ setenv("JULIA_LOAD_PATH", os.getenv("EBJULIA_LOAD_PATH") .. ":")
     # This needs testing, the module generate seems to work fine, but the loading of the module within EB does not
     # properly resolve the $::env() and leaves it as a string
     "Tcl": """
-setenv JULIA_DEPOT_PATH ":\$::env(EBJULIA_DEPOT_PATH)"
-setenv JULIA_LOAD_PATH "\$::env(EBJULIA_LOAD_PATH):"
+setenv JULIA_DEPOT_PATH ":$::env(EBJULIA_DEPOT_PATH)"
+setenv JULIA_LOAD_PATH "$::env(EBJULIA_LOAD_PATH):"
 """,
 }
 
@@ -262,7 +262,7 @@ class JuliaPackage(ExtensionEasyBlock):
             pkg_dir = os.path.dirname(pkg_path)
 
         if not os.path.isfile(pkg_path):
-            raise EasyBuildError("Project.toml file not found for package %s in path: %s", pkg_name, pkg_dir)
+            raise EasyBuildError("Project.toml file not found in path: %s", pkg_dir)
 
         project_toml = cls.read_project_toml(pkg_path)
         pkg_name = project_toml['name']
@@ -554,7 +554,10 @@ class JuliaPackage(ExtensionEasyBlock):
         # mod += self.module_generator.append_paths('JULIA_DEPOT_PATH', [''])
 
         mod += self.module_generator.prepend_paths('EBJULIA_DEPOT_PATH', [''])
-        mod += self.module_generator.prepend_paths('EBJULIA_LOAD_PATH', [self.julia_env_path(absolute=False, base=False)])
+        mod += self.module_generator.prepend_paths(
+            'EBJULIA_LOAD_PATH',
+            [self.julia_env_path(absolute=False, base=False)]
+        )
 
         return mod
 

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -39,17 +39,19 @@ import easybuild.tools.environment as env
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.config import build_option
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.filetools import move_file
 from easybuild.tools.run import run_shell_cmd
-from easybuild.tools.utilities import trace_msg
+from easybuild.tools.utilities import trace_msg, print_msg
+from easybuild.tools.hooks import BUILD_STEP, TEST_STEP
 
 from easybuild.easyblocks.j.julia import EB_JULIA_DEPOT_PATH_VAR, EB_JULIA_LOAD_PATH_VAR
 
 _COMPILECACHE_CHECK = ' | '.join([
     # "julia -E 'Base.compilecache_path(Base.identify_package(\"%(ext_name)s\"), Base.get_world_counter())'",
     # compilecache_path is not part of the stable API and changes arguments across versions
-    # allow internal cache resolution and use debug statemnts to get the path of the loaded cache
+    # allow internal cache resolution and use debug statements to get the path of the loaded cache
     "JULIA_DEBUG=loading julia -e 'using %(ext_name)s' 2>&1 1>/dev/null",
     "grep -E 'Loading (object )?cache file .*%(grep_loc)s'"
 ])
@@ -149,6 +151,7 @@ class JuliaPackage(ExtensionEasyBlock):
         self._pkg_deps = []
         self._pkg_to_test = []
         self._tmp_test_dir = None
+        self._installdir_created = False
 
     @property
     def julia_version(self) -> str:
@@ -177,7 +180,7 @@ class JuliaPackage(ExtensionEasyBlock):
     def is_last_extension(self):
         """Whether this extension is the last one to be installed in the installation."""
         if not self.is_extension:
-            return False
+            return True
 
         return self.master.ext_instances and self.master.ext_instances[-1] is self
 
@@ -395,15 +398,14 @@ class JuliaPackage(ExtensionEasyBlock):
         build_only_deps = self.cfg.dependencies(build_only=True)
         # add packages found in dependencies to this installation environment
         for dep in self.cfg.dependencies():
-            test_only = dep in build_only_deps
             dep_name = dep['name']
             dep_root = get_software_root(dep_name)
             dep_env = self.julia_env_path(absolute=True, base=True, basedir=dep_root)
-            dep_manifest = os.path.join(dep_env, 'Manifest.toml')
-            if not os.path.isfile(dep_manifest):
-                self.log.warning("No Manifest.toml file found in dependency %s, skipping: %s", dep_name, dep_env)
+            if not os.path.isdir(dep_env):
+                self.log.warning("No environment directory found in dependency %s, skipping: %s", dep_name, dep_env)
                 continue
 
+            test_only = dep in build_only_deps
             if test_only:
                 trace_msg(
                     f"Incorporating Julia package in TEST    environment {dep_name}: {dep_env}"
@@ -415,11 +417,19 @@ class JuliaPackage(ExtensionEasyBlock):
                 )
 
             for pkg_path in self._deps_from_project(dep_env):
-                self.add_package(pkg_path, test_only=dep in build_only_deps)
+                self.add_package(pkg_path, test_only=test_only)
+
+    def make_installdir(self):
+        """Create new installation directory and ensure this is done only once"""
+        # Stop installdir from being re-created at the install step
+        if not self._installdir_created:
+            super().make_installdir()
+            self._installdir_created = True
 
     def prepare_step(self, *args, **kwargs):
         """Prepare for Julia package installation."""
         super().prepare_step(*args, **kwargs)
+        self.make_installdir()
 
         if get_software_root('Julia') is None:
             raise EasyBuildError("Julia not included as dependency!")
@@ -430,9 +440,32 @@ class JuliaPackage(ExtensionEasyBlock):
         """Configure step for Julia packages is a no-op, as there is no configuration needed before installation."""
         pass
 
+    def install_source(self):
+        """Add the Julia package source files in the installation directory."""
+        if self.cfg['is_test_dependency']:
+            self.log.debug(
+                f"Package {self.name} is only needed for testing, installing sources in {self.tmp_test_dir}"
+            )
+            trace_msg("Installing as a test dependency...")
+            package_dir = os.path.join(self.tmp_test_dir, 'packages', self.name)
+        else:
+            package_dir = os.path.join(self.installdir, 'packages', self.name)
+
+        move_file(self.start_dir, package_dir)
+        self.add_package(package_dir, test_only=self.cfg['is_test_dependency'])
+
+    def _build_install_step(self, basedir=None):
+        """Install step commons between single-package and extensions based installs."""
+        self.install_source()
+        if self.is_last_extension:
+            self.prepare_julia_env(basedir=basedir, online=self.cfg['download_pkg_deps'])
+            return self.install_pkg(basedir=basedir)
+        else:
+            trace_msg("Delegating build+install to last extension")
+
     def build_step(self):
         """Build step for Julia packages is a no-op, as there is no build needed before installation."""
-        pass
+        return self._build_install_step()
 
     def test_step(self):
         """
@@ -440,6 +473,13 @@ class JuliaPackage(ExtensionEasyBlock):
 
         :param return_output: return output and exit code of test command
         """
+        if self.cfg['runtest']:
+            self.pkg_to_test.append(self.name)
+
+        if not self.is_last_extension:
+            trace_msg("Delegating testing to last extension")
+            return
+
         if self.pkg_to_test:
             env = self.julia_env_path(basedir=self.tmp_test_dir)
             pkg_specs = ', '.join(f'PackageSpec(path="{path}")' for path in self.julia_deps_test.values())
@@ -464,54 +504,40 @@ class JuliaPackage(ExtensionEasyBlock):
                 self.cfg['testopts'],
             ])
 
-            run_shell_cmd(cmd)
+            res = run_shell_cmd(cmd, fail_on_error=False)
 
-    def install_source(self):
-        """Add the Julia package source files in the installation directory."""
-        if self.cfg['is_test_dependency']:
-            self.log.debug(
-                f"Package {self.name} is only needed for testing, installing sources in {self.tmp_test_dir}"
-            )
-            trace_msg("Installing as a test dependency...")
-            package_dir = os.path.join(self.tmp_test_dir, 'packages', self.name)
-        else:
-            package_dir = os.path.join(self.installdir, 'packages', self.name)
-
-        move_file(self.start_dir, package_dir)
-        self.add_package(package_dir, test_only=self.cfg['is_test_dependency'])
-
-    def _install_step(self, basedir=None):
-        """Install step commons between single-package and extensions based installs."""
-        self.prepare_julia_env(basedir=basedir, online=self.cfg['download_pkg_deps'])
-        return self.install_pkg(basedir=basedir)
+            if res.exit_code != 0:
+                self.report_test_failure(f"Tests failed for Julia package {self.name}:\n{res.output}")
 
     def install_step(self):
-        """Prepare installation environment and install Julia package."""
-        if self.cfg['runtest']:
-            self.pkg_to_test.append(self.name)
+        """Install step for Julia packages is a no-op, as there is no build needed before installation."""
+        pass
 
-        self.install_source()
-        res = self._install_step()
-        self.test_step()
-
-        return res
-
-    def install_extension(self):
+    def install_extension(self, *args, **kwargs):
         """Install Julia package as an extension."""
         if not self.src:
             errmsg = "No source found for Julia package %s, required for installation. (src: %s)"
             raise EasyBuildError(errmsg, self.name, self.src)
 
-        # Unpack source into install directory and add package to the main environment Project.toml file
-        ExtensionEasyBlock.install_extension(self, unpack_src=True)
-        self.install_source()
+        super().install_extension(*args, unpack_src=True)
 
-        if self.cfg['runtest']:
-            self.pkg_to_test.append(self.name)
-
-        if self.is_last_extension:
-            self._install_step()
-            self.test_step()
+        steps = [
+            (BUILD_STEP, 'building', [lambda x: x._build_install_step], True),
+            (TEST_STEP, 'testing', [lambda x: x._test_step], True),
+        ]
+        self.skip = False  # --skip does not apply here
+        self.silent = build_option('silent')
+        # See EasyBlock.run_all_steps
+        for (step_name, descr, step_methods, skippable) in steps:
+            if self.skip_step(step_name, skippable):
+                print_msg("\t%s [skipped]" % descr, log=self.log, silent=self.silent)
+            else:
+                if self.dry_run:
+                    self.dry_run_msg("\t%s... [DRY RUN]\n", descr)
+                else:
+                    print_msg("\t%s..." % descr, log=self.log, silent=self.silent)
+                    for step_method in step_methods:
+                        step_method(self)()
 
     def sanity_check_step(self, *args, **kwargs):
         """Custom sanity check for JuliaPackage"""

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -54,13 +54,6 @@ _COMPILECACHE_CHECK = ' | '.join([
     "grep -E 'Loading (object )?cache file .*%(grep_loc)s'"
 ])
 
-EXTS_FILTER_JULIA_PACKAGES = (
-    " && ".join([
-        _COMPILECACHE_CHECK.replace('%(grep_loc)s', '%(ext_name)s'),
-        "julia -e 'using %(ext_name)s'",
-    ]),
-    ""
-)
 USER_DEPOT_PATTERN = re.compile(r"\/\.julia\/?(.*\.toml)*$")
 
 
@@ -433,6 +426,14 @@ class JuliaPackage(ExtensionEasyBlock):
 
         self.include_pkg_dependencies()
 
+    def configure_step(self):
+        """Configure step for Julia packages is a no-op, as there is no configuration needed before installation."""
+        pass
+
+    def build_step(self):
+        """Build step for Julia packages is a no-op, as there is no build needed before installation."""
+        pass
+
     def test_step(self):
         """
         Test the built Julia package.
@@ -486,8 +487,14 @@ class JuliaPackage(ExtensionEasyBlock):
 
     def install_step(self):
         """Prepare installation environment and install Julia package."""
+        if self.cfg['runtest']:
+            self.pkg_to_test.append(self.name)
+
         self.install_source()
-        return self._install_step()
+        res = self._install_step()
+        self.test_step()
+
+        return res
 
     def install_extension(self):
         """Install Julia package as an extension."""
@@ -514,10 +521,19 @@ class JuliaPackage(ExtensionEasyBlock):
 
         pkg_dir = os.path.join('packages', self.name)
 
+        ext_filters = ["julia -e 'using %(ext_name)s'"]
+
+        cc_check = False
+        if LooseVersion(self.julia_version) >= LooseVersion('1.8'):
+            cc_check = True
+            ext_filters.insert(
+                0,
+                _COMPILECACHE_CHECK % {'ext_name': self.name, 'grep_loc': self.name}
+            )
+
         custom_commands = []
         # Check that the compile cache of the dependencies can still be loaded and is coming from the expected package
-
-        if not self.is_extension:
+        if not self.is_extension and cc_check:
             for dep, root in self.pkg_deps:
                 # root_comp = os.path.join(root, 'compiled')
                 custom_commands.append(
@@ -533,7 +549,7 @@ class JuliaPackage(ExtensionEasyBlock):
         }
         kwargs.update({'custom_paths': custom_paths})
 
-        return ExtensionEasyBlock.sanity_check_step(self, EXTS_FILTER_JULIA_PACKAGES, *args, **kwargs)
+        return ExtensionEasyBlock.sanity_check_step(self, (" && ".join(ext_filters), ""), *args, **kwargs)
 
     def make_module_extra(self, *args, **kwargs):
         """

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -99,11 +99,6 @@ class JuliaPackage(ExtensionEasyBlock):
             'download_pkg_deps': [
                 False, "Let Julia download and bundle all needed dependencies for this installation", CUSTOM
             ],
-            'is_test_dependency': [
-                False,
-                "Whether this package is only needed for testing and should not be added to installation environment",
-                CUSTOM
-            ],
             'julia_debug': [
                 False,
                 "Whether to set JULIA_DEBUG=all during installation and testing, to get more verbose output.",
@@ -117,10 +112,6 @@ class JuliaPackage(ExtensionEasyBlock):
             'test_online': [
                 False,
                 "Allow online tests that require downloading dependencies. By default, tests are run in offline mode.",
-                CUSTOM
-            ],
-            'subpackages_dirs': [
-                None, "List of subdirectories to look for additional packages to add to the environment",
                 CUSTOM
             ],
         })
@@ -152,6 +143,7 @@ class JuliaPackage(ExtensionEasyBlock):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._pkg_deps = []
+        self._pkt_to_test = []
         self._julia_deps = {}
         self._julia_deps_test = {}
         self._julia_version = None
@@ -179,6 +171,13 @@ class JuliaPackage(ExtensionEasyBlock):
         if self.is_extension:
             return self.master.pkg_deps
         return self._pkg_deps
+
+    @property
+    def pkg_to_test(self):
+        """List of Julia dependencies to be included in the test environment."""
+        if self.is_extension:
+            return self.master.pkg_to_test
+        return self._pkt_to_test
 
     @property
     def julia_deps(self):
@@ -231,8 +230,8 @@ class JuliaPackage(ExtensionEasyBlock):
 
         return project_env
 
-    def set_pkg_offline(self, online=False):
-        """Enable offline mode of Julia Pkg"""
+    def set_pkg_remote(self, online=False):
+        """Enable online/offline mode of Julia Pkg"""
 
         julia_version = get_software_version('Julia')
         if LooseVersion(julia_version) >= LooseVersion('1.5'):
@@ -291,9 +290,8 @@ class JuliaPackage(ExtensionEasyBlock):
             errmsg = "Failed to prepare Julia environment for installation of: %s"
             raise EasyBuildError(errmsg, self.name)
 
-        # Enable offline mode
-        if not online:
-            self.set_pkg_offline()
+        # Enable/disable offline mode
+        self.set_pkg_remote(online=online)
 
         if self.cfg['julia_debug']:
             env.setvar('JULIA_DEBUG', 'all')
@@ -329,6 +327,8 @@ class JuliaPackage(ExtensionEasyBlock):
             # Usage `Pkg.instantiate()` after all sources are in place to let Pkg handle all dependencies.
             # This has the advantage of letting Pkg deal with the order and parallel installation.
             'Pkg.instantiate()',
+            # Ensure operations done only by build.jl are done for all packages if needed
+            'Pkg.build()',
         ]
 
         julia_pkg_cmd = '; '.join(julia_pkg_cmd)
@@ -364,8 +364,10 @@ class JuliaPackage(ExtensionEasyBlock):
 
     def include_pkg_dependencies(self):
         """Add to installation environment all Julia packages already present in its dependencies"""
+        build_only_deps = self.cfg.dependencies(build_only=True)
         # add packages found in dependencies to this installation environment
         for dep in self.cfg.dependencies():
+            test_only = dep in build_only_deps
             dep_name = dep['name']
             dep_root = get_software_root(dep_name)
             dep_env = self.julia_env_path(absolute=True, base=True, basedir=dep_root)
@@ -374,13 +376,18 @@ class JuliaPackage(ExtensionEasyBlock):
                 self.log.warning("No Manifest.toml file found in dependency %s, skipping: %s", dep_name, dep_env)
                 continue
 
-            self.pkg_deps.append((dep_name, dep_root))
-            trace_msg(
-                f"Incorporating Julia package dependencies from {dep_name} in installation environment: {dep_env}"
-            )
+            if test_only:
+                trace_msg(
+                    f"Incorporating Julia package in TEST    environment {dep_name}: {dep_env}"
+                )
+            else:
+                self.pkg_deps.append((dep_name, dep_root))
+                trace_msg(
+                    f"Incorporating Julia package in INSTALL environment {dep_name}: {dep_env}"
+                )
 
             for pkg_path in self._deps_from_project(dep_env):
-                self.add_package(pkg_path)
+                self.add_package(pkg_path, test_only=dep in build_only_deps)
 
     def prepare_step(self, *args, **kwargs):
         """Prepare for Julia package installation."""
@@ -397,22 +404,18 @@ class JuliaPackage(ExtensionEasyBlock):
 
         :param return_output: return output and exit code of test command
         """
-        testcmd = None
-        if isinstance(self.cfg['runtest'], str):
-            testcmd = self.cfg['runtest']
-
-        if self.cfg['runtest']:
-            if testcmd is None:
-                env = self.julia_env_path(basedir=self.tmp_test_dir)
-                package_specs = ', '.join(f'PackageSpec(path="{path}")' for path in self.julia_deps_test.values())
-                testcmd = [
-                    'using Pkg',
-                    f'Pkg.activate("{env}")',
-                    f'Pkg.develop([{package_specs}]; preserve=PRESERVE_ALL)',
-                    f'Pkg.test("{self.name}")',
-                ]
-                testcmd = '; '.join(testcmd)
-                testcmd = f"julia -e '{testcmd}'"
+        if self.pkg_to_test:
+            env = self.julia_env_path(basedir=self.tmp_test_dir)
+            pkg_specs = ', '.join(f'PackageSpec(path="{path}")' for path in self.julia_deps_test.values())
+            pkg_test = ', '.join(f'"{pkg}"' for pkg in self.pkg_to_test)
+            testcmd = [
+                'using Pkg',
+                f'Pkg.activate("{env}")',
+                f'Pkg.develop([{pkg_specs}]; preserve=PRESERVE_ALL)',
+                f'Pkg.test([{pkg_test}])',
+            ]
+            testcmd = '; '.join(testcmd)
+            testcmd = f"julia -e '{testcmd}'"
 
             # Also add normal DEPOT/LOAD paths to environment to try and re-use pre-compiled caches as much as possible
             # But also ensure that artifacts for packages that do not need recompilation are still found in the tests
@@ -429,31 +432,9 @@ class JuliaPackage(ExtensionEasyBlock):
 
     def install_source(self):
         """Add the Julia package source files in the installation directory."""
-        if self.cfg['is_test_dependency']:
-            self.log.debug(
-                f"Package {self.name} is only needed for testing, installing sources in {self.tmp_test_dir}"
-            )
-            trace_msg("Installing as a test dependency...")
-            package_dir = os.path.join(self.tmp_test_dir, 'packages', self.name)
-        else:
-            package_dir = os.path.join(self.installdir, 'packages', self.name)
-
-        # This also warks for dirs and will fail if the destination already exists
-        move_file(self.ext_dir if self.is_extension else self.start_dir, package_dir)
-
-        # Add all packages to the test environment Project.toml file
-        self.add_package(package_dir, test_only=self.cfg['is_test_dependency'])
-
-        subpkg_dirs = self.cfg['subpackages_dirs'] or []
-        for subpkg_dir in subpkg_dirs:
-            # pkg_name = os.path.basename(subpkg_dir)
-            subpkg_path = os.path.join(package_dir, subpkg_dir)
-            if not os.path.isdir(subpkg_path):
-                self.log.warning("Sub-package directory specified but not found, skipping: %s", subpkg_path)
-                continue
-            trace_msg(f"Adding sub-package from specified directory {subpkg_path}")
-
-            self.add_package(subpkg_path, test_only=self.cfg['is_test_dependency'])
+        package_dir = os.path.join(self.installdir, 'packages', self.name)
+        move_file(self.start_dir, package_dir)
+        self.add_package(package_dir)
 
     def _install_step(self, basedir=None):
         """Install step commons between single-package and extensions based installs."""
@@ -475,24 +456,23 @@ class JuliaPackage(ExtensionEasyBlock):
         ExtensionEasyBlock.install_extension(self, unpack_src=True)
         self.install_source()
 
+        if self.cfg['runtest']:
+            self.pkg_to_test.append(self.name)
+
         if self.is_last_extension:
             self._install_step()
             self.test_step()
 
     def sanity_check_step(self, *args, **kwargs):
         """Custom sanity check for JuliaPackage"""
-        if self.cfg['is_test_dependency']:
-            self.log.debug(f"Package {self.name} is only used for testing, skipping sanity check")
-            return (True, "Test dependency, skipping sanity check")
-
         pkg_dir = os.path.join('packages', self.name)
 
         custom_commands = []
-        # Check that the compile cache of the dependencies can still be loaded and is coming from the expected package
 
+        # Check that the compile cache of the dependencies can still be loaded and is coming from the expected package
         if not self.is_extension:
             for dep, root in self.pkg_deps:
-                root_comp = os.path.join(root, 'compiled')
+                # root_comp = os.path.join(root, 'compiled')
                 custom_commands.append(
                     # _COMPILECACHE_CHECK % {'ext_name': dep, 'grep_loc': f'Loading object cache file .*{root_comp}'}
                     _COMPILECACHE_CHECK % {'ext_name': dep, 'grep_loc': dep}

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -155,7 +155,8 @@ class JuliaPackage(ExtensionEasyBlock):
         self._julia_deps_test = {}
         self._julia_version = None
         self._pkg_deps = []
-        self._pkgs_to_test = []
+        self._pkgs_to_test_online = []
+        self._pkgs_to_test_offline = []
         self._tmp_test_dir = None
         self._installdir_created = False
 
@@ -226,11 +227,18 @@ class JuliaPackage(ExtensionEasyBlock):
         return self._pkg_deps
 
     @property
-    def pkgs_to_test(self) -> List[str]:
-        """List extension names with `runtest` set to True that should be tested."""
+    def pkgs_to_test_online(self) -> List[str]:
+        """List extension names with `runtest` set to True that should be tested in online mode."""
         if self.is_extension:
-            return self.master.pkgs_to_test
-        return self._pkgs_to_test
+            return self.master.pkgs_to_test_online
+        return self._pkgs_to_test_online
+
+    @property
+    def pkgs_to_test_offline(self) -> List[str]:
+        """List extension names with `runtest` set to True that should be tested in offline mode."""
+        if self.is_extension:
+            return self.master.pkgs_to_test_offline
+        return self._pkgs_to_test_offline
 
     @property
     def tmp_test_dir(self) -> str:
@@ -521,33 +529,59 @@ class JuliaPackage(ExtensionEasyBlock):
         :param return_output: return output and exit code of test command
         """
         if self.cfg['runtest']:
-            self.pkgs_to_test.append(self.name)
+            if self.cfg['test_online']:
+                self.pkgs_to_test_online.append(self.name)
+            else:
+                self.pkgs_to_test_offline.append(self.name)
 
         if not self.is_last_extension:
             trace_msg("Delegating testing to last extension")
             return
 
-        if self.pkgs_to_test:
-            env = self.julia_env_path(basedir=self.tmp_test_dir)
+        env = self.julia_env_path(basedir=self.tmp_test_dir)
+        testcmd = [
+            'using Pkg',
+            f'Pkg.activate("{env}")',
+            # f'Pkg.develop([{pkg_specs}]; preserve=PRESERVE_ALL)',
+            # 'Pkg.test([{pkg_test}])',
+        ]
+        if self.julia_deps_test:
             pkg_specs = ', '.join(f'PackageSpec(path="{path}")' for path in self.julia_deps_test.values())
-            pkg_test = ', '.join(f'"{pkg}"' for pkg in self.pkgs_to_test)
-            testcmd = [
-                'using Pkg',
-                f'Pkg.activate("{env}")',
-                f'Pkg.develop([{pkg_specs}]; preserve=PRESERVE_ALL)',
-                f'Pkg.test([{pkg_test}])',
-            ]
-            testcmd = '; '.join(testcmd)
-            testcmd = f"julia -e '{testcmd}'"
+            testcmd.append(f'Pkg.develop([{pkg_specs}]; preserve=PRESERVE_ALL)')
+        testcmd.append('Pkg.test([{pkg_test}])')
+        testcmd = '; '.join(testcmd)
+        testcmd = f"julia -e '{testcmd}'"
 
-            # Also add normal DEPOT/LOAD paths to environment to try and re-use pre-compiled caches as much as possible
-            # But also ensure that artifacts for packages that do not need recompilation are still found in the tests
-            self.prepare_julia_env(online=self.cfg['test_online'])
-            self.prepare_julia_env(basedir=self.tmp_test_dir, online=self.cfg['test_online'])
+        # Also add normal DEPOT/LOAD paths to environment to try and re-use pre-compiled caches as much as possible
+        # But also ensure that artifacts for packages that do not need recompilation are still found in the tests
+        self.prepare_julia_env()
+        self.prepare_julia_env(basedir=self.tmp_test_dir)
+
+        # Run offline tests first just in case the online ones could modify the environment
+        if self.pkgs_to_test_offline:
+            trace_msg("Running offline tests:")
+            self.set_pkg_remote(online=False)
+            pkg_test = ', '.join(f'"{pkg}"' for pkg in self.pkgs_to_test_offline)
 
             cmd = ' '.join([
                 self.cfg['pretestopts'],
-                testcmd,
+                testcmd.format(pkg_test=pkg_test),
+                self.cfg['testopts'],
+            ])
+
+            res = run_shell_cmd(cmd, fail_on_error=False)
+
+            if res.exit_code != 0:
+                self.report_test_failure(f"Offline tests failed for Julia package {self.name}:\n{res.output}")
+
+        if self.pkgs_to_test_online:
+            trace_msg("Running online tests:")
+            self.set_pkg_remote(online=True)
+            pkg_test = ', '.join(f'"{pkg}"' for pkg in self.pkgs_to_test_online)
+
+            cmd = ' '.join([
+                self.cfg['pretestopts'],
+                testcmd.format(pkg_test=pkg_test),
                 self.cfg['testopts'],
             ])
 

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -77,9 +77,11 @@ JULIA_MODULE_FOOTER = {
 setenv("JULIA_DEPOT_PATH", ":" .. os.getenv("EBJULIA_DEPOT_PATH") )
 setenv("JULIA_LOAD_PATH", os.getenv("EBJULIA_LOAD_PATH") .. ":")
 """,
+    # This needs testing, the module generate seems to work fine, but the loading of the module within EB does not
+    # properly resolve the $::env() and leaves it as a string
     "Tcl": """
-setenv JULIA_DEPOT_PATH ":$::env(EBJULIA_DEPOT_PATH)"
-setenv JULIA_LOAD_PATH "$::env(EBJULIA_LOAD_PATH):"
+setenv JULIA_DEPOT_PATH ":\$::env(EBJULIA_DEPOT_PATH)"
+setenv JULIA_LOAD_PATH "\$::env(EBJULIA_LOAD_PATH):"
 """,
 }
 
@@ -159,6 +161,7 @@ class JuliaPackage(ExtensionEasyBlock):
         self._env_toml = {'deps': {}, 'sources': {}}
         self.julia_deps = []
         self._julia_version = None
+        self._tmp_test_dir = None
 
     @property
     def julia_version(self) -> str:
@@ -190,6 +193,16 @@ class JuliaPackage(ExtensionEasyBlock):
             return False
 
         return self.master.ext_instances and self.master.ext_instances[-1] is self
+
+    @property
+    def tmp_test_dir(self):
+        """Temporary path used for running the test step."""
+        if not self._tmp_test_dir:
+            try:
+                self._tmp_test_dir = tempfile.mkdtemp(suffix='-julia_tests')
+            except Exception as e:
+                raise EasyBuildError("Failed to create temporary directory for Julia package testing: %s", str(e))
+        return self._tmp_test_dir
 
     @staticmethod
     def write_project_toml(file_path, project_toml):
@@ -394,17 +407,12 @@ class JuliaPackage(ExtensionEasyBlock):
             if testcmd is None:
                 testcmd = f"julia -e 'using Pkg; Pkg.test(\"{self.name}\")'"
 
-            try:
-                tmpdir = tempfile.mkdtemp()
-            except OSError as err:
-                raise EasyBuildError("Failed to create test install dir: %s", err)
-
             depot_path = self.get_julia_env("DEPOT_PATH")
             load_path = self.get_julia_env("LOAD_PATH")
             self.log.info("Original DEPOT_PATH for testing: %s", os.pathsep.join(depot_path))
             self.log.info("Original LOAD_PATH for testing: %s", os.pathsep.join(load_path))
 
-            depot_path = os.pathsep.join([tmpdir] + depot_path)
+            depot_path = os.pathsep.join([self.tmp_test_dir] + depot_path)
 
             extrapath = " && ".join([
                 f"export JULIA_DEPOT_PATH=\"{depot_path}\"",
@@ -423,7 +431,14 @@ class JuliaPackage(ExtensionEasyBlock):
 
     def install_source(self):
         """Add the Julia package source files in the installation directory."""
-        package_dir = os.path.join(self.installdir, 'packages', self.name)
+        if self.cfg['is_test_dependency']:
+            self.log.debug(
+                f"Package {self.name} is only needed for testing, installing sources in {self.tmp_test_dir}"
+            )
+            package_dir = os.path.join(self.tmp_test_dir, 'packages', self.name)
+        else:
+            package_dir = os.path.join(self.installdir, 'packages', self.name)
+        # This also warks for dirs and will fail if the destination already exists
         move_file(self.ext_dir if self.is_extension else self.start_dir, package_dir)
 
         # Add package to the main environment Project.toml file
@@ -446,10 +461,6 @@ class JuliaPackage(ExtensionEasyBlock):
         if not self.src:
             errmsg = "No source found for Julia package %s, required for installation. (src: %s)"
             raise EasyBuildError(errmsg, self.name, self.src)
-
-        if self.cfg['is_test_dependency']:
-            self.log.info("Package %s is only needed for testing, skipping installation", self.name)
-            return
 
         # Unpack source into install directory and add package to the main environment Project.toml file
         ExtensionEasyBlock.install_extension(self, unpack_src=True)

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -146,6 +146,10 @@ class JuliaPackage(ExtensionEasyBlock):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        if self.cfg['is_test_dependency'] and not self.is_extension:
+            raise EasyBuildError("Test dependencies can only be defined as an extension, not as a bundle itself")
+
         self._conflicts = []
         self._julia_deps = {}
         self._julia_deps_test = {}

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -128,10 +128,12 @@ class JuliaPackage(ExtensionEasyBlock):
             "LOAD_PATH": "julia -E 'Base.load_path()'",
         }
 
-        try:
-            res = run_shell_cmd(julia_read_cmd[env_var], hidden=True)
-        except KeyError:
+        if env_var not in julia_read_cmd:
             raise EasyBuildError("Unknown Julia environment variable requested: %s", env_var)
+
+        cmd = julia_read_cmd[env_var]
+
+        res = run_shell_cmd(cmd, hidden=True)
 
         try:
             parsed_var = ast.literal_eval(res.output)
@@ -142,11 +144,12 @@ class JuliaPackage(ExtensionEasyBlock):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._pkg_deps = []
-        self._pkt_to_test = []
+        self._conflicts = []
         self._julia_deps = {}
         self._julia_deps_test = {}
         self._julia_version = None
+        self._pkg_deps = []
+        self._pkg_to_test = []
         self._tmp_test_dir = None
 
     @property
@@ -166,18 +169,19 @@ class JuliaPackage(ExtensionEasyBlock):
         return self._julia_version
 
     @property
-    def pkg_deps(self):
-        """List of Julia dependencies found in this installation."""
+    def conflicts(self):
+        """List of conflicting software."""
         if self.is_extension:
-            return self.master.pkg_deps
-        return self._pkg_deps
+            return self.master.conflicts
+        return self._conflicts
 
     @property
-    def pkg_to_test(self):
-        """List of Julia dependencies to be included in the test environment."""
-        if self.is_extension:
-            return self.master.pkg_to_test
-        return self._pkt_to_test
+    def is_last_extension(self):
+        """Whether this extension is the last one to be installed in the installation."""
+        if not self.is_extension:
+            return False
+
+        return self.master.ext_instances and self.master.ext_instances[-1] is self
 
     @property
     def julia_deps(self):
@@ -194,12 +198,18 @@ class JuliaPackage(ExtensionEasyBlock):
         return self._julia_deps_test
 
     @property
-    def is_last_extension(self):
-        """Whether this extension is the last one to be installed in the installation."""
-        if not self.is_extension:
-            return False
+    def pkg_deps(self):
+        """List of Julia dependencies found in this installation."""
+        if self.is_extension:
+            return self.master.pkg_deps
+        return self._pkg_deps
 
-        return self.master.ext_instances and self.master.ext_instances[-1] is self
+    @property
+    def pkg_to_test(self):
+        """List of Julia dependencies to be included in the test environment."""
+        if self.is_extension:
+            return self.master.pkg_to_test
+        return self._pkg_to_test
 
     @property
     def tmp_test_dir(self):
@@ -303,17 +313,29 @@ class JuliaPackage(ExtensionEasyBlock):
 
     def add_package(self, pkg_source, test_only=False):
         pkg_name = os.path.basename(pkg_source)
-        if pkg_name in self.julia_deps and self.julia_deps[pkg_name] != pkg_source:
-            raise EasyBuildError(
-                "Conflict detected for package '%s': already added from source '%s', cannot add from source '%s'",
-                pkg_name, self.julia_deps[pkg_name], pkg_source
-            )
+        if pkg_name in self.julia_deps:
+            prev_source = self.julia_deps[pkg_name]
+            if prev_source != pkg_source:
+                self.conflicts.append((self.name, pkg_name, prev_source, pkg_source))
+
         self.julia_deps_test[pkg_name] = pkg_source
         if not test_only:
             self.julia_deps[pkg_name] = pkg_source
 
+    def _check_conflicts(self):
+        """Check for conflicts in Julia dependencies and raise an error if any are found."""
+        if self.conflicts:
+            conflict_msgs = []
+            for ext_name, pkg_name, prev_source, new_source in self.conflicts:
+                conflict_msgs.append(
+                    f"Conflict detected for package '{pkg_name}' in extension '{ext_name}': "
+                    f"already added from source '{prev_source}', cannot add from source '{new_source}'"
+                )
+            raise EasyBuildError("Conflicts detected in Julia dependencies:\n" + "\n".join(conflict_msgs))
+
     def install_pkg(self, basedir=None):
         """Execute Julia.Pkg command to install package from its sources"""
+        self._check_conflicts()
         basedir = basedir or self.installdir
         env = self.julia_env_path(basedir=basedir)
 

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -26,6 +26,7 @@
 EasyBuild support for Julia Packages, implemented as an easyblock
 
 @author: Alex Domingo (Vrije Universiteit Brussel)
+@author: Davide Grassano (CECAM, EPFL)
 """
 import ast
 import os
@@ -126,8 +127,23 @@ class JuliaPackage(ExtensionEasyBlock):
                 "Whether this package is only needed for testing and should not be added to installation environment",
                 CUSTOM
             ],
+            'julia_debug': [
+                False,
+                "Whether to set JULIA_DEBUG=all during installation and testing, to get more verbose output.",
+                CUSTOM
+            ],
+            # Arguably this should be set to True by default. In many cases the test environment in Julia packages
+            # will attempt to re-install the package being tested. If not all required packages to be  brought in the
+            # test environment were specified in test/Project.toml, running Pkg.test() in offline mode will fail.
+            # Some test tools like Aqua will also re-create their own tmp environment which can be broken even if
+            # test/Project.toml is properly set up/patched.
             'test_online': [
-                False, "Allow online tests that require downloading dependencies. By default, tests are run in offline mode.",
+                False,
+                "Allow online tests that require downloading dependencies. By default, tests are run in offline mode.",
+                CUSTOM
+            ],
+            'subpackages_dirs': [
+                None, "List of subdirectories to look for additional packages to add to the environment",
                 CUSTOM
             ],
         })
@@ -159,6 +175,7 @@ class JuliaPackage(ExtensionEasyBlock):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._env_toml = {'deps': {}, 'sources': {}}
+        self._env_toml_test = {'deps': {}, 'sources': {}}
         self.julia_deps = []
         self._julia_version = None
         self._tmp_test_dir = None
@@ -187,6 +204,13 @@ class JuliaPackage(ExtensionEasyBlock):
         return self._env_toml
 
     @property
+    def env_toml_test(self):
+        """Property to store content of installation environment Project.toml file."""
+        if self.is_extension:
+            return self.master.env_toml_test
+        return self._env_toml_test
+
+    @property
     def is_last_extension(self):
         """Whether this extension is the last one to be installed in the installation."""
         if not self.is_extension:
@@ -197,6 +221,9 @@ class JuliaPackage(ExtensionEasyBlock):
     @property
     def tmp_test_dir(self):
         """Temporary path used for running the test step."""
+        if self.is_extension:
+            return self.master.tmp_test_dir
+
         if not self._tmp_test_dir:
             try:
                 self._tmp_test_dir = tempfile.mkdtemp(suffix='-julia_tests')
@@ -207,6 +234,7 @@ class JuliaPackage(ExtensionEasyBlock):
     @staticmethod
     def write_project_toml(file_path, project_toml):
         """Write a Project.toml file with the given content to the given path"""
+        mkdir(os.path.dirname(file_path), parents=True)
         with open(file_path, 'w') as env_proj:
             for section, items in project_toml.items():
                 env_proj.write(f'[{section}]\n')
@@ -225,7 +253,7 @@ class JuliaPackage(ExtensionEasyBlock):
         return project_toml
 
     @classmethod
-    def update_toml_data(cls, toml_data, pkg_name, pkg_path):
+    def update_toml_data(cls, toml_data, pkg_path):
         """Update given toml data with new package and return updated data"""
         if os.path.isdir(pkg_path):
             pkg_dir = pkg_path
@@ -237,6 +265,7 @@ class JuliaPackage(ExtensionEasyBlock):
             raise EasyBuildError("Project.toml file not found for package %s in path: %s", pkg_name, pkg_dir)
 
         project_toml = cls.read_project_toml(pkg_path)
+        pkg_name = project_toml['name']
         pkg_uuid = project_toml['uuid']
 
         toml_data.setdefault('deps', {})[pkg_name] = pkg_uuid
@@ -244,27 +273,33 @@ class JuliaPackage(ExtensionEasyBlock):
 
         return toml_data
 
-    def write_env_toml(self, toml_data):
+    def write_env_toml(self):
         """Write environment Project.toml file"""
-        dir_path = self.julia_env_path()
-        mkdir(dir_path, parents=True)
-        self.write_project_toml(self.julia_env_path(base=False), toml_data)
+        self.write_project_toml(self.julia_env_path(base=False), self.env_toml)
 
-    def add_to_env_toml(self):
+    def write_env_toml_test(self):
+        """Write test environment Project.toml file"""
+        self.write_project_toml(self.julia_env_path(base=False, basedir=self.tmp_test_dir), self.env_toml_test)
+
+    def add_to_env_toml(self, package_dir):
         """Add package to environment toml file of the installation"""
-        package_dir = os.path.join(self.installdir, 'packages', self.name)
-        self.update_toml_data(self.env_toml, self.name, package_dir)
+        self.update_toml_data(self.env_toml, package_dir)
 
-    def julia_env_path(self, absolute=True, base=True):
+    def add_to_env_toml_test(self, package_dir):
+        """Add package to environment toml file of the test environment"""
+        self.update_toml_data(self.env_toml_test, package_dir)
+
+    def julia_env_path(self, absolute=True, base=True, basedir=None):
         """
         Return path to installation environment file.
         """
-        julia_version = get_software_version('Julia').split('.')
+        basedir = basedir or self.installdir
+        julia_version = self.julia_version.split('.')
         env_dir = "v{}.{}".format(*julia_version[:2])
         project_env = os.path.join("environments", env_dir, "Project.toml")
 
         if absolute:
-            project_env = os.path.join(self.installdir, project_env)
+            project_env = os.path.join(basedir, project_env)
         if base:
             project_env = os.path.dirname(project_env)
 
@@ -273,21 +308,20 @@ class JuliaPackage(ExtensionEasyBlock):
     def set_pkg_offline(self):
         """Enable offline mode of Julia Pkg"""
 
-        if not self.cfg['download_pkg_deps']:
-            julia_version = get_software_version('Julia')
-            if LooseVersion(julia_version) >= LooseVersion('1.5'):
-                # Enable offline mode of Julia Pkg
-                # https://pkgdocs.julialang.org/v1/api/#Pkg.offline
-                env.setvar('JULIA_PKG_OFFLINE', 'true')
-            else:
-                errmsg = (
-                    "Cannot set offline mode in Julia v%s (needs Julia >= 1.5). "
-                    "Enable easyconfig option 'download_pkg_deps' to allow installation "
-                    "with any extra downloaded dependencies."
-                )
-                raise EasyBuildError(errmsg, julia_version)
+        julia_version = get_software_version('Julia')
+        if LooseVersion(julia_version) >= LooseVersion('1.5'):
+            # Enable offline mode of Julia Pkg
+            # https://pkgdocs.julialang.org/v1/api/#Pkg.offline
+            env.setvar('JULIA_PKG_OFFLINE', 'true')
+        else:
+            errmsg = (
+                "Cannot set offline mode in Julia v%s (needs Julia >= 1.5). "
+                "Enable easyconfig option 'download_pkg_deps' to allow installation "
+                "with any extra downloaded dependencies."
+            )
+            raise EasyBuildError(errmsg, julia_version)
 
-    def prepare_julia_env(self):
+    def prepare_julia_env(self, basedir=None, online=False):
         """
         1. Remove user depot and prepend installation directory to DEPOT_PATH.
         Top directory in Julia DEPOT_PATH is the target installation directory.
@@ -303,6 +337,7 @@ class JuliaPackage(ExtensionEasyBlock):
 
         4. Enable automatic precompilation of packages after each build.
         """
+        basedir = basedir or self.installdir
         # Grab both DEPOT_PATH and LOAD_PATH before any changes are made
         # given that Julia might automatically update LOAD_PATH from a change on DEPOT_PATH
         dirty_depot = self.get_julia_env("DEPOT_PATH")
@@ -312,33 +347,38 @@ class JuliaPackage(ExtensionEasyBlock):
 
         # First set DEPOT_PATH and then LOAD_PATH to avoid any automatic changes made by Julia
         clean_depot = [path for path in dirty_depot if not USER_DEPOT_PATTERN.search(path) and path != self.installdir]
-        install_depot = os.pathsep.join([self.installdir] + clean_depot)
+        install_depot = os.pathsep.join([basedir] + clean_depot)
         self.log.debug("Preparing Julia 'DEPOT_PATH' for installation: %s", install_depot)
         env.setvar("JULIA_DEPOT_PATH", install_depot)
 
-        project_toml = self.julia_env_path(base=False)
+        project_toml = self.julia_env_path(base=False, basedir=basedir)
         clean_load = [path for path in dirty_load if not USER_DEPOT_PATTERN.search(path) and path != project_toml]
         install_load = os.pathsep.join([project_toml] + clean_load)
         self.log.debug("Preparing Julia 'LOAD_PATH' for installation: %s", install_load)
         env.setvar("JULIA_LOAD_PATH", install_load)
 
-        if self.julia_env_path(base=False) not in self.get_julia_env("LOAD_PATH"):
+        if project_toml not in self.get_julia_env("LOAD_PATH"):
             errmsg = "Failed to prepare Julia environment for installation of: %s"
             raise EasyBuildError(errmsg, self.name)
 
         # Enable offline mode
-        self.set_pkg_offline()
+        if not online:
+            self.set_pkg_offline()
+
+        if self.cfg['julia_debug']:
+            env.setvar('JULIA_DEBUG', 'all')
 
         # Set the maximum number of concurrent package builds
         env.setvar('JULIA_NUM_PRECOMPILE_TASKS', str(self.cfg.parallel))
         # Enable automatic precompilation
         env.setvar('JULIA_PKG_PRECOMPILE_AUTO', 'true')
 
-    def install_pkg(self):
+    def install_pkg(self, basedir=None):
         """Execute Julia.Pkg command to install package from its sources"""
+        basedir = basedir or self.installdir
         julia_pkg_cmd = [
             'using Pkg',
-            'Pkg.activate("%s")' % self.julia_env_path(),
+            'Pkg.activate("%s")' % self.julia_env_path(basedir=basedir),
             # Usage `Pkg.instantiate()` after all sources are in place to let Pkg handle all dependencies.
             # This has the advantage of letting Pkg deal with the order and parallel installation.
             'Pkg.instantiate()',
@@ -374,9 +414,9 @@ class JuliaPackage(ExtensionEasyBlock):
 
             dep_toml = self.read_project_toml(dep_env)
             for section in sections:
-                self.env_toml.setdefault(section, {}).update(dep_toml.get(section, {}))
-
-        self.write_env_toml(self.env_toml)
+                data = dep_toml.get(section, {})
+                for toml in [self.env_toml, self.env_toml_test]:
+                    toml.setdefault(section, {}).update(data)
 
     def prepare_step(self, *args, **kwargs):
         """Prepare for Julia package installation."""
@@ -407,21 +447,12 @@ class JuliaPackage(ExtensionEasyBlock):
             if testcmd is None:
                 testcmd = f"julia -e 'using Pkg; Pkg.test(\"{self.name}\")'"
 
-            depot_path = self.get_julia_env("DEPOT_PATH")
-            load_path = self.get_julia_env("LOAD_PATH")
-            self.log.info("Original DEPOT_PATH for testing: %s", os.pathsep.join(depot_path))
-            self.log.info("Original LOAD_PATH for testing: %s", os.pathsep.join(load_path))
+            # Write test environment Project.toml that also include path reference to test dependencies
+            self.write_env_toml_test()
 
-            depot_path = os.pathsep.join([self.tmp_test_dir] + depot_path)
-
-            extrapath = " && ".join([
-                f"export JULIA_DEPOT_PATH=\"{depot_path}\"",
-                f"export JULIA_PKG_OFFLINE={'false' if self.cfg['test_online'] else 'true'}",
-                ""
-            ])
+            self.prepare_julia_env(basedir=self.tmp_test_dir, online=self.cfg['test_online'])
 
             cmd = ' '.join([
-                extrapath,
                 self.cfg['pretestopts'],
                 testcmd,
                 self.cfg['testopts'],
@@ -435,20 +466,32 @@ class JuliaPackage(ExtensionEasyBlock):
             self.log.debug(
                 f"Package {self.name} is only needed for testing, installing sources in {self.tmp_test_dir}"
             )
+            trace_msg("Installing as a test dependency...")
             package_dir = os.path.join(self.tmp_test_dir, 'packages', self.name)
         else:
             package_dir = os.path.join(self.installdir, 'packages', self.name)
         # This also warks for dirs and will fail if the destination already exists
         move_file(self.ext_dir if self.is_extension else self.start_dir, package_dir)
 
-        # Add package to the main environment Project.toml file
-        self.add_to_env_toml()
+        # Add all packages to the test environment Project.toml file
+        self.add_to_env_toml_test(package_dir)
+        if not self.cfg['is_test_dependency']:
+            self.add_to_env_toml(package_dir)
 
-    def _install_step(self):
+        subpkg_dirs = self.cfg['subpackages_dirs'] or []
+        for subpkg_dir in subpkg_dirs:
+            subpkg_path = os.path.join(package_dir, subpkg_dir)
+            if not os.path.isdir(subpkg_path):
+                self.log.warning("Sub-package directory specified but not found, skipping: %s", subpkg_path)
+                continue
+            trace_msg(f"Adding sub-package from specified directory {subpkg_path}")
+            self.add_to_env_toml(subpkg_path)
+
+    def _install_step(self, basedir=None):
         """Install step commons between single-package and extensions based installs."""
-        self.write_env_toml(self.env_toml)
-        self.prepare_julia_env()
-        return self.install_pkg()
+        self.write_env_toml()
+        self.prepare_julia_env(basedir=basedir, online=self.cfg['download_pkg_deps'])
+        return self.install_pkg(basedir=basedir)
 
     def install_step(self):
         """Prepare installation environment and install Julia package."""
@@ -457,7 +500,6 @@ class JuliaPackage(ExtensionEasyBlock):
 
     def install_extension(self):
         """Install Julia package as an extension."""
-
         if not self.src:
             errmsg = "No source found for Julia package %s, required for installation. (src: %s)"
             raise EasyBuildError(errmsg, self.name, self.src)
@@ -472,6 +514,9 @@ class JuliaPackage(ExtensionEasyBlock):
 
     def sanity_check_step(self, *args, **kwargs):
         """Custom sanity check for JuliaPackage"""
+        if self.cfg['is_test_dependency']:
+            self.log.debug(f"Package {self.name} is only used for testing, skipping sanity check")
+            return (True, "Test dependency, skipping sanity check")
 
         pkg_dir = os.path.join('packages', self.name)
 
@@ -480,7 +525,6 @@ class JuliaPackage(ExtensionEasyBlock):
         # name as rebuilding using PkgA and PkgB as dependenices can retrigger a compilation of PkgB in case e.g. it
         # was a `weakdep` of PkgA with an associated extension
         for julia_dep in self.julia_deps:
-            trace_msg(f"Checking that compile cache of dependency {julia_dep} can still be loaded")
             custom_commands.append(
                 _COMPILECACHE_CHECK % {'ext_name': julia_dep}
             )

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -635,17 +635,6 @@ class JuliaPackage(ExtensionEasyBlock):
         if self.is_extension:
             pkg_dir = os.path.join('packages', self.name)
 
-            custom_commands = []
-            # Check that the compile cache of the dependencies can still be loaded
-            if not self.is_extension and cc_check:
-                for dep, _ in self.pkg_deps:
-                    # root_comp = os.path.join(root, 'compiled')
-                    custom_commands.append(
-                        _COMPILECACHE_CHECK % {'ext_name': dep, 'grep_loc': dep}
-
-                    )
-            kwargs.setdefault('custom_commands', []).extend(custom_commands)
-
             custom_paths = {
                 'files': [],
                 'dirs': [pkg_dir],
@@ -660,6 +649,13 @@ class JuliaPackage(ExtensionEasyBlock):
                 'files': [],
                 'dirs': ['packages', 'environments'],
             }
+            custom_commands = []
+            if cc_check:
+                for dep, _ in self.pkg_deps:
+                    custom_commands.append(
+                        _COMPILECACHE_CHECK % {'ext_name': dep, 'grep_loc': dep}
+                    )
+            kwargs.setdefault('custom_commands', []).extend(custom_commands)
 
         kwargs.update({'custom_paths': custom_paths})
 

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -51,7 +51,7 @@ _COMPILECACHE_CHECK = ' | '.join([
     # compilecache_path is not part of the stable API and changes arguments across versions
     # allow internal cache resolution and use debug statemnts to get the path of the loaded cache
     "JULIA_DEBUG=loading julia -e 'using %(ext_name)s' 2>&1 1>/dev/null",
-    "grep '%(grep_loc)s'"
+    "grep 'Loading object cache file .*%(grep_loc)s'"
 ])
 
 EXTS_FILTER_JULIA_PACKAGES = (
@@ -231,14 +231,14 @@ class JuliaPackage(ExtensionEasyBlock):
 
         return project_env
 
-    def set_pkg_offline(self):
+    def set_pkg_offline(self, online=False):
         """Enable offline mode of Julia Pkg"""
 
         julia_version = get_software_version('Julia')
         if LooseVersion(julia_version) >= LooseVersion('1.5'):
             # Enable offline mode of Julia Pkg
             # https://pkgdocs.julialang.org/v1/api/#Pkg.offline
-            env.setvar('JULIA_PKG_OFFLINE', 'true')
+            env.setvar('JULIA_PKG_OFFLINE', 'false' if online else 'true')
         else:
             errmsg = (
                 "Cannot set offline mode in Julia v%s (needs Julia >= 1.5). "
@@ -494,7 +494,9 @@ class JuliaPackage(ExtensionEasyBlock):
             for dep, root in self.pkg_deps:
                 root_comp = os.path.join(root, 'compiled')
                 custom_commands.append(
-                    _COMPILECACHE_CHECK % {'ext_name': dep, 'grep_loc': root_comp}
+                    # _COMPILECACHE_CHECK % {'ext_name': dep, 'grep_loc': f'Loading object cache file .*{root_comp}'}
+                    _COMPILECACHE_CHECK % {'ext_name': dep, 'grep_loc': dep}
+
                 )
         kwargs.setdefault('custom_commands', []).extend(custom_commands)
 

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -43,7 +43,7 @@ from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option
 from easybuild.tools.modules import get_software_root, get_software_version
-from easybuild.tools.filetools import move_file
+from easybuild.tools.filetools import copy_dir
 from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.utilities import trace_msg, print_msg
 from easybuild.tools.hooks import BUILD_STEP, TEST_STEP
@@ -502,7 +502,7 @@ class JuliaPackage(ExtensionEasyBlock):
         else:
             package_dir = os.path.join(self.installdir, 'packages', self.name)
 
-        move_file(self.start_dir, package_dir)
+        copy_dir(self.start_dir, package_dir)
         self.add_package(package_dir, test_only=self.cfg['is_test_dependency'])
 
     def _build_install_step(self, basedir: Union[str, None] = None):

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -40,15 +40,17 @@ from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root, get_software_version
-from easybuild.tools.filetools import mkdir, move_file
+from easybuild.tools.filetools import move_file
 from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.utilities import trace_msg
-from easybuild.tools import tomllib
 
 from easybuild.easyblocks.j.julia import EB_JULIA_DEPOT_PATH_VAR, EB_JULIA_LOAD_PATH_VAR
 
 _COMPILECACHE_CHECK = ' | '.join([
-    "julia -E 'Base.compilecache_path(Base.identify_package(\"%(ext_name)s\"))'",
+    # "julia -E 'Base.compilecache_path(Base.identify_package(\"%(ext_name)s\"), Base.get_world_counter())'",
+    # compilecache_path is not part of the stable API and changes arguments across versions
+    # allow internal cache resolution and use debug statemnts to get the path of the loaded cache
+    "JULIA_DEBUG=loading julia -e 'using %(ext_name)s' 2>&1 1>/dev/null",
     "grep '%(grep_loc)s'"
 ])
 
@@ -149,9 +151,9 @@ class JuliaPackage(ExtensionEasyBlock):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._env_toml = {'deps': {}, 'sources': {}}
-        self._env_toml_test = {'deps': {}, 'sources': {}}
-        self.julia_deps = []
+        self._pkg_deps = []
+        self._julia_deps = {}
+        self._julia_deps_test = {}
         self._julia_version = None
         self._tmp_test_dir = None
 
@@ -172,18 +174,25 @@ class JuliaPackage(ExtensionEasyBlock):
         return self._julia_version
 
     @property
-    def env_toml(self):
-        """Property to store content of installation environment Project.toml file."""
+    def pkg_deps(self):
+        """List of Julia dependencies found in this installation."""
         if self.is_extension:
-            return self.master.env_toml
-        return self._env_toml
+            return self.master.pkg_deps
+        return self._pkg_deps
 
     @property
-    def env_toml_test(self):
-        """Property to store content of installation environment Project.toml file."""
+    def julia_deps(self):
+        """List of Julia dependencies found in this installation."""
         if self.is_extension:
-            return self.master.env_toml_test
-        return self._env_toml_test
+            return self.master.julia_deps
+        return self._julia_deps
+
+    @property
+    def julia_deps_test(self):
+        """List of Julia dependencies found in this installation."""
+        if self.is_extension:
+            return self.master.julia_deps_test
+        return self._julia_deps_test
 
     @property
     def is_last_extension(self):
@@ -205,64 +214,6 @@ class JuliaPackage(ExtensionEasyBlock):
             except Exception as e:
                 raise EasyBuildError("Failed to create temporary directory for Julia package testing: %s", str(e))
         return self._tmp_test_dir
-
-    @staticmethod
-    def write_project_toml(file_path, project_toml):
-        """Write a Project.toml file with the given content to the given path"""
-        mkdir(os.path.dirname(file_path), parents=True)
-        with open(file_path, 'w') as env_proj:
-            for section, items in project_toml.items():
-                env_proj.write(f'[{section}]\n')
-                for key, value in items.items():
-                    value = repr(value)
-                    value = value.replace("'", '"')
-                    value = value.replace(': ', ' = ')
-                    env_proj.write(f'{key} = {value}\n')
-                env_proj.write('\n')
-
-    @staticmethod
-    def read_project_toml(file_path):
-        """Read a Project.toml file and return its content as a dict"""
-        with open(file_path, 'rb') as env_proj:
-            project_toml = tomllib.load(env_proj)
-        return project_toml
-
-    @classmethod
-    def update_toml_data(cls, toml_data, pkg_path):
-        """Update given toml data with new package and return updated data"""
-        if os.path.isdir(pkg_path):
-            pkg_dir = pkg_path
-            pkg_path = os.path.join(pkg_path, 'Project.toml')
-        else:
-            pkg_dir = os.path.dirname(pkg_path)
-
-        if not os.path.isfile(pkg_path):
-            raise EasyBuildError("Project.toml file not found in path: %s", pkg_dir)
-
-        project_toml = cls.read_project_toml(pkg_path)
-        pkg_name = project_toml['name']
-        pkg_uuid = project_toml['uuid']
-
-        toml_data.setdefault('deps', {})[pkg_name] = pkg_uuid
-        toml_data.setdefault('sources', {})[pkg_name] = {'path': pkg_dir}
-
-        return toml_data
-
-    def write_env_toml(self):
-        """Write environment Project.toml file"""
-        self.write_project_toml(self.julia_env_path(base=False), self.env_toml)
-
-    def write_env_toml_test(self):
-        """Write test environment Project.toml file"""
-        self.write_project_toml(self.julia_env_path(base=False, basedir=self.tmp_test_dir), self.env_toml_test)
-
-    def add_to_env_toml(self, package_dir):
-        """Add package to environment toml file of the installation"""
-        self.update_toml_data(self.env_toml, package_dir)
-
-    def add_to_env_toml_test(self, package_dir):
-        """Add package to environment toml file of the test environment"""
-        self.update_toml_data(self.env_toml_test, package_dir)
 
     def julia_env_path(self, absolute=True, base=True, basedir=None):
         """
@@ -332,6 +283,10 @@ class JuliaPackage(ExtensionEasyBlock):
         self.log.debug("Preparing Julia 'LOAD_PATH' for installation: %s", install_load)
         env.setvar("JULIA_LOAD_PATH", install_load)
 
+        # Disable EB controlled PATHS to enforce the specific configurations
+        env.setvar(EB_JULIA_DEPOT_PATH_VAR, "")
+        env.setvar(EB_JULIA_LOAD_PATH_VAR, "")
+
         if project_toml not in self.get_julia_env("LOAD_PATH"):
             errmsg = "Failed to prepare Julia environment for installation of: %s"
             raise EasyBuildError(errmsg, self.name)
@@ -348,12 +303,29 @@ class JuliaPackage(ExtensionEasyBlock):
         # Enable automatic precompilation
         env.setvar('JULIA_PKG_PRECOMPILE_AUTO', 'true')
 
+    def add_package(self, pkg_source, test_only=False):
+        pkg_name = os.path.basename(pkg_source)
+        if pkg_name in self.julia_deps and self.julia_deps[pkg_name] != pkg_source:
+            raise EasyBuildError(
+                "Conflict detected for package '%s': already added from source '%s', cannot add from source '%s'",
+                pkg_name, self.julia_deps[pkg_name], pkg_source
+            )
+        self.julia_deps_test[pkg_name] = pkg_source
+        if not test_only:
+            self.julia_deps[pkg_name] = pkg_source
+
     def install_pkg(self, basedir=None):
         """Execute Julia.Pkg command to install package from its sources"""
         basedir = basedir or self.installdir
+        env = self.julia_env_path(basedir=basedir)
+
+        package_specs = ', '.join(f'PackageSpec(path="{path}")' for path in self.julia_deps.values())
+
         julia_pkg_cmd = [
             'using Pkg',
-            'Pkg.activate("%s")' % self.julia_env_path(basedir=basedir),
+            f'Pkg.activate("{env}")',
+
+            f'Pkg.develop([{package_specs}]; preserve=PRESERVE_ALL)',
             # Usage `Pkg.instantiate()` after all sources are in place to let Pkg handle all dependencies.
             # This has the advantage of letting Pkg deal with the order and parallel installation.
             'Pkg.instantiate()',
@@ -369,45 +341,46 @@ class JuliaPackage(ExtensionEasyBlock):
 
         return res.output
 
+    def _deps_from_project(self, environment):
+        """Get list of dependencies from a Project.toml file"""
+        julia_root = get_software_root('Julia')
+        cmd = "; ".join([
+            'using Pkg',
+            f'Pkg.activate("{environment}")',
+            # 'Pkg.status(; mode=PKGMODE_MANIFEST)',
+            'for (_, pkg) in Pkg.dependencies()',
+            'println("$(pkg.source)")',
+            'end'
+        ])
+
+        res = run_shell_cmd(f"julia -E '{cmd}'", split_stderr=True, hidden=True)
+        deps = res.output.strip().splitlines()
+
+        # Filter out Julia's stdlib dependencies
+        deps = filter(lambda d: not d.startswith(julia_root), deps)
+        deps = filter(lambda d: d != 'nothing', deps)
+
+        return list(deps)
+
     def include_pkg_dependencies(self):
         """Add to installation environment all Julia packages already present in its dependencies"""
-        sections = ['deps', 'sources']
-
         # add packages found in dependencies to this installation environment
         for dep in self.cfg.dependencies():
             dep_name = dep['name']
             dep_root = get_software_root(dep_name)
-            dep_env = os.path.join(dep_root, self.julia_env_path(absolute=False, base=False))
-            if not os.path.isfile(dep_env):
-                self.log.warning("No environment file found in dependency %s, skipping: %s", dep_name, dep_env)
+            dep_env = self.julia_env_path(absolute=True, base=True, basedir=dep_root)
+            dep_manifest = os.path.join(dep_env, 'Manifest.toml')
+            if not os.path.isfile(dep_manifest):
+                self.log.warning("No Manifest.toml file found in dependency %s, skipping: %s", dep_name, dep_env)
                 continue
 
-            self.julia_deps.append((dep_name, dep_root))
+            self.pkg_deps.append((dep_name, dep_root))
             trace_msg(
                 f"Incorporating Julia package dependencies from {dep_name} in installation environment: {dep_env}"
             )
 
-            dep_toml = self.read_project_toml(dep_env)
-            conflicts = []
-            for section in sections:
-                data = dep_toml.get(section, {})
-                for toml in [self.env_toml, self.env_toml_test]:
-                    sec_dct = toml.setdefault(section, {})
-                    for key, val in data.items():
-                        if key in sec_dct and sec_dct[key] != val:
-                            conflicts.append((key, section, dep_name, sec_dct[key], val))
-                    sec_dct.update(data)
-            if conflicts:
-                error_msg = '\n'.join(
-                    f'- Package "{k}" in section "{section}" `{current_v}` -> `{dep_v}`'
-                    for k, section, _, current_v, dep_v in conflicts
-                )
-                raise EasyBuildError(
-                    "\nConflicts found when merging dependency '%s' into installation environment:\n%s\n"
-                    "Make sure that all dependencies do not specify duplicate packages as extensions, otherwise the "
-                    "compile cache will be broken based on the module load order.",
-                    dep_name, error_msg
-                )
+            for pkg_path in self._deps_from_project(dep_env):
+                self.add_package(pkg_path)
 
     def prepare_step(self, *args, **kwargs):
         """Prepare for Julia package installation."""
@@ -416,13 +389,7 @@ class JuliaPackage(ExtensionEasyBlock):
         if get_software_root('Julia') is None:
             raise EasyBuildError("Julia not included as dependency!")
 
-    def configure_step(self):
-        """No separate configuration for JuliaPackage."""
-        pass
-
-    def build_step(self):
-        """No separate build procedure for JuliaPackage."""
-        pass
+        self.include_pkg_dependencies()
 
     def test_step(self):
         """
@@ -436,11 +403,20 @@ class JuliaPackage(ExtensionEasyBlock):
 
         if self.cfg['runtest']:
             if testcmd is None:
-                testcmd = f"julia -e 'using Pkg; Pkg.test(\"{self.name}\")'"
+                env = self.julia_env_path(basedir=self.tmp_test_dir)
+                package_specs = ', '.join(f'PackageSpec(path="{path}")' for path in self.julia_deps_test.values())
+                testcmd = [
+                    'using Pkg',
+                    f'Pkg.activate("{env}")',
+                    f'Pkg.develop([{package_specs}]; preserve=PRESERVE_ALL)',
+                    f'Pkg.test("{self.name}")',
+                ]
+                testcmd = '; '.join(testcmd)
+                testcmd = f"julia -e '{testcmd}'"
 
-            # Write test environment Project.toml that also include path reference to test dependencies
-            self.write_env_toml_test()
-
+            # Also add normal DEPOT/LOAD paths to environment to try and re-use pre-compiled caches as much as possible
+            # But also ensure that artifacts for packages that do not need recompilation are still found in the tests
+            self.prepare_julia_env(online=self.cfg['test_online'])
             self.prepare_julia_env(basedir=self.tmp_test_dir, online=self.cfg['test_online'])
 
             cmd = ' '.join([
@@ -461,26 +437,26 @@ class JuliaPackage(ExtensionEasyBlock):
             package_dir = os.path.join(self.tmp_test_dir, 'packages', self.name)
         else:
             package_dir = os.path.join(self.installdir, 'packages', self.name)
+
         # This also warks for dirs and will fail if the destination already exists
         move_file(self.ext_dir if self.is_extension else self.start_dir, package_dir)
 
         # Add all packages to the test environment Project.toml file
-        self.add_to_env_toml_test(package_dir)
-        if not self.cfg['is_test_dependency']:
-            self.add_to_env_toml(package_dir)
+        self.add_package(package_dir, test_only=self.cfg['is_test_dependency'])
 
         subpkg_dirs = self.cfg['subpackages_dirs'] or []
         for subpkg_dir in subpkg_dirs:
+            # pkg_name = os.path.basename(subpkg_dir)
             subpkg_path = os.path.join(package_dir, subpkg_dir)
             if not os.path.isdir(subpkg_path):
                 self.log.warning("Sub-package directory specified but not found, skipping: %s", subpkg_path)
                 continue
             trace_msg(f"Adding sub-package from specified directory {subpkg_path}")
-            self.add_to_env_toml(subpkg_path)
+
+            self.add_package(subpkg_path, test_only=self.cfg['is_test_dependency'])
 
     def _install_step(self, basedir=None):
         """Install step commons between single-package and extensions based installs."""
-        self.write_env_toml()
         self.prepare_julia_env(basedir=basedir, online=self.cfg['download_pkg_deps'])
         return self.install_pkg(basedir=basedir)
 
@@ -513,10 +489,13 @@ class JuliaPackage(ExtensionEasyBlock):
 
         custom_commands = []
         # Check that the compile cache of the dependencies can still be loaded and is coming from the expected package
-        for dep, root in self.julia_deps:
-            custom_commands.append(
-                _COMPILECACHE_CHECK % {'ext_name': dep, 'grep_loc': root}
-            )
+
+        if not self.is_extension:
+            for dep, root in self.pkg_deps:
+                root_comp = os.path.join(root, 'compiled')
+                custom_commands.append(
+                    _COMPILECACHE_CHECK % {'ext_name': dep, 'grep_loc': root_comp}
+                )
         kwargs.setdefault('custom_commands', []).extend(custom_commands)
 
         custom_paths = {
@@ -542,7 +521,7 @@ class JuliaPackage(ExtensionEasyBlock):
         mod += self.module_generator.prepend_paths(EB_JULIA_DEPOT_PATH_VAR, [''])
         mod += self.module_generator.prepend_paths(
             EB_JULIA_LOAD_PATH_VAR,
-            [self.julia_env_path(absolute=False, base=False)]
+            [self.julia_env_path(absolute=False, base=True)]
         )
 
         return mod

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -28,7 +28,6 @@ EasyBuild support for Julia Packages, implemented as an easyblock
 @author: Alex Domingo (Vrije Universiteit Brussel)
 """
 import ast
-import glob
 import os
 import re
 import tempfile
@@ -40,9 +39,10 @@ from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root, get_software_version
-from easybuild.tools.filetools import copy_dir, mkdir
+from easybuild.tools.filetools import copy_dir, mkdir, change_dir, move_file
 from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.utilities import trace_msg
+from easybuild.tools import tomllib
 
 EXTS_FILTER_JULIA_PACKAGES = ("julia -e 'using %(ext_name)s'", "")
 USER_DEPOT_PATTERN = re.compile(r"\/\.julia\/?(.*\.toml)*$")
@@ -93,6 +93,17 @@ class JuliaPackage(ExtensionEasyBlock):
             'download_pkg_deps': [
                 False, "Let Julia download and bundle all needed dependencies for this installation", CUSTOM
             ],
+            'is_test_dependency': [
+                False,
+                "Whether this package is only needed for testing and should not be added to installation environment",
+                CUSTOM
+            ],
+            'is_main_package': [
+                False,
+                "Whether this package is the main package of the installation. Only this will be installed and Julia "
+                "will take care of installing dependencies.",
+                CUSTOM
+            ],
         })
         return extra_vars
 
@@ -118,6 +129,17 @@ class JuliaPackage(ExtensionEasyBlock):
             raise EasyBuildError("Failed to parse %s from julia shell: %s", env_var, res.output)
 
         return parsed_var
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._env_toml = {'deps': {}, 'sources': {}}
+
+    @property
+    def env_toml(self):
+        """Property to store content of installation environment Project.toml file."""
+        if self.is_extension:
+            return self.master.env_toml
+        return self._env_toml
 
     def julia_env_path(self, absolute=True, base=True):
         """
@@ -232,17 +254,91 @@ class JuliaPackage(ExtensionEasyBlock):
 
         return res.output
 
+    @staticmethod
+    def write_project_toml(file_path, project_toml):
+        """Write a Project.toml file with the given content to the given path"""
+
+        with open(file_path, 'w') as env_proj:
+            for section, items in project_toml.items():
+                env_proj.write(f'[{section}]\n')
+                for key, value in items.items():
+                    value = repr(value)
+                    value = value.replace("'", '"')
+                    value = value.replace(': ', ' = ')
+                    env_proj.write(f'{key} = {value}\n')
+                env_proj.write('\n')
+
+    @staticmethod
+    def read_project_toml(file_path):
+        """Read a Project.toml file and return its content as a dict"""
+
+        with open(file_path, 'rb') as env_proj:
+            project_toml = tomllib.load(env_proj)
+
+        return project_toml
+
+    def write_env_toml(self, toml_data):
+        """Write environment Project.toml file"""
+
+        self.write_project_toml(self.julia_env_path(base=False), toml_data)
+
+
+    # def include_pkg_dependencies(self):
+    #     """Add to installation environment all Julia packages already present in its dependencies"""
+    #     # Location of project environment files in install dir
+    #     mkdir(self.julia_env_path(), parents=True)
+
+    #     # add packages found in dependencies to this installation environment
+    #     for dep in self.cfg.dependencies():
+    #         dep_root = get_software_root(dep['name'])
+    #         for pkg in glob.glob(os.path.join(dep_root, 'packages/*')):
+    #             trace_msg("incorporating Julia package from dependencies: %s" % os.path.basename(pkg))
+    #             self.install_pkg_source(pkg, self.julia_env_path(), trace=False)
+
     def include_pkg_dependencies(self):
         """Add to installation environment all Julia packages already present in its dependencies"""
         # Location of project environment files in install dir
         mkdir(self.julia_env_path(), parents=True)
 
+        sections = ['deps', 'sources']
+
         # add packages found in dependencies to this installation environment
+        to_remove = set()
         for dep in self.cfg.dependencies():
-            dep_root = get_software_root(dep['name'])
-            for pkg in glob.glob(os.path.join(dep_root, 'packages/*')):
-                trace_msg("incorporating Julia package from dependencies: %s" % os.path.basename(pkg))
-                self.install_pkg_source(pkg, self.julia_env_path(), trace=False)
+            dep_name = dep['name']
+            dep_root = get_software_root(dep_name)
+            dep_env = os.path.join(dep_root, self.julia_env_path(absolute=False, base=False))
+            if not os.path.isfile(dep_env):
+                self.log.warning("No environment file found in dependency %s, skipping: %s", dep_name, dep_env)
+                continue
+
+            to_remove.add(dep_name)
+            trace_msg
+
+            dep_toml = self.read_project_toml(dep_env)
+            for section in sections:
+                self.env_toml.setdefault(section, {}).update(dep_toml.get(section, {}))
+
+        if to_remove:
+            trace_msg(
+                "Removing dependencies from installation environment. "
+                "These dependencies will not appear in the resulting module:"
+            )
+        for dep_type in ['dependencies', 'builddependencies']:
+            to_remove_idx = []
+            ref = self.cfg.get_ref(dep_type)
+            for idx, dep in enumerate(ref):
+                if dep['name'] in to_remove:
+                    trace_msg(f'- {dep}')
+                    to_remove_idx.insert(0, idx)
+            for idx in to_remove_idx:
+                del ref[idx]
+
+        # print("Updated dependencies after removing Julia packages: %s", self.cfg.dependencies())
+        # print("Updated dependencies after removing Julia packages: %s", self.cfg.dependencies())
+
+        self.write_env_toml(self.env_toml)
+
 
     def install_pkg(self):
         """Install Julia package"""
@@ -295,6 +391,8 @@ class JuliaPackage(ExtensionEasyBlock):
             load_path = self.get_julia_env("LOAD_PATH")
             self.log.info("Original DEPOT_PATH for testing: %s", os.pathsep.join(depot_path))
             self.log.info("Original LOAD_PATH for testing: %s", os.pathsep.join(load_path))
+            # print("Testing with DEPOT_PATH: %s", os.pathsep.join(depot_path))
+            # print("Testing with LOAD_PATH: %s", os.pathsep.join(load_path))
 
             depot_path = os.pathsep.join([tmpdir] + depot_path)
 
@@ -302,7 +400,7 @@ class JuliaPackage(ExtensionEasyBlock):
                 f"export JULIA_DEPOT_PATH=\"{depot_path}\"",
                 # Ensure TEST dependencies can be downloaded
                 # The alternative is to install them as normal dependencies of the package
-                "export JULIA_PKG_OFFLINE=false",
+                # "export JULIA_PKG_OFFLINE=false",
                 ""
             ])
 
@@ -329,11 +427,52 @@ class JuliaPackage(ExtensionEasyBlock):
         if not self.src:
             errmsg = "No source found for Julia package %s, required for installation. (src: %s)"
             raise EasyBuildError(errmsg, self.name, self.src)
+
+        if self.cfg['is_test_dependency']:
+            self.log.info("Package %s is only needed for testing, skipping installation", self.name)
+            return
+
         ExtensionEasyBlock.install_extension(self, unpack_src=True)
 
-        self.prepare_julia_env()
-        self.install_pkg()
-        self._test_step()
+        if not self.cfg['is_main_package']:
+            self.log.info("Package %s is not the main package of the installation, skipping installation", self.name)
+
+            change_dir(self.master.start_dir)
+            package_dir = os.path.join(self.installdir, 'packages', self.name)
+            move_file(self.ext_dir, package_dir)
+
+            self.add_to_env_toml()
+        else:
+            self.write_project_toml(self.julia_env_path(base=False), self.env_toml)
+
+            self.prepare_julia_env()
+            self.install_pkg()
+            self._test_step()
+
+    @classmethod
+    def update_toml_data(cls, toml_data, pkg_name, pkg_path):
+        """Update given toml data with new package and return updated data"""
+        if os.path.isdir(pkg_path):
+            pkg_dir = pkg_path
+            pkg_path = os.path.join(pkg_path, 'Project.toml')
+        else:
+            pkg_dir = os.path.dirname(pkg_path)
+
+        if not os.path.isfile(pkg_path):
+            raise EasyBuildError("Project.toml file not found for package %s in path: %s", pkg_name, pkg_dir)
+
+        project_toml = cls.read_project_toml(pkg_path)
+        pkg_uuid = project_toml['uuid']
+
+        toml_data.setdefault('deps', {})[pkg_name] = pkg_uuid
+        toml_data.setdefault('sources', {})[pkg_name] = {'path': pkg_dir}
+
+        return toml_data
+
+    def add_to_env_toml(self):
+        """Add package to environment toml file of the installation"""
+        package_dir = os.path.join(self.installdir, 'packages', self.name)
+        self.update_toml_data(self.env_toml, self.name, package_dir)
 
     def sanity_check_step(self, *args, **kwargs):
         """Custom sanity check for JuliaPackage"""

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -51,7 +51,7 @@ _COMPILECACHE_CHECK = ' | '.join([
     # compilecache_path is not part of the stable API and changes arguments across versions
     # allow internal cache resolution and use debug statemnts to get the path of the loaded cache
     "JULIA_DEBUG=loading julia -e 'using %(ext_name)s' 2>&1 1>/dev/null",
-    "grep 'Loading object cache file .*%(grep_loc)s'"
+    "grep -E 'Loading (object )?cache file .*%(grep_loc)s'"
 ])
 
 EXTS_FILTER_JULIA_PACKAGES = (
@@ -98,6 +98,11 @@ class JuliaPackage(ExtensionEasyBlock):
         extra_vars.update({
             'download_pkg_deps': [
                 False, "Let Julia download and bundle all needed dependencies for this installation", CUSTOM
+            ],
+            'is_test_dependency': [
+                False,
+                "Whether this package is only needed for testing and should not be added to installation environment",
+                CUSTOM
             ],
             'julia_debug': [
                 False,
@@ -339,6 +344,15 @@ class JuliaPackage(ExtensionEasyBlock):
         basedir = basedir or self.installdir
         env = self.julia_env_path(basedir=basedir)
 
+        if len(self.julia_deps) == 0:
+            if len(self.julia_deps_test) > 0:
+                raise EasyBuildError(
+                    "Only test dependencies found for Julia package %s, cannot proceed with installation. "
+                    "Please check that all needed dependencies are properly specified in the easyconfig file.",
+                    self.name
+                )
+            raise EasyBuildError("No Julia packages to install for: %s", self.name)
+
         package_specs = ', '.join(f'PackageSpec(path="{path}")' for path in self.julia_deps.values())
 
         julia_pkg_cmd = [
@@ -369,7 +383,6 @@ class JuliaPackage(ExtensionEasyBlock):
         cmd = "; ".join([
             'using Pkg',
             f'Pkg.activate("{environment}")',
-            # 'Pkg.status(; mode=PKGMODE_MANIFEST)',
             'for (_, pkg) in Pkg.dependencies()',
             'println("$(pkg.source)")',
             'end'
@@ -454,9 +467,17 @@ class JuliaPackage(ExtensionEasyBlock):
 
     def install_source(self):
         """Add the Julia package source files in the installation directory."""
-        package_dir = os.path.join(self.installdir, 'packages', self.name)
+        if self.cfg['is_test_dependency']:
+            self.log.debug(
+                f"Package {self.name} is only needed for testing, installing sources in {self.tmp_test_dir}"
+            )
+            trace_msg("Installing as a test dependency...")
+            package_dir = os.path.join(self.tmp_test_dir, 'packages', self.name)
+        else:
+            package_dir = os.path.join(self.installdir, 'packages', self.name)
+
         move_file(self.start_dir, package_dir)
-        self.add_package(package_dir)
+        self.add_package(package_dir, test_only=self.cfg['is_test_dependency'])
 
     def _install_step(self, basedir=None):
         """Install step commons between single-package and extensions based installs."""
@@ -487,11 +508,15 @@ class JuliaPackage(ExtensionEasyBlock):
 
     def sanity_check_step(self, *args, **kwargs):
         """Custom sanity check for JuliaPackage"""
+        if self.cfg['is_test_dependency']:
+            self.log.debug(f"Package {self.name} is only used for testing, skipping sanity check")
+            return (True, "Test dependency, skipping sanity check")
+
         pkg_dir = os.path.join('packages', self.name)
 
         custom_commands = []
-
         # Check that the compile cache of the dependencies can still be loaded and is coming from the expected package
+
         if not self.is_extension:
             for dep, root in self.pkg_deps:
                 # root_comp = os.path.join(root, 'compiled')
@@ -529,3 +554,10 @@ class JuliaPackage(ExtensionEasyBlock):
         )
 
         return mod
+
+    def make_extension_list(self):
+        """Generate list of extensions while filtering out test dependencies."""
+        exts = super().make_extension_list()
+        test_dep_names = self.julia_deps_test.keys() - self.julia_deps.keys()
+
+        return list(filter(lambda ext: ext[0] not in test_dep_names, exts))

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -560,7 +560,7 @@ class JuliaPackage(ExtensionEasyBlock):
         custom_commands = []
         # Check that the compile cache of the dependencies can still be loaded and is coming from the expected package
         if not self.is_extension and cc_check:
-            for dep, root in self.pkg_deps:
+            for dep, _ in self.pkg_deps:
                 # root_comp = os.path.join(root, 'compiled')
                 custom_commands.append(
                     # _COMPILECACHE_CHECK % {'ext_name': dep, 'grep_loc': f'Loading object cache file .*{root_comp}'}

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -45,6 +45,8 @@ from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.utilities import trace_msg
 from easybuild.tools import tomllib
 
+from easybuild.easyblocks.j.julia import EB_JULIA_DEPOT_PATH_VAR, EB_JULIA_LOAD_PATH_VAR
+
 _COMPILECACHE_CHECK = ' | '.join([
     "julia -E 'Base.compilecache_path(Base.identify_package(\"%(ext_name)s\"))'",
     "grep '%(grep_loc)s'"
@@ -58,33 +60,6 @@ EXTS_FILTER_JULIA_PACKAGES = (
     ""
 )
 USER_DEPOT_PATTERN = re.compile(r"\/\.julia\/?(.*\.toml)*$")
-
-# JULIA_PATHS_SOFT_INIT = {
-#     "Lua": """
-# if ( mode() == "load" ) then
-#     if ( os.getenv("JULIA_DEPOT_PATH") == nil ) then setenv("JULIA_DEPOT_PATH", ":") end
-#     if ( os.getenv("JULIA_LOAD_PATH") == nil ) then setenv("JULIA_LOAD_PATH", ":") end
-# end
-# """,
-#     "Tcl": """
-# if { [ module-info mode load ] } {
-#     if {![info exists env(JULIA_DEPOT_PATH)]} { setenv JULIA_DEPOT_PATH : }
-#     if {![info exists env(JULIA_LOAD_PATH)]} { setenv JULIA_LOAD_PATH : }
-# """,
-# }
-
-JULIA_MODULE_FOOTER = {
-    "Lua": """
-setenv("JULIA_DEPOT_PATH", ":" .. os.getenv("EBJULIA_DEPOT_PATH") )
-setenv("JULIA_LOAD_PATH", os.getenv("EBJULIA_LOAD_PATH") .. ":")
-""",
-    # This needs testing, the module generate seems to work fine, but the loading of the module within EB does not
-    # properly resolve the $::env() and leaves it as a string
-    "Tcl": """
-setenv JULIA_DEPOT_PATH ":$::env(EBJULIA_DEPOT_PATH)"
-setenv JULIA_LOAD_PATH "$::env(EBJULIA_LOAD_PATH):"
-""",
-}
 
 
 class JuliaPackage(ExtensionEasyBlock):
@@ -563,26 +538,11 @@ class JuliaPackage(ExtensionEasyBlock):
         See issue easybuilders/easybuild-easyconfigs#17455
         """
         mod = super().make_module_extra()
-        # if self.module_generator.SYNTAX:
-        #     mod += JULIA_PATHS_SOFT_INIT[self.module_generator.SYNTAX]
-        # mod += self.module_generator.append_paths('JULIA_DEPOT_PATH', [''])
 
-        mod += self.module_generator.prepend_paths('EBJULIA_DEPOT_PATH', [''])
+        mod += self.module_generator.prepend_paths(EB_JULIA_DEPOT_PATH_VAR, [''])
         mod += self.module_generator.prepend_paths(
-            'EBJULIA_LOAD_PATH',
+            EB_JULIA_LOAD_PATH_VAR,
             [self.julia_env_path(absolute=False, base=False)]
         )
 
         return mod
-
-    def make_module_footer(self):
-        """
-        Extend module footer with statements to set up shell completion for Click-based Python tools.
-        """
-        footer = super().make_module_footer()
-
-        if self.module_generator.SYNTAX:
-            extra_footer = JULIA_MODULE_FOOTER[self.module_generator.SYNTAX]
-            footer += '\n' + extra_footer + '\n'
-
-        return footer

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -629,10 +629,6 @@ class JuliaPackage(ExtensionEasyBlock):
         cc_check = LooseVersion(self.julia_version) >= LooseVersion('1.8')
 
         if self.is_extension:
-            exts_filter = []
-            if cc_check:
-                exts_filter.append(_COMPILECACHE_CHECK % {'ext_name': self.name, 'grep_loc': self.name})
-            exts_filter.append("julia -e 'using %(ext_name)s'")
             pkg_dir = os.path.join('packages', self.name)
 
             custom_paths = {

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -413,10 +413,26 @@ class JuliaPackage(ExtensionEasyBlock):
             )
 
             dep_toml = self.read_project_toml(dep_env)
+            conflicts = []
             for section in sections:
                 data = dep_toml.get(section, {})
                 for toml in [self.env_toml, self.env_toml_test]:
-                    toml.setdefault(section, {}).update(data)
+                    sec_dct = toml.setdefault(section, {})
+                    for k,v in data.items():
+                        if k in sec_dct and sec_dct[k] != v:
+                            conflicts.append((k, section, dep_name, sec_dct[k], v))
+                    sec_dct.update(data)
+            if conflicts:
+                error_msg = '\n'.join(
+                    f'- Package "{k}" in section "{section}" `{current_v}` -> `{dep_v}`'
+                    for k, section, _, current_v, dep_v in conflicts
+                )
+                raise EasyBuildError(
+                    "\nConflicts found when merging dependency '%s' into installation environment:\n%s\n"
+                    "Make sure that all dependencies do not specify duplicate packages as extensions, otherwise the "
+                    "compile cache will be broken based on the module load order.",
+                    dep_name, error_msg
+                )
 
     def prepare_step(self, *args, **kwargs):
         """Prepare for Julia package installation."""

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -44,7 +44,18 @@ from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.utilities import trace_msg
 from easybuild.tools import tomllib
 
-EXTS_FILTER_JULIA_PACKAGES = ("julia -e 'using %(ext_name)s'", "")
+_COMPILECACHE_CHECK = ' | '.join([
+    "julia -E 'Base.compilecache_path(Base.identify_package(\"%(ext_name)s\"))'",
+    "grep '%(ext_name)s'"
+])
+
+EXTS_FILTER_JULIA_PACKAGES = (
+    " && ".join([
+        _COMPILECACHE_CHECK,
+        "julia -e 'using %(ext_name)s'",
+    ]),
+    ""
+)
 USER_DEPOT_PATTERN = re.compile(r"\/\.julia\/?(.*\.toml)*$")
 
 JULIA_PATHS_SOFT_INIT = {
@@ -58,7 +69,35 @@ end
 if { [ module-info mode load ] } {
     if {![info exists env(JULIA_DEPOT_PATH)]} { setenv JULIA_DEPOT_PATH : }
     if {![info exists env(JULIA_LOAD_PATH)]} { setenv JULIA_LOAD_PATH : }
+""",
 }
+
+JULIA_MODULE_FOOTER = {
+    "Lua": """
+setenv("JULIA_DEPOT_PATH", ":" .. os.getenv("EBJULIA_DEPOT_PATH") )
+setenv("JULIA_LOAD_PATH", os.getenv("EBJULIA_LOAD_PATH") .. ":")
+""",
+#     "Lua": """
+# if ( mode() == "load" ) then
+#     setenv("JULIA_DEPOT_PATH", ":" .. os.getenv("EBJULIA_DEPOT_PATH") )
+#     setenv("JULIA_LOAD_PATH", os.getenv("EBJULIA_LOAD_PATH") .. ":")
+# end
+# if (mode() == "unload") then
+#     if (os.getenv("JULIA_DEPOT_PATH") == nil) then
+#         setenv("JULIA_DEPOT_PATH", "")
+#     else
+#         setenv("JULIA_DEPOT_PATH", ":" .. os.getenv("EBJULIA_DEPOT_PATH") )
+#         setenv("JULIA_LOAD_PATH", os.getenv("EBJULIA_LOAD_PATH") .. ":")
+#     end
+# end
+# """,
+    "Lua": """
+execute{cmd="export JULIA_DEPOT_PATH=:${EBJULIA_DEPOT_PATH}", modeA={"load", "unload"}}
+execute{cmd="export JULIA_LOAD_PATH=${EBJULIA_LOAD_PATH}:", modeA={"load", "unload"}}
+""",
+    "Tcl": """
+setenv JULIA_DEPOT_PATH [file join $env(:) $env(EBJULIA_DEPOT_PATH)]
+setenv JULIA_LOAD_PATH [file join $env(EBJULIA_LOAD_PATH) :]
 """,
 }
 
@@ -104,6 +143,10 @@ class JuliaPackage(ExtensionEasyBlock):
                 "will take care of installing dependencies.",
                 CUSTOM
             ],
+            'test_online': [
+                False, "Allow online tests that require downloading dependencies. By default, tests are run in offline mode.",
+                CUSTOM
+            ],
         })
         return extra_vars
 
@@ -133,6 +176,7 @@ class JuliaPackage(ExtensionEasyBlock):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._env_toml = {'deps': {}, 'sources': {}}
+        self.julia_deps = []
 
     @property
     def env_toml(self):
@@ -303,7 +347,7 @@ class JuliaPackage(ExtensionEasyBlock):
         sections = ['deps', 'sources']
 
         # add packages found in dependencies to this installation environment
-        to_remove = set()
+        # to_remove = set()
         for dep in self.cfg.dependencies():
             dep_name = dep['name']
             dep_root = get_software_root(dep_name)
@@ -312,27 +356,32 @@ class JuliaPackage(ExtensionEasyBlock):
                 self.log.warning("No environment file found in dependency %s, skipping: %s", dep_name, dep_env)
                 continue
 
-            to_remove.add(dep_name)
-            trace_msg
+            self.julia_deps.append(dep_name)
+            trace_msg(
+                f"Incorporating Julia package dependencies from {dep_name} in installation environment: {dep_env}"
+            )
+
+            # to_remove.add(dep_name)
+            # trace_msg
 
             dep_toml = self.read_project_toml(dep_env)
             for section in sections:
                 self.env_toml.setdefault(section, {}).update(dep_toml.get(section, {}))
 
-        if to_remove:
-            trace_msg(
-                "Removing dependencies from installation environment. "
-                "These dependencies will not appear in the resulting module:"
-            )
-        for dep_type in ['dependencies', 'builddependencies']:
-            to_remove_idx = []
-            ref = self.cfg.get_ref(dep_type)
-            for idx, dep in enumerate(ref):
-                if dep['name'] in to_remove:
-                    trace_msg(f'- {dep}')
-                    to_remove_idx.insert(0, idx)
-            for idx in to_remove_idx:
-                del ref[idx]
+        # if to_remove:
+        #     trace_msg(
+        #         "Removing dependencies from installation environment. "
+        #         "These dependencies will not appear in the resulting module:"
+        #     )
+        # for dep_type in ['dependencies', 'builddependencies']:
+        #     to_remove_idx = []
+        #     ref = self.cfg.get_ref(dep_type)
+        #     for idx, dep in enumerate(ref):
+        #         if dep['name'] in to_remove:
+        #             trace_msg(f'- {dep}')
+        #             to_remove_idx.insert(0, idx)
+        #     for idx in to_remove_idx:
+        #         del ref[idx]
 
         # print("Updated dependencies after removing Julia packages: %s", self.cfg.dependencies())
         # print("Updated dependencies after removing Julia packages: %s", self.cfg.dependencies())
@@ -396,13 +445,18 @@ class JuliaPackage(ExtensionEasyBlock):
 
             depot_path = os.pathsep.join([tmpdir] + depot_path)
 
-            extrapath = " && ".join([
-                f"export JULIA_DEPOT_PATH=\"{depot_path}\"",
-                # Ensure TEST dependencies can be downloaded
-                # The alternative is to install them as normal dependencies of the package
-                # "export JULIA_PKG_OFFLINE=false",
-                ""
-            ])
+            # extrapath = " && ".join([
+            #     f"export JULIA_DEPOT_PATH=\"{depot_path}\"",
+            #     # Ensure TEST dependencies can be downloaded
+            #     # The alternative is to install them as normal dependencies of the package
+            #     # "export JULIA_PKG_OFFLINE=false",
+            #     # ""
+            # ])
+
+            extrapath = f"export JULIA_DEPOT_PATH=\"{depot_path}\""
+            if self.cfg['test_online']:
+                extrapath += " && export JULIA_PKG_OFFLINE=false"
+            extrapath += " && "
 
             cmd = ' '.join([
                 extrapath,
@@ -479,6 +533,16 @@ class JuliaPackage(ExtensionEasyBlock):
 
         pkg_dir = os.path.join('packages', self.name)
 
+        custom_commands = []
+        # Check that the compile cache of the dependencies can still be loaded. The check is only w.r.t the package
+        # name as rebuilding using PkgA and PkgB as dependenices can retrigger a compilation of PkgB in case e.g. it
+        # was a `weakdep` of PkgA with an associated extension
+        for julia_dep in self.julia_deps:
+            custom_commands.append(
+                _COMPILECACHE_CHECK % {'ext_name': julia_dep}
+            )
+        kwargs.setdefault('custom_commands', []).extend(custom_commands)
+
         custom_paths = {
             'files': [],
             'dirs': [pkg_dir],
@@ -498,9 +562,23 @@ class JuliaPackage(ExtensionEasyBlock):
         See issue easybuilders/easybuild-easyconfigs#17455
         """
         mod = super().make_module_extra()
-        if self.module_generator.SYNTAX:
-            mod += JULIA_PATHS_SOFT_INIT[self.module_generator.SYNTAX]
-        mod += self.module_generator.append_paths('JULIA_DEPOT_PATH', [''])
-        mod += self.module_generator.append_paths('JULIA_LOAD_PATH', [self.julia_env_path(absolute=False, base=False)])
+        # if self.module_generator.SYNTAX:
+        #     mod += JULIA_PATHS_SOFT_INIT[self.module_generator.SYNTAX]
+        # mod += self.module_generator.append_paths('JULIA_DEPOT_PATH', [''])
+
+        mod += self.module_generator.prepend_paths('EBJULIA_DEPOT_PATH', [''])
+        mod += self.module_generator.prepend_paths('EBJULIA_LOAD_PATH', [self.julia_env_path(absolute=False, base=False)])
 
         return mod
+
+    def make_module_footer(self):
+        """
+        Extend module footer with statements to set up shell completion for Click-based Python tools.
+        """
+        footer = super().make_module_footer()
+
+        if self.module_generator.SYNTAX:
+            extra_footer = JULIA_MODULE_FOOTER[self.module_generator.SYNTAX]
+            footer += '\n' + extra_footer + '\n'
+
+        return footer

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -626,37 +626,45 @@ class JuliaPackage(ExtensionEasyBlock):
             self.log.debug(f"Package {self.name} is only used for testing, skipping sanity check")
             return (True, "Test dependency, skipping sanity check")
 
-        pkg_dir = os.path.join('packages', self.name)
-
-        ext_filters = ["julia -e 'using %(ext_name)s'"]
-
+        exts_filter = ["julia -e 'using %(ext_name)s'"]
         cc_check = False
         if LooseVersion(self.julia_version) >= LooseVersion('1.8'):
             cc_check = True
-            ext_filters.insert(
-                0,
-                _COMPILECACHE_CHECK % {'ext_name': self.name, 'grep_loc': self.name}
-            )
+            exts_filter.insert(0, _COMPILECACHE_CHECK % {'ext_name': self.name, 'grep_loc': self.name})
 
-        custom_commands = []
-        # Check that the compile cache of the dependencies can still be loaded and is coming from the expected package
-        if not self.is_extension and cc_check:
-            for dep, _ in self.pkg_deps:
-                # root_comp = os.path.join(root, 'compiled')
-                custom_commands.append(
-                    # _COMPILECACHE_CHECK % {'ext_name': dep, 'grep_loc': f'Loading object cache file .*{root_comp}'}
-                    _COMPILECACHE_CHECK % {'ext_name': dep, 'grep_loc': dep}
+        if self.is_extension:
+            pkg_dir = os.path.join('packages', self.name)
 
-                )
-        kwargs.setdefault('custom_commands', []).extend(custom_commands)
+            custom_commands = []
+            # Check that the compile cache of the dependencies can still be loaded and is coming from the expected package
+            if not self.is_extension and cc_check:
+                for dep, _ in self.pkg_deps:
+                    # root_comp = os.path.join(root, 'compiled')
+                    custom_commands.append(
+                        # _COMPILECACHE_CHECK % {'ext_name': dep, 'grep_loc': f'Loading object cache file .*{root_comp}'}
+                        _COMPILECACHE_CHECK % {'ext_name': dep, 'grep_loc': dep}
 
-        custom_paths = {
-            'files': [],
-            'dirs': [pkg_dir],
-        }
+                    )
+            kwargs.setdefault('custom_commands', []).extend(custom_commands)
+
+            custom_paths = {
+                'files': [],
+                'dirs': [pkg_dir],
+            }
+
+            exts_filter = " && ".join(exts_filter)
+            exts_filter = (exts_filter, "")
+
+            self.cfg['exts_filter'] = exts_filter
+        else:
+            custom_paths = {
+                'files': [],
+                'dirs': ['packages', 'environments'],
+            }
+
         kwargs.update({'custom_paths': custom_paths})
 
-        return ExtensionEasyBlock.sanity_check_step(self, (" && ".join(ext_filters), ""), *args, **kwargs)
+        return super().sanity_check_step(*args, **kwargs)
 
     def make_module_extra(self, *args, **kwargs):
         """

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -154,6 +154,7 @@ class JuliaPackage(ExtensionEasyBlock):
         self._julia_deps = {}
         self._julia_deps_test = {}
         self._julia_version = None
+        self._pkg_deps_included = False
         self._pkg_deps = []
         self._pkgs_to_test_online = []
         self._pkgs_to_test_offline = []
@@ -444,8 +445,16 @@ class JuliaPackage(ExtensionEasyBlock):
 
         return list(deps)
 
-    def include_pkg_dependencies(self):
-        """Add to installation environment all Julia packages already present in its dependencies"""
+    def include_pkg_dependencies(self, add_subdeps: bool = True):
+        """Add to installation environment all Julia packages already present in its dependencies
+
+        :param add_subdeps: whether to also add sub-dependencies to the installation environment. Defaults to True,
+          for actual installation. Should be set to False when used for `--sanity-check-only` or similar modes that
+          skip the installation
+        """
+        if self._pkg_deps_included:
+            return
+        self._pkg_deps_included = True
         build_only_deps = self.cfg.dependencies(build_only=True)
         # add packages found in dependencies to this installation environment
         for dep in self.cfg.dependencies():
@@ -467,8 +476,9 @@ class JuliaPackage(ExtensionEasyBlock):
                     f"Incorporating Julia package in INSTALL environment {dep_name}: {dep_env}"
                 )
 
-            for pkg_path in self._deps_from_project(dep_env):
-                self.add_package(pkg_path, test_only=test_only)
+            if add_subdeps:
+                for pkg_path in self._deps_from_project(dep_env):
+                    self.add_package(pkg_path, test_only=test_only)
 
     def make_installdir(self):
         """Create new installation directory and ensure this is done only once"""
@@ -643,6 +653,8 @@ class JuliaPackage(ExtensionEasyBlock):
             exts_filter = " && ".join(exts_filter)
             self.cfg['exts_filter'] = (exts_filter, "")
         else:
+            # Ensure `pkg_deps` is populated also in `--sanity-check-only` or similar modes
+            self.include_pkg_dependencies(add_subdeps=False)
             custom_paths = {
                 'files': [],
                 'dirs': ['packages', 'environments'],

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -186,28 +186,28 @@ class JuliaPackage(ExtensionEasyBlock):
 
     @property
     def julia_deps(self):
-        """List of Julia dependencies found in this installation."""
+        """List of Julia dependencies found in this installation excluding test dependencies."""
         if self.is_extension:
             return self.master.julia_deps
         return self._julia_deps
 
     @property
     def julia_deps_test(self):
-        """List of Julia dependencies found in this installation."""
+        """List of Julia dependencies found in this installation including test dependencies."""
         if self.is_extension:
             return self.master.julia_deps_test
         return self._julia_deps_test
 
     @property
     def pkg_deps(self):
-        """List of Julia dependencies found in this installation."""
+        """List of easybuild runtime dependencies that will need to be sanity-checked."""
         if self.is_extension:
             return self.master.pkg_deps
         return self._pkg_deps
 
     @property
     def pkgs_to_test(self):
-        """List of Julia dependencies to be included in the test environment."""
+        """List extension wiht `runtest` set to true that should be tested."""
         if self.is_extension:
             return self.master.pkgs_to_test
         return self._pkgs_to_test

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -31,6 +31,7 @@ import ast
 import glob
 import os
 import re
+import tempfile
 
 from easybuild.tools import LooseVersion
 
@@ -272,8 +273,47 @@ class JuliaPackage(ExtensionEasyBlock):
         pass
 
     def test_step(self):
-        """No separate (standard) test procedure for JuliaPackage."""
-        pass
+        """
+        Test the built Julia package.
+
+        :param return_output: return output and exit code of test command
+        """
+        testcmd = None
+        if isinstance(self.cfg['runtest'], str):
+            testcmd = self.cfg['runtest']
+
+        if self.cfg['runtest']:
+            if testcmd is None:
+                testcmd = f"julia -e 'using Pkg; Pkg.test(\"{self.name}\")'"
+
+            try:
+                tmpdir = tempfile.mkdtemp()
+            except OSError as err:
+                raise EasyBuildError("Failed to create test install dir: %s", err)
+
+            depot_path = self.get_julia_env("DEPOT_PATH")
+            load_path = self.get_julia_env("LOAD_PATH")
+            self.log.info("Original DEPOT_PATH for testing: %s", os.pathsep.join(depot_path))
+            self.log.info("Original LOAD_PATH for testing: %s", os.pathsep.join(load_path))
+
+            depot_path = os.pathsep.join([tmpdir] + depot_path)
+
+            extrapath = " && ".join([
+                f"export JULIA_DEPOT_PATH=\"{depot_path}\"",
+                # Ensure TEST dependencies can be downloaded
+                # The alternative is to install them as normal dependencies of the package
+                "export JULIA_PKG_OFFLINE=false",
+                ""
+            ])
+
+            cmd = ' '.join([
+                extrapath,
+                self.cfg['pretestopts'],
+                testcmd,
+                self.cfg['testopts'],
+            ])
+
+            run_shell_cmd(cmd)
 
     def install_step(self):
         """Prepare installation environment and install Julia package."""
@@ -293,6 +333,7 @@ class JuliaPackage(ExtensionEasyBlock):
 
         self.prepare_julia_env()
         self.install_pkg()
+        self._test_step()
 
     def sanity_check_step(self, *args, **kwargs):
         """Custom sanity check for JuliaPackage"""

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -39,7 +39,7 @@ from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root, get_software_version
-from easybuild.tools.filetools import copy_dir, mkdir, change_dir, move_file
+from easybuild.tools.filetools import mkdir, move_file
 from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.utilities import trace_msg
 from easybuild.tools import tomllib
@@ -58,46 +58,28 @@ EXTS_FILTER_JULIA_PACKAGES = (
 )
 USER_DEPOT_PATTERN = re.compile(r"\/\.julia\/?(.*\.toml)*$")
 
-JULIA_PATHS_SOFT_INIT = {
-    "Lua": """
-if ( mode() == "load" ) then
-    if ( os.getenv("JULIA_DEPOT_PATH") == nil ) then setenv("JULIA_DEPOT_PATH", ":") end
-    if ( os.getenv("JULIA_LOAD_PATH") == nil ) then setenv("JULIA_LOAD_PATH", ":") end
-end
-""",
-    "Tcl": """
-if { [ module-info mode load ] } {
-    if {![info exists env(JULIA_DEPOT_PATH)]} { setenv JULIA_DEPOT_PATH : }
-    if {![info exists env(JULIA_LOAD_PATH)]} { setenv JULIA_LOAD_PATH : }
-""",
-}
+# JULIA_PATHS_SOFT_INIT = {
+#     "Lua": """
+# if ( mode() == "load" ) then
+#     if ( os.getenv("JULIA_DEPOT_PATH") == nil ) then setenv("JULIA_DEPOT_PATH", ":") end
+#     if ( os.getenv("JULIA_LOAD_PATH") == nil ) then setenv("JULIA_LOAD_PATH", ":") end
+# end
+# """,
+#     "Tcl": """
+# if { [ module-info mode load ] } {
+#     if {![info exists env(JULIA_DEPOT_PATH)]} { setenv JULIA_DEPOT_PATH : }
+#     if {![info exists env(JULIA_LOAD_PATH)]} { setenv JULIA_LOAD_PATH : }
+# """,
+# }
 
 JULIA_MODULE_FOOTER = {
     "Lua": """
 setenv("JULIA_DEPOT_PATH", ":" .. os.getenv("EBJULIA_DEPOT_PATH") )
 setenv("JULIA_LOAD_PATH", os.getenv("EBJULIA_LOAD_PATH") .. ":")
 """,
-#     "Lua": """
-# if ( mode() == "load" ) then
-#     setenv("JULIA_DEPOT_PATH", ":" .. os.getenv("EBJULIA_DEPOT_PATH") )
-#     setenv("JULIA_LOAD_PATH", os.getenv("EBJULIA_LOAD_PATH") .. ":")
-# end
-# if (mode() == "unload") then
-#     if (os.getenv("JULIA_DEPOT_PATH") == nil) then
-#         setenv("JULIA_DEPOT_PATH", "")
-#     else
-#         setenv("JULIA_DEPOT_PATH", ":" .. os.getenv("EBJULIA_DEPOT_PATH") )
-#         setenv("JULIA_LOAD_PATH", os.getenv("EBJULIA_LOAD_PATH") .. ":")
-#     end
-# end
-# """,
-    "Lua": """
-execute{cmd="export JULIA_DEPOT_PATH=:${EBJULIA_DEPOT_PATH}", modeA={"load", "unload"}}
-execute{cmd="export JULIA_LOAD_PATH=${EBJULIA_LOAD_PATH}:", modeA={"load", "unload"}}
-""",
     "Tcl": """
-setenv JULIA_DEPOT_PATH [file join $env(:) $env(EBJULIA_DEPOT_PATH)]
-setenv JULIA_LOAD_PATH [file join $env(EBJULIA_LOAD_PATH) :]
+setenv JULIA_DEPOT_PATH ":$::env(EBJULIA_DEPOT_PATH)"
+setenv JULIA_LOAD_PATH "$::env(EBJULIA_LOAD_PATH):"
 """,
 }
 
@@ -111,17 +93,22 @@ class JuliaPackage(ExtensionEasyBlock):
         - remove paths in user depot '~/.julia' from DEPOT_PATH and LOAD_PATH
         - put installation directory as top DEPOT_PATH, the target depot for installations with Pkg
         - put installation environment as top LOAD_PATH, needed to precompile installed packages
-        - add Julia packages found in dependencies of the easyconfig to installation environment, needed
-          for Pkg to be aware of those packages and not install them again
-        - add newly installed Julia packages to installation environment (automatically done by Pkg)
+        - merge the environment of julia dependencies of this installation to the environment of this installation.
+        - add newly installed Julia packages to installation environment
+        - install all packages (main and deps) in parallel using Pkg.instantiate() command
 
     Julia environment setup on module load:
         User depot and its shared environment for this version of Julia are kept as top paths of DEPOT_PATH and
         LOAD_PATH respectively. This ensures that the user can keep using its own environment after loading
         JuliaPackage modules, installing additional software on its personal depot while still using packages
         provided by the module. Effectively, this translates to:
-        - append installation directory to list of DEPOT_PATH, only really needed to load artifacts (JLL packages)
-        - append installation Project.toml file to list of LOAD_PATH, needed to load packages with `using` command
+        - prepend installation directory to list of EB_JULIA_DEPOT_PATH, only really needed to load JLL artifacts
+        - prepend installation Project.toml file to list of EB_JULIA_LOAD_PATH, needed to load packages with `using`
+        - Generate JULIA_DEPOT_PATH by append the default DEPOT_PATH (:) to EB_JULIA_DEPOT_PATH
+        - Generate JULIA_LOAD_PATH by prepending the default LOAD_PATH (:) to EB_JULIA_LOAD_PATH
+          The prepending here is necessary as the default LOAD_PATH [@, @v#.#, @stdlib] can cause stdlib's packages
+          that have been made upgradable (https://github.com/JuliaLang/julia/issues/50697) to fail matching the cache.
+          See https://github.com/easybuilders/easybuild-easyblocks/issues/4123#issuecomment-4386990190 for more details.
     """
 
     @staticmethod
@@ -135,12 +122,6 @@ class JuliaPackage(ExtensionEasyBlock):
             'is_test_dependency': [
                 False,
                 "Whether this package is only needed for testing and should not be added to installation environment",
-                CUSTOM
-            ],
-            'is_main_package': [
-                False,
-                "Whether this package is the main package of the installation. Only this will be installed and Julia "
-                "will take care of installing dependencies.",
                 CUSTOM
             ],
             'test_online': [
@@ -177,6 +158,23 @@ class JuliaPackage(ExtensionEasyBlock):
         super().__init__(*args, **kwargs)
         self._env_toml = {'deps': {}, 'sources': {}}
         self.julia_deps = []
+        self._julia_version = None
+
+    @property
+    def julia_version(self) -> str:
+        """Needs to get Julia version from dependencies to allow --sanity-check-only to generate the fake module"""
+        if self._julia_version is None:
+            deps = self.cfg.dependencies(runtime_only=True)
+            for dep in deps:
+                if dep['name'] == 'Julia':
+                    self._julia_version = dep['version']
+                    break
+            else:
+                raise EasyBuildError(
+                    "Julia not included as dependency, cannot determine Julia version for installation of: %s",
+                    self.name
+                )
+        return self._julia_version
 
     @property
     def env_toml(self):
@@ -184,6 +182,65 @@ class JuliaPackage(ExtensionEasyBlock):
         if self.is_extension:
             return self.master.env_toml
         return self._env_toml
+
+    @property
+    def is_last_extension(self):
+        """Whether this extension is the last one to be installed in the installation."""
+        if not self.is_extension:
+            return False
+
+        return self.master.ext_instances and self.master.ext_instances[-1] is self
+
+    @staticmethod
+    def write_project_toml(file_path, project_toml):
+        """Write a Project.toml file with the given content to the given path"""
+        with open(file_path, 'w') as env_proj:
+            for section, items in project_toml.items():
+                env_proj.write(f'[{section}]\n')
+                for key, value in items.items():
+                    value = repr(value)
+                    value = value.replace("'", '"')
+                    value = value.replace(': ', ' = ')
+                    env_proj.write(f'{key} = {value}\n')
+                env_proj.write('\n')
+
+    @staticmethod
+    def read_project_toml(file_path):
+        """Read a Project.toml file and return its content as a dict"""
+        with open(file_path, 'rb') as env_proj:
+            project_toml = tomllib.load(env_proj)
+        return project_toml
+
+    @classmethod
+    def update_toml_data(cls, toml_data, pkg_name, pkg_path):
+        """Update given toml data with new package and return updated data"""
+        if os.path.isdir(pkg_path):
+            pkg_dir = pkg_path
+            pkg_path = os.path.join(pkg_path, 'Project.toml')
+        else:
+            pkg_dir = os.path.dirname(pkg_path)
+
+        if not os.path.isfile(pkg_path):
+            raise EasyBuildError("Project.toml file not found for package %s in path: %s", pkg_name, pkg_dir)
+
+        project_toml = cls.read_project_toml(pkg_path)
+        pkg_uuid = project_toml['uuid']
+
+        toml_data.setdefault('deps', {})[pkg_name] = pkg_uuid
+        toml_data.setdefault('sources', {})[pkg_name] = {'path': pkg_dir}
+
+        return toml_data
+
+    def write_env_toml(self, toml_data):
+        """Write environment Project.toml file"""
+        dir_path = self.julia_env_path()
+        mkdir(dir_path, parents=True)
+        self.write_project_toml(self.julia_env_path(base=False), toml_data)
+
+    def add_to_env_toml(self):
+        """Add package to environment toml file of the installation"""
+        package_dir = os.path.join(self.installdir, 'packages', self.name)
+        self.update_toml_data(self.env_toml, self.name, package_dir)
 
     def julia_env_path(self, absolute=True, base=True):
         """
@@ -259,34 +316,20 @@ class JuliaPackage(ExtensionEasyBlock):
         # Enable offline mode
         self.set_pkg_offline()
 
+        # Set the maximum number of concurrent package builds
+        env.setvar('JULIA_NUM_PRECOMPILE_TASKS', str(self.cfg.parallel))
         # Enable automatic precompilation
         env.setvar('JULIA_PKG_PRECOMPILE_AUTO', 'true')
 
-    def install_pkg_source(self, pkg_source, environment, trace=True):
+    def install_pkg(self):
         """Execute Julia.Pkg command to install package from its sources"""
-
         julia_pkg_cmd = [
             'using Pkg',
-            'Pkg.activate("%s")' % environment,
+            'Pkg.activate("%s")' % self.julia_env_path(),
+            # Usage `Pkg.instantiate()` after all sources are in place to let Pkg handle all dependencies.
+            # This has the advantage of letting Pkg deal with the order and parallel installation.
+            'Pkg.instantiate()',
         ]
-
-        if os.path.isdir(os.path.join(pkg_source, '.git')):
-            # sources from git repos can be installed as any remote package
-            self.log.debug('Installing Julia package in normal mode (Pkg.add)')
-
-            julia_pkg_cmd.extend([
-                # install package from local path preserving existing dependencies
-                'Pkg.add(url="%s"; preserve=PRESERVE_ALL)' % pkg_source,
-            ])
-        else:
-            # plain sources have to be installed in develop mode
-            self.log.debug('Installing Julia package in develop mode (Pkg.develop)')
-
-            julia_pkg_cmd.extend([
-                # install package from local path preserving existing dependencies
-                'Pkg.develop(PackageSpec(path="%s"); preserve=PRESERVE_ALL)' % pkg_source,
-                'Pkg.build("%s")' % os.path.basename(pkg_source),
-            ])
 
         julia_pkg_cmd = '; '.join(julia_pkg_cmd)
         cmd = ' '.join([
@@ -298,56 +341,11 @@ class JuliaPackage(ExtensionEasyBlock):
 
         return res.output
 
-    @staticmethod
-    def write_project_toml(file_path, project_toml):
-        """Write a Project.toml file with the given content to the given path"""
-
-        with open(file_path, 'w') as env_proj:
-            for section, items in project_toml.items():
-                env_proj.write(f'[{section}]\n')
-                for key, value in items.items():
-                    value = repr(value)
-                    value = value.replace("'", '"')
-                    value = value.replace(': ', ' = ')
-                    env_proj.write(f'{key} = {value}\n')
-                env_proj.write('\n')
-
-    @staticmethod
-    def read_project_toml(file_path):
-        """Read a Project.toml file and return its content as a dict"""
-
-        with open(file_path, 'rb') as env_proj:
-            project_toml = tomllib.load(env_proj)
-
-        return project_toml
-
-    def write_env_toml(self, toml_data):
-        """Write environment Project.toml file"""
-
-        self.write_project_toml(self.julia_env_path(base=False), toml_data)
-
-
-    # def include_pkg_dependencies(self):
-    #     """Add to installation environment all Julia packages already present in its dependencies"""
-    #     # Location of project environment files in install dir
-    #     mkdir(self.julia_env_path(), parents=True)
-
-    #     # add packages found in dependencies to this installation environment
-    #     for dep in self.cfg.dependencies():
-    #         dep_root = get_software_root(dep['name'])
-    #         for pkg in glob.glob(os.path.join(dep_root, 'packages/*')):
-    #             trace_msg("incorporating Julia package from dependencies: %s" % os.path.basename(pkg))
-    #             self.install_pkg_source(pkg, self.julia_env_path(), trace=False)
-
     def include_pkg_dependencies(self):
         """Add to installation environment all Julia packages already present in its dependencies"""
-        # Location of project environment files in install dir
-        mkdir(self.julia_env_path(), parents=True)
-
         sections = ['deps', 'sources']
 
         # add packages found in dependencies to this installation environment
-        # to_remove = set()
         for dep in self.cfg.dependencies():
             dep_name = dep['name']
             dep_root = get_software_root(dep_name)
@@ -361,46 +359,11 @@ class JuliaPackage(ExtensionEasyBlock):
                 f"Incorporating Julia package dependencies from {dep_name} in installation environment: {dep_env}"
             )
 
-            # to_remove.add(dep_name)
-            # trace_msg
-
             dep_toml = self.read_project_toml(dep_env)
             for section in sections:
                 self.env_toml.setdefault(section, {}).update(dep_toml.get(section, {}))
 
-        # if to_remove:
-        #     trace_msg(
-        #         "Removing dependencies from installation environment. "
-        #         "These dependencies will not appear in the resulting module:"
-        #     )
-        # for dep_type in ['dependencies', 'builddependencies']:
-        #     to_remove_idx = []
-        #     ref = self.cfg.get_ref(dep_type)
-        #     for idx, dep in enumerate(ref):
-        #         if dep['name'] in to_remove:
-        #             trace_msg(f'- {dep}')
-        #             to_remove_idx.insert(0, idx)
-        #     for idx in to_remove_idx:
-        #         del ref[idx]
-
-        # print("Updated dependencies after removing Julia packages: %s", self.cfg.dependencies())
-        # print("Updated dependencies after removing Julia packages: %s", self.cfg.dependencies())
-
         self.write_env_toml(self.env_toml)
-
-
-    def install_pkg(self):
-        """Install Julia package"""
-
-        # determine source type of current installation
-        if os.path.isdir(os.path.join(self.start_dir, '.git')):
-            pkg_source = self.start_dir
-        else:
-            # copy non-git sources to install directory
-            pkg_source = os.path.join(self.installdir, 'packages', self.name)
-            copy_dir(self.start_dir, pkg_source)
-
-        return self.install_pkg_source(pkg_source, self.julia_env_path())
 
     def prepare_step(self, *args, **kwargs):
         """Prepare for Julia package installation."""
@@ -440,23 +403,14 @@ class JuliaPackage(ExtensionEasyBlock):
             load_path = self.get_julia_env("LOAD_PATH")
             self.log.info("Original DEPOT_PATH for testing: %s", os.pathsep.join(depot_path))
             self.log.info("Original LOAD_PATH for testing: %s", os.pathsep.join(load_path))
-            # print("Testing with DEPOT_PATH: %s", os.pathsep.join(depot_path))
-            # print("Testing with LOAD_PATH: %s", os.pathsep.join(load_path))
 
             depot_path = os.pathsep.join([tmpdir] + depot_path)
 
-            # extrapath = " && ".join([
-            #     f"export JULIA_DEPOT_PATH=\"{depot_path}\"",
-            #     # Ensure TEST dependencies can be downloaded
-            #     # The alternative is to install them as normal dependencies of the package
-            #     # "export JULIA_PKG_OFFLINE=false",
-            #     # ""
-            # ])
-
-            extrapath = f"export JULIA_DEPOT_PATH=\"{depot_path}\""
-            if self.cfg['test_online']:
-                extrapath += " && export JULIA_PKG_OFFLINE=false"
-            extrapath += " && "
+            extrapath = " && ".join([
+                f"export JULIA_DEPOT_PATH=\"{depot_path}\"",
+                f"export JULIA_PKG_OFFLINE={'false' if self.cfg['test_online'] else 'true'}",
+                ""
+            ])
 
             cmd = ' '.join([
                 extrapath,
@@ -467,13 +421,24 @@ class JuliaPackage(ExtensionEasyBlock):
 
             run_shell_cmd(cmd)
 
+    def install_source(self):
+        """Add the Julia package source files in the installation directory."""
+        package_dir = os.path.join(self.installdir, 'packages', self.name)
+        move_file(self.ext_dir if self.is_extension else self.start_dir, package_dir)
+
+        # Add package to the main environment Project.toml file
+        self.add_to_env_toml()
+
+    def _install_step(self):
+        """Install step commons between single-package and extensions based installs."""
+        self.write_env_toml(self.env_toml)
+        self.prepare_julia_env()
+        return self.install_pkg()
+
     def install_step(self):
         """Prepare installation environment and install Julia package."""
-
-        self.prepare_julia_env()
-        self.include_pkg_dependencies()
-
-        return self.install_pkg()
+        self.install_source()
+        return self._install_step()
 
     def install_extension(self):
         """Install Julia package as an extension."""
@@ -486,47 +451,13 @@ class JuliaPackage(ExtensionEasyBlock):
             self.log.info("Package %s is only needed for testing, skipping installation", self.name)
             return
 
+        # Unpack source into install directory and add package to the main environment Project.toml file
         ExtensionEasyBlock.install_extension(self, unpack_src=True)
+        self.install_source()
 
-        if not self.cfg['is_main_package']:
-            self.log.info("Package %s is not the main package of the installation, skipping installation", self.name)
-
-            change_dir(self.master.start_dir)
-            package_dir = os.path.join(self.installdir, 'packages', self.name)
-            move_file(self.ext_dir, package_dir)
-
-            self.add_to_env_toml()
-        else:
-            self.write_project_toml(self.julia_env_path(base=False), self.env_toml)
-
-            self.prepare_julia_env()
-            self.install_pkg()
-            self._test_step()
-
-    @classmethod
-    def update_toml_data(cls, toml_data, pkg_name, pkg_path):
-        """Update given toml data with new package and return updated data"""
-        if os.path.isdir(pkg_path):
-            pkg_dir = pkg_path
-            pkg_path = os.path.join(pkg_path, 'Project.toml')
-        else:
-            pkg_dir = os.path.dirname(pkg_path)
-
-        if not os.path.isfile(pkg_path):
-            raise EasyBuildError("Project.toml file not found for package %s in path: %s", pkg_name, pkg_dir)
-
-        project_toml = cls.read_project_toml(pkg_path)
-        pkg_uuid = project_toml['uuid']
-
-        toml_data.setdefault('deps', {})[pkg_name] = pkg_uuid
-        toml_data.setdefault('sources', {})[pkg_name] = {'path': pkg_dir}
-
-        return toml_data
-
-    def add_to_env_toml(self):
-        """Add package to environment toml file of the installation"""
-        package_dir = os.path.join(self.installdir, 'packages', self.name)
-        self.update_toml_data(self.env_toml, self.name, package_dir)
+        if self.is_last_extension:
+            self._install_step()
+            self.test_step()
 
     def sanity_check_step(self, *args, **kwargs):
         """Custom sanity check for JuliaPackage"""
@@ -538,6 +469,7 @@ class JuliaPackage(ExtensionEasyBlock):
         # name as rebuilding using PkgA and PkgB as dependenices can retrigger a compilation of PkgB in case e.g. it
         # was a `weakdep` of PkgA with an associated extension
         for julia_dep in self.julia_deps:
+            trace_msg(f"Checking that compile cache of dependency {julia_dep} can still be loaded")
             custom_commands.append(
                 _COMPILECACHE_CHECK % {'ext_name': julia_dep}
             )

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -626,13 +626,13 @@ class JuliaPackage(ExtensionEasyBlock):
             self.log.debug(f"Package {self.name} is only used for testing, skipping sanity check")
             return (True, "Test dependency, skipping sanity check")
 
-        exts_filter = ["julia -e 'using %(ext_name)s'"]
-        cc_check = False
-        if LooseVersion(self.julia_version) >= LooseVersion('1.8'):
-            cc_check = True
-            exts_filter.insert(0, _COMPILECACHE_CHECK % {'ext_name': self.name, 'grep_loc': self.name})
+        cc_check = LooseVersion(self.julia_version) >= LooseVersion('1.8')
 
         if self.is_extension:
+            exts_filter = []
+            if cc_check:
+                exts_filter.append(_COMPILECACHE_CHECK % {'ext_name': self.name, 'grep_loc': self.name})
+            exts_filter.append("julia -e 'using %(ext_name)s'")
             pkg_dir = os.path.join('packages', self.name)
 
             custom_paths = {
@@ -640,10 +640,12 @@ class JuliaPackage(ExtensionEasyBlock):
                 'dirs': [pkg_dir],
             }
 
+            exts_filter = []
+            if cc_check:
+                exts_filter.append(_COMPILECACHE_CHECK % {'ext_name': self.name, 'grep_loc': self.name})
+            exts_filter.append("julia -e 'using %(ext_name)s'")
             exts_filter = " && ".join(exts_filter)
-            exts_filter = (exts_filter, "")
-
-            self.cfg['exts_filter'] = exts_filter
+            self.cfg['exts_filter'] = (exts_filter, "")
         else:
             custom_paths = {
                 'files': [],

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -47,12 +47,12 @@ from easybuild.tools import tomllib
 
 _COMPILECACHE_CHECK = ' | '.join([
     "julia -E 'Base.compilecache_path(Base.identify_package(\"%(ext_name)s\"))'",
-    "grep '%(ext_name)s'"
+    "grep '%(grep_loc)s'"
 ])
 
 EXTS_FILTER_JULIA_PACKAGES = (
     " && ".join([
-        _COMPILECACHE_CHECK,
+        _COMPILECACHE_CHECK.replace('%(grep_loc)s', '%(ext_name)s'),
         "julia -e 'using %(ext_name)s'",
     ]),
     ""
@@ -407,7 +407,7 @@ class JuliaPackage(ExtensionEasyBlock):
                 self.log.warning("No environment file found in dependency %s, skipping: %s", dep_name, dep_env)
                 continue
 
-            self.julia_deps.append(dep_name)
+            self.julia_deps.append((dep_name, dep_root))
             trace_msg(
                 f"Incorporating Julia package dependencies from {dep_name} in installation environment: {dep_env}"
             )
@@ -418,9 +418,9 @@ class JuliaPackage(ExtensionEasyBlock):
                 data = dep_toml.get(section, {})
                 for toml in [self.env_toml, self.env_toml_test]:
                     sec_dct = toml.setdefault(section, {})
-                    for k,v in data.items():
-                        if k in sec_dct and sec_dct[k] != v:
-                            conflicts.append((k, section, dep_name, sec_dct[k], v))
+                    for key, val in data.items():
+                        if key in sec_dct and sec_dct[key] != val:
+                            conflicts.append((key, section, dep_name, sec_dct[key], val))
                     sec_dct.update(data)
             if conflicts:
                 error_msg = '\n'.join(
@@ -537,12 +537,10 @@ class JuliaPackage(ExtensionEasyBlock):
         pkg_dir = os.path.join('packages', self.name)
 
         custom_commands = []
-        # Check that the compile cache of the dependencies can still be loaded. The check is only w.r.t the package
-        # name as rebuilding using PkgA and PkgB as dependenices can retrigger a compilation of PkgB in case e.g. it
-        # was a `weakdep` of PkgA with an associated extension
-        for julia_dep in self.julia_deps:
+        # Check that the compile cache of the dependencies can still be loaded and is coming from the expected package
+        for dep, root in self.julia_deps:
             custom_commands.append(
-                _COMPILECACHE_CHECK % {'ext_name': julia_dep}
+                _COMPILECACHE_CHECK % {'ext_name': dep, 'grep_loc': root}
             )
         kwargs.setdefault('custom_commands', []).extend(custom_commands)
 

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -636,12 +636,11 @@ class JuliaPackage(ExtensionEasyBlock):
             pkg_dir = os.path.join('packages', self.name)
 
             custom_commands = []
-            # Check that the compile cache of the dependencies can still be loaded and is coming from the expected package
+            # Check that the compile cache of the dependencies can still be loaded
             if not self.is_extension and cc_check:
                 for dep, _ in self.pkg_deps:
                     # root_comp = os.path.join(root, 'compiled')
                     custom_commands.append(
-                        # _COMPILECACHE_CHECK % {'ext_name': dep, 'grep_loc': f'Loading object cache file .*{root_comp}'}
                         _COMPILECACHE_CHECK % {'ext_name': dep, 'grep_loc': dep}
 
                     )

--- a/easybuild/easyblocks/generic/juliapackage.py
+++ b/easybuild/easyblocks/generic/juliapackage.py
@@ -149,7 +149,7 @@ class JuliaPackage(ExtensionEasyBlock):
         self._julia_deps_test = {}
         self._julia_version = None
         self._pkg_deps = []
-        self._pkg_to_test = []
+        self._pkgs_to_test = []
         self._tmp_test_dir = None
         self._installdir_created = False
 
@@ -206,11 +206,11 @@ class JuliaPackage(ExtensionEasyBlock):
         return self._pkg_deps
 
     @property
-    def pkg_to_test(self):
+    def pkgs_to_test(self):
         """List of Julia dependencies to be included in the test environment."""
         if self.is_extension:
-            return self.master.pkg_to_test
-        return self._pkg_to_test
+            return self.master.pkgs_to_test
+        return self._pkgs_to_test
 
     @property
     def tmp_test_dir(self):
@@ -474,16 +474,16 @@ class JuliaPackage(ExtensionEasyBlock):
         :param return_output: return output and exit code of test command
         """
         if self.cfg['runtest']:
-            self.pkg_to_test.append(self.name)
+            self.pkgs_to_test.append(self.name)
 
         if not self.is_last_extension:
             trace_msg("Delegating testing to last extension")
             return
 
-        if self.pkg_to_test:
+        if self.pkgs_to_test:
             env = self.julia_env_path(basedir=self.tmp_test_dir)
             pkg_specs = ', '.join(f'PackageSpec(path="{path}")' for path in self.julia_deps_test.values())
-            pkg_test = ', '.join(f'"{pkg}"' for pkg in self.pkg_to_test)
+            pkg_test = ', '.join(f'"{pkg}"' for pkg in self.pkgs_to_test)
             testcmd = [
                 'using Pkg',
                 f'Pkg.activate("{env}")',

--- a/easybuild/easyblocks/j/julia.py
+++ b/easybuild/easyblocks/j/julia.py
@@ -1,0 +1,90 @@
+##
+# Copyright 2022-2026 Vrije Universiteit Brussel
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+Custom EasyBlock for installing Julia binaries with an extra startup script to give special treatment to.
+
+@author: Davide Grassano (CECAM)
+"""
+import os
+
+from easybuild.tools.filetools import write_file
+from easybuild.tools.systemtools import get_shared_lib_ext
+from easybuild.easyblocks.generic.tarball import Tarball
+
+EB_JULIA_DEPOT_PATH_VAR = "EBJULIA_DEPOT_PATH"
+EB_JULIA_LOAD_PATH_VAR = "EBJULIA_LOAD_PATH"
+
+STARTUP_CONTENT = rf"""
+# Read EB environment variables
+function get_env_list(name)
+    haskey(ENV, name) ? split(ENV[name], ':') : []
+end
+
+EB_LOAD_PATH = get_env_list("{EB_JULIA_LOAD_PATH_VAR}")
+EB_DEPOT_PATH = get_env_list("{EB_JULIA_DEPOT_PATH_VAR}")
+
+# Append EB_LOAD_PATH to the default LOAD_PATH
+if !isempty(EB_LOAD_PATH)
+    pushfirst!(LOAD_PATH, EB_LOAD_PATH...)
+end
+# Prepend EB_DEPOT_PATH to the default DEPOT_PATH
+if !isempty(EB_DEPOT_PATH)
+    push!(DEPOT_PATH, EB_DEPOT_PATH...)
+end
+"""
+
+
+class EB_Julia(Tarball):
+    """Add custom startup script and sanity checks to Julia installations."""
+
+    def sanity_check_step(self):
+        """Custom sanity check for Julia."""
+
+        shlib_ext = get_shared_lib_ext()
+
+        custom_files = [
+            'bin/julia', 'include/julia/julia.h', f'lib/libjulia.{shlib_ext}', 'etc/julia/startup.jl',
+        ]
+        custom_dirs = ['bin', 'etc', 'include', 'lib', 'share']
+        custom_commands = [
+            "julia --help",
+            "julia --version",
+            "julia -E '1+2 == 3' | grep true",
+        ]
+        custom_paths = {
+            'files': custom_files,
+            'dirs': custom_dirs,
+        }
+
+        super().sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
+
+    def install_step(self, *args, **kwargs):
+        """Install procedure for Julia."""
+        super().install_step(*args, **kwargs)
+
+        startup_script = os.path.join(self.installdir, 'etc', 'julia', 'startup.jl')
+        os.makedirs(os.path.dirname(startup_script), exist_ok=True)
+
+        write_file(startup_script, STARTUP_CONTENT)

--- a/easybuild/easyblocks/j/julia.py
+++ b/easybuild/easyblocks/j/julia.py
@@ -56,7 +56,7 @@ if !isempty(EB_DEPOT_PATH)
 end
 """
 
-WRAPPER_CONTENT = rf"""#!/bin/sh
+WRAPPER_CONTENT = r"""#!/bin/sh
 LD_LIBRARY_PATH="$EBROOTJULIA/lib:$EBROOTJULIA/lib/julia:$LD_LIBRARY_PATH" julia.bin "$@"
 """
 

--- a/easybuild/easyblocks/j/julia.py
+++ b/easybuild/easyblocks/j/julia.py
@@ -28,8 +28,9 @@ Custom EasyBlock for installing Julia binaries with an extra startup script to g
 @author: Davide Grassano (CECAM)
 """
 import os
+import stat
 
-from easybuild.tools.filetools import write_file
+from easybuild.tools.filetools import write_file, move_file, adjust_permissions
 from easybuild.tools.systemtools import get_shared_lib_ext
 from easybuild.easyblocks.generic.tarball import Tarball
 
@@ -55,6 +56,10 @@ if !isempty(EB_DEPOT_PATH)
 end
 """
 
+WRAPPER_CONTENT = rf"""#!/bin/sh
+LD_LIBRARY_PATH="$EBROOTJULIA/lib:$EBROOTJULIA/lib/julia:$LD_LIBRARY_PATH" julia.bin "$@"
+"""
+
 
 class EB_Julia(Tarball):
     """Add custom startup script and sanity checks to Julia installations."""
@@ -65,7 +70,8 @@ class EB_Julia(Tarball):
         shlib_ext = get_shared_lib_ext()
 
         custom_files = [
-            'bin/julia', 'include/julia/julia.h', f'lib/libjulia.{shlib_ext}', 'etc/julia/startup.jl',
+            'bin/julia', 'bin/julia.bin',
+            'include/julia/julia.h', f'lib/libjulia.{shlib_ext}', 'etc/julia/startup.jl',
         ]
         custom_dirs = ['bin', 'etc', 'include', 'lib', 'share']
         custom_commands = [
@@ -88,3 +94,10 @@ class EB_Julia(Tarball):
         os.makedirs(os.path.dirname(startup_script), exist_ok=True)
 
         write_file(startup_script, STARTUP_CONTENT)
+        julia_bin = os.path.join(self.installdir, 'bin', 'julia')
+        julia_bin_new = os.path.join(self.installdir, 'bin', 'julia.bin')
+
+        # install wrapper with linking safeguards for Julia libraries
+        move_file(julia_bin, julia_bin_new)
+        write_file(julia_bin, WRAPPER_CONTENT)
+        adjust_permissions(julia_bin, stat.S_IRUSR | stat.S_IXUSR)

--- a/test/easyblocks/module.py
+++ b/test/easyblocks/module.py
@@ -451,7 +451,7 @@ def suite(loader):
         write_file(os.path.join(TMPDIR, 'modules', 'all', prgenv, '1.2.3'), "#%Module")
 
     # add empty module files for dependencies that are required for testing easyblocks
-    for dep_mod_name in ('foo/1.2.3.4.5', 'PyTorch/1.12.1'):
+    for dep_mod_name in ('foo/1.2.3.4.5', 'PyTorch/1.12.1', "Julia/1.6.7"):
         write_file(os.path.join(TMPDIR, 'modules', 'all', dep_mod_name), "#%Module")
 
     for easyblock in easyblocks:
@@ -505,6 +505,10 @@ def suite(loader):
         elif eb_fn in ['python.py', 'tkinter.py']:
             # custom easyblock for Python (ensurepip) requires version >= 3.4.0
             innertest = make_inner_test(easyblock, name=eb_fn.replace('_', '-')[:-3], version='3.4.0')
+        elif eb_fn in ['juliapackage.py', 'juliabundle.py']:
+            # Building a Julia package/bundle requires Julia as a dependency
+            extra_txt = 'dependencies = [("Julia", "1.6.7")]'
+            innertest = make_inner_test(easyblock, name='julia-stuff', extra_txt=extra_txt)
         elif eb_fn == 'torchvision.py':
             # torchvision easyblock requires that PyTorch is listed as dependency
             extra_txt = "dependencies = [('PyTorch', '1.12.1')]"


### PR DESCRIPTION
## Summary of changes

- Adds compile_cache check to sanity checks to ensure that the compiled version of the package can actually be found/re-used
- Allow specifying test-only dependencies with the `is_test_dependency` EC param
- Allow turning on Julia's verbose output with the `julia_debug` EC param
- Allow reusing packages from a dependency (fix #4123)
  - The environments of the dependencies are merged into the one of the package being installed
- Use `Pkg.instantiate()` to install all extensions instead of installing them one by one with `Pkg.develop`
  - Remove need for deps to be ordered in the EC files
  - Makes use of Julia's capability to install extension in parallel (still respecting the `max_parallel` option)
- Allows running package tests in a dedicated step (setting `runtest` to True for every extension that needs testing)
   - The test are both skippable (`--skip-test-step`) and ignorable (`--ignore-test-failure`)
   - Tests are ran in offline mode by default unless `test_online` is set to true
   - If both offline and online test are to be performed, the offline ones go first as they should not modify the test environment that we are setting up
- Switch to using an EB specific environment variable to keep track of the LOAD/DEPOT PATHS and use them to correctly set them for Julia in a site-specific startup script

## Maybe TODO

- [X] Improve Lua/Tcl syntax in module footer
- [X] Modify Julia itself similar to https://github.com/easybuilders/JSC/blob/6285a066b6debed28211730afb8ffc5eb2430c2f/Custom_EasyBlocks/julia.py to allow the interpreter to pick up the DEPOT/LOAD path directly from the new env variables
- [X] Test how reusable deps really are. The original approach aimed at copying all packages from the deps into the current package and re-install everything. Here we actually re-use them but the results seems to be dependent on the load order (see discussion in #4123) so if the dep order is switched w.r.t. the one at build time slow re-compilation might happen
  - PoC in https://github.com/easybuilders/easybuild-easyconfigs/pull/26214 at-least on package used at the same time should work, more investigation might be needed on loading multiple packages that re-compiles the same deps at the same time

## Notes

This PRs includes the changes from:

- #4122 
- #4124 

Fixes:

- #4123

### AI usage

- GitHub CoPilot FIM auto-completion is active in my IDE and has been used in this PR to sporadically auto-complete code/docstrings