### PR TITLE
disable `rust.lld` for Rust >= 1.90, use system linker instead

### DIFF
--- a/easybuild/easyblocks/r/rust.py
+++ b/easybuild/easyblocks/r/rust.py
@@ -114,6 +114,11 @@ class EB_Rust(ConfigureMake):
         # old llvm builds from CI get deleted after a certain time
         self.cfg.update('configopts', "--set=llvm.download-ci-llvm=false")
 
+        # Use system linker to avoid rust.ldd to bypass our rpath wrappers
+        # See https://github.com/easybuilders/easybuild-easyconfigs/issues/26232 for more details
+        if build_option('rpath') and LooseVersion(self.version) >= '1.9':
+            self.cfg.update('configopts', "--disable-lld")
+
         # set channel to "stable", otherwise Rust will be built with nightly channel,
         # see also https://rust-lang.github.io/rustup/concepts/channels.html;
         # for recent version of Rust, this would also result in using rust-lld instead of the default linker,

--- a/easybuild/easyblocks/r/rust.py
+++ b/easybuild/easyblocks/r/rust.py
@@ -116,7 +116,7 @@ class EB_Rust(ConfigureMake):
 
         # Use system linker to avoid rust.ldd to bypass our rpath wrappers
         # See https://github.com/easybuilders/easybuild-easyconfigs/issues/26232 for more details
-        if build_option('rpath') and LooseVersion(self.version) >= '1.9':
+        if build_option('rpath') and LooseVersion(self.version) >= '1.90':
             self.cfg.update('configopts', "--disable-lld")
 
         # set channel to "stable", otherwise Rust will be built with nightly channel,


### PR DESCRIPTION
Ensure `rust.lld` is not used by default with RPATH-ing on to avoid it bypassing Easybuild's wrappers.

An alternative solution would be to ship also wrappers that encapsulate `rust.lld`

- check whether normal LLVM wrappers would be enough (as simple LDD might be called under the hood) or if we need a dedicated one

Fixes
- Fix https://github.com/easybuilders/easybuild-easyconfigs/issues/26232