### PR TITLE
fix OpenMPI and UCX easyblocks w.r.t. ROCm support

### DIFF
--- a/easybuild/easyblocks/o/openmpi.py
+++ b/easybuild/easyblocks/o/openmpi.py
@@ -243,11 +243,11 @@ class EB_OpenMPI(ConfigureMake):
                 "ompi_info | grep -i 'rocm'",
                 # ROCm MPI extension is built and exposed
                 "ompi_info --all | grep -E 'MPI extensions:.*rocm'",
-                # UCX PML can see the ROCm memory type
-                "ompi_info --param pml ucx --level 9 | grep -i rocm_ipc",
                 # The ROCm accelerator framework component is present
                 "ompi_info | grep -E 'MCA accelerator: rocm'",
             ])
+            if get_software_root('UCX') or get_software_root('UCX-ROCm'):
+                custom_commands.append("ompi_info --param pml ucx --level 9 | grep -i rocm_ipc")
 
         # Add minimal test program to sanity checks
         # Run with correct MPI launcher

--- a/easybuild/easyblocks/o/openmpi.py
+++ b/easybuild/easyblocks/o/openmpi.py
@@ -79,10 +79,7 @@ class EB_OpenMPI(ConfigureMake):
             # ROCm support added to OpenMPI after 5.0.x
             rocmroot = get_software_root('ROCm-LLVM')
             if rocmroot:
-                # remove plain UCC and UCX
-                known_dependencies = [d for d in known_dependencies if d not in ('UCX', 'UCC')]
-                # replace with rocm versions
-                known_dependencies.extend(['HIP', 'UCX-ROCm', 'UCC-ROCm'])
+                known_dependencies.append('HIP')
 
         # Value to use for `--with-<dep>=<value>` if the dependency is not specified in the easyconfig
         # No entry is interpreted as no option added at all
@@ -109,13 +106,10 @@ class EB_OpenMPI(ConfigureMake):
             # libfabric option renamed in OpenMPI 3.1.0 to ofi
             if dep == 'libfabric' and LooseVersion(self.version) >= LooseVersion('3.1'):
                 opt_name = 'ofi'
+
             # needed in easybuild setup as rocm-llvm and hip live in separate dirs
-            elif dep == 'HIP':
+            if dep == 'HIP' and LooseVersion(self.version) >= LooseVersion('5.0'):
                 opt_name = 'rocm'
-            elif dep == 'UCC-ROCm':
-                opt_name = 'ucc'
-            elif dep == 'UCX-ROCm':
-                opt_name = 'ucx'
 
             # check again if option is already used, using new name
             if config_opt_used(opt_name):

--- a/easybuild/easyblocks/u/ucx_plugins.py
+++ b/easybuild/easyblocks/u/ucx_plugins.py
@@ -62,7 +62,7 @@ class EB_UCX_Plugins(ConfigureMake):
                 if 'GDRCopy' in dep_names:
                     plugins['uct_cuda'].append('gdrcopy')
 
-            if 'ROCm' in dep_names:
+            if 'rocm-compilers' in self.toolchain.name:
                 for key in ('ucm', 'uct', 'ucx_perftest'):
                     plugins[key].append('rocm')
 
@@ -94,7 +94,7 @@ class EB_UCX_Plugins(ConfigureMake):
 
             self.makefile_dirs.extend(os.path.join(x, 'cuda') for x in ('uct', 'ucm', 'tools/perf'))
 
-        rocmroot = get_software_root('ROCm')
+        rocmroot = get_software_root('ROCm-LLVM')
         if rocmroot:
             configopts += '--with-rocm=%s ' % rocmroot
             self.makefile_dirs.extend(os.path.join(x, 'rocm') for x in ('uct', 'ucm', 'tools/perf'))


### PR DESCRIPTION
For UCX, see the comment: https://github.com/easybuilders/easybuild-easyconfigs/pull/25902#discussion_r3473153782

For OpenMPI fixes, since UCC-ROCm and UCX-ROCm are now built as plugins to UCC and UCX, respectively, we can rely on the existing ucc and ucx in the known_dependencies. We only need to redirect HIP to --with-rocm flag.