### PR TITLE
Fix `--sanity-check-only` for `netcdf4-python`

### DIFF
--- a/easybuild/easyblocks/n/netcdf4_python.py
+++ b/easybuild/easyblocks/n/netcdf4_python.py
@@ -86,6 +86,9 @@ class EB_netcdf4_minus_python(PythonPackage):
 
     def sanity_check_step(self):
         """Custom sanity check for netcdf4-python"""
+        # Required to have `self.pylibdir` set in --sanity-check-only mode
+        if self.python_cmd is None:
+            self.prepare_python()
         custom_paths = {
             'files': ['bin/nc3tonc4', 'bin/nc4tonc3', 'bin/ncinfo'],
             'dirs': [self.pylibdir],


### PR DESCRIPTION
This change is needed as `self.pylibdir` will be set to `UNKNOWN` without giving a weird sanity check error 

```
Installation ended unsuccessfully: Sanity check failed: no (non-empty) directory found at 'UNKNOWN' in /home/crivella/.local/easybuild/software/netcdf4-python/1.7.2-foss-2025b
```

I think we should make this a property to ensure it is always set when accessed but that is for another PR