### PR TITLE
Use bounded `git rev-list` for version detection

### DIFF
--- a/easybuild/easyblocks/__init__.py
+++ b/easybuild/easyblocks/__init__.py
@@ -60,7 +60,7 @@ def get_git_revision():
     try:
         path = os.path.dirname(__file__)
         gitrepo = Git(path)
-        res = gitrepo.rev_list('HEAD').splitlines()[0]
+        res = gitrepo.rev_list('-n', '1', 'HEAD').splitlines()[0]
         # 'encode' may be required to make sure a regular string is returned rather than a unicode string
         # (only needed in Python 2; in Python 3, regular strings are already unicode)
         if not isinstance(res, str):


### PR DESCRIPTION
This PR avoids an unnecessary full Git history traversal during EasyBuild version detection.

Currently the code uses `git rev-list HEAD` and then only keeps the first returned commit hash. On large repositories or filesystems with slow metadata access, this can make even simple commands like `eb --version` noticeably slow, because `git rev-list HEAD` walks the full reachable commit history.

Since EasyBuild only needs the current `HEAD` commit hash here, this PR changes the call to the equivalent of:

```text
git rev-list -n 1 HEAD
```

This preserves the existing GitPython-based implementation and the resulting version string, but avoids traversing more history than needed.

In my local testing on an HPC filesystem, this reduced warm `eb --version` startup time from many seconds to about 0.5 s, while keeping the same reported EasyBuild version and Git revision hashes.
This is the matching change for the same version-detection pattern in easyblocks.

*this PR was created with help of ChatGPT5.5

Framework PR:
- https://github.com/easybuilders/easybuild-framework/pull/5201