### PR TITLE
Add extra easyconfig parameter `object_storage_ignore_dirs` to generic `Dataset` easyblock

### DIFF
--- a/easybuild/easyblocks/generic/dataset.py
+++ b/easybuild/easyblocks/generic/dataset.py
@@ -48,7 +48,8 @@ class Dataset(Binary):
         extra_vars.update({
             'extract_sources': [True, "Whether or not to extract data sources", CUSTOM],
             'data_install_path': [None, "Custom installation path for datasets", CUSTOM],
-            'cleanup_data_sources': [False, "Whether or not to delete the data sources after installation", CUSTOM]
+            'cleanup_data_sources': [False, "Whether or not to delete the data sources after installation", CUSTOM],
+            'object_storage_ignore_dirs': [None, "Directories to be excluded from object storage", CUSTOM],
         })
         return extra_vars
 
@@ -78,7 +79,7 @@ class Dataset(Binary):
         change_dir(self.installdir)
         object_storage = os.path.normpath(os.path.join(os.getcwd(), os.pardir, 'object_storage'))
 
-        datafiles = create_index(os.curdir)
+        datafiles = create_index(os.curdir, ignore_dirs=self.cfg['object_storage_ignore_dirs'])
 
         for datafile in datafiles:
             cks = compute_checksum(datafile, checksum_type='sha256')

--- a/easybuild/easyblocks/generic/dataset.py
+++ b/easybuild/easyblocks/generic/dataset.py
@@ -49,7 +49,7 @@ class Dataset(Binary):
             'extract_sources': [True, "Whether or not to extract data sources", CUSTOM],
             'data_install_path': [None, "Custom installation path for datasets", CUSTOM],
             'cleanup_data_sources': [False, "Whether or not to delete the data sources after installation", CUSTOM],
-            'object_storage_ignore_dirs': [None, "Directories to be excluded from object storage", CUSTOM],
+            'object_storage_ignore_dirs': [[], "List of directories to be excluded from object storage", CUSTOM],
         })
         return extra_vars
 
@@ -79,10 +79,15 @@ class Dataset(Binary):
         change_dir(self.installdir)
         object_storage = os.path.normpath(os.path.join(os.getcwd(), os.pardir, 'object_storage'))
 
-        if self.cfg['object_storage_ignore_dirs'] and self.installdir in self.cfg['object_storage_ignore_dirs']:
+        ignore_dirs = self.cfg['object_storage_ignore_dirs']
+        if not isinstance(ignore_dirs, (list, tuple)):
+            raise EasyBuildError("Incorrect value type for object_storage_ignore_dirs, should be list or tuple: ",
+                                 ignore_dirs)
+
+        if ignore_dirs and self.installdir in ignore_dirs:
             datafiles = []
         else:
-            datafiles = create_index(os.curdir, ignore_dirs=self.cfg['object_storage_ignore_dirs'])
+            datafiles = create_index(os.curdir, ignore_dirs=ignore_dirs)
 
         for datafile in datafiles:
             cks = compute_checksum(datafile, checksum_type='sha256')

--- a/easybuild/easyblocks/generic/dataset.py
+++ b/easybuild/easyblocks/generic/dataset.py
@@ -49,7 +49,8 @@ class Dataset(Binary):
             'extract_sources': [True, "Whether or not to extract data sources", CUSTOM],
             'data_install_path': [None, "Custom installation path for datasets", CUSTOM],
             'cleanup_data_sources': [False, "Whether or not to delete the data sources after installation", CUSTOM],
-            'object_storage_ignore_dirs': [[], "List of directories to be excluded from object storage", CUSTOM],
+            'object_storage_ignore_dirs': [[], "List of directories (relative to installdir) to be excluded from "
+                                               "object storage (use '.' for full installdir)", CUSTOM],
         })
         return extra_vars
 
@@ -60,6 +61,12 @@ class Dataset(Binary):
         if self.cfg['sources']:
             raise EasyBuildError(
                 "Easyconfig parameter 'sources' is not supported for this EasyBlock. Use 'data_sources' instead.")
+
+        with self.cfg.disable_templating():
+            ignore_dirs = self.cfg['object_storage_ignore_dirs']
+        if not isinstance(ignore_dirs, (list, tuple)):
+            raise EasyBuildError(f"Incorrect value type '{type(ignore_dirs).__name__}' for "
+                                 "object_storage_ignore_dirs, should be list or tuple.")
 
         if self.cfg['data_install_path']:
             self.installdir = self.cfg['data_install_path']
@@ -83,11 +90,7 @@ class Dataset(Binary):
         object_storage = os.path.normpath(os.path.join(os.getcwd(), os.pardir, 'object_storage'))
 
         ignore_dirs = self.cfg['object_storage_ignore_dirs']
-        if not isinstance(ignore_dirs, (list, tuple)):
-            raise EasyBuildError("Incorrect value type for object_storage_ignore_dirs, should be list or tuple: ",
-                                 ignore_dirs)
-
-        if ignore_dirs and self.installdir in ignore_dirs:
+        if ignore_dirs and '.' in ignore_dirs:
             datafiles = []
         else:
             datafiles = create_index(os.curdir, ignore_dirs=ignore_dirs)

--- a/easybuild/easyblocks/generic/dataset.py
+++ b/easybuild/easyblocks/generic/dataset.py
@@ -79,7 +79,10 @@ class Dataset(Binary):
         change_dir(self.installdir)
         object_storage = os.path.normpath(os.path.join(os.getcwd(), os.pardir, 'object_storage'))
 
-        datafiles = create_index(os.curdir, ignore_dirs=self.cfg['object_storage_ignore_dirs'])
+        if self.cfg['object_storage_ignore_dirs'] and self.installdir in self.cfg['object_storage_ignore_dirs']:
+            datafiles = []
+        else:
+            datafiles = create_index(os.curdir, ignore_dirs=self.cfg['object_storage_ignore_dirs'])
 
         for datafile in datafiles:
             cks = compute_checksum(datafile, checksum_type='sha256')


### PR DESCRIPTION
Some datasets can have a very large number of files. Symlinking each individual file can be costly during installation, but especially concerning is that it might be really tank the read performance on some file systems.

This commit introduces a variable for the dataset easyblock where you can specify which directories to ignore when creating the object storage files.

An alternative could be to put the entire directory into object storage.

I should also add that I haven't benchmarked how much of a performance hit this actually is, its just what I suspect at the moment.