### PR TITLE
add back removed `dirs` in sanity check of custom easyblock for TensorRT

### DIFF
--- a/easybuild/easyblocks/t/tensorrt.py
+++ b/easybuild/easyblocks/t/tensorrt.py
@@ -98,16 +98,13 @@ class EB_TensorRT(PythonPackage, Binary):
 
     def sanity_check_step(self):
         """Custom sanity check for TensorRT."""
-        custom_paths = {
-            'dirs': [os.path.join('lib', 'python%(pyshortver)s', 'site-packages')],
-        }
         if LooseVersion(self.version) >= LooseVersion('6'):
             lib_name = 'libnvinfer_static.a'
         else:
             lib_name = 'libnvinfer.a'
         custom_paths = {
             'files': ['bin/trtexec', f'lib/{lib_name}'],
-            'dirs': [],
+            'dirs': [os.path.join('lib', 'python%(pyshortver)s', 'site-packages')],
         }
 
         custom_commands = ["%(python)s -c 'import tensorrt'"]


### PR DESCRIPTION
Followup to #4169 after #4046 introduced a regression: The fix missed the initial assignment

@boegel 