### PR TITLE
enhance `binutils` easyblock to ensure system search path is used for `ld` instead of the default one by setting `$LIB_PATH` in build step

### DIFF
--- a/easybuild/easyblocks/b/binutils.py
+++ b/easybuild/easyblocks/b/binutils.py
@@ -61,6 +61,8 @@ class EB_binutils(ConfigureMake):
         """Easyblock constructor"""
         super().__init__(*args, **kwargs)
 
+        self.search_paths = []
+
         if LooseVersion(self.version) >= LooseVersion('2.44') or get_cpu_family() == RISCV:
             # ld.gold linker is not supported on RISC-V, and is being phased out starting from v2.44
             self.use_gold = False
@@ -297,6 +299,9 @@ class EB_binutils(ConfigureMake):
 
         # All binaries support --version, check that they can be run
         custom_commands = ['%s --version' % b for b in binaries]
+
+        for sdir in self.search_paths:
+            custom_commands.append(f'ld -verbose | grep "SEARCH_DIR(" | grep "{sdir}"')
 
         # if zlib is listed as a build dependency, it should have been linked in statically
         build_deps = self.cfg.dependencies(build_only=True)

--- a/easybuild/easyblocks/b/binutils.py
+++ b/easybuild/easyblocks/b/binutils.py
@@ -103,12 +103,12 @@ class EB_binutils(ConfigureMake):
 
         version = LooseVersion(self.version)
 
+        # determine list of 'lib' directories to use rpath for;
+        # this should 'harden' the resulting binutils to bootstrap GCC
+        # (no trouble when other libstdc++ is build etc)
+        lib_paths = self.determine_used_library_paths()
+        self.search_paths = lib_paths.copy()
         if self.toolchain.is_system_toolchain():
-            # determine list of 'lib' directories to use rpath for;
-            # this should 'harden' the resulting binutils to bootstrap GCC
-            # (no trouble when other libstdc++ is build etc)
-            lib_paths = self.determine_used_library_paths()
-
             # The installed lib dir must come first though to avoid taking system libs over installed ones, see:
             # https://github.com/easybuilders/easybuild-easyconfigs/issues/10056
             # To get literal $ORIGIN through Make we need to escape it by doubling $$, else it's a variable to Make;
@@ -229,6 +229,10 @@ class EB_binutils(ConfigureMake):
                 if gcc_version and ('4.8.1' <= gcc_version < '6.1.0'):
                     # append "-std=c++11" to $CXXFLAGS, not overriding
                     self.cfg.update('buildopts', 'CXXFLAGS="$CXXFLAGS -std=c++11"')
+
+    def build_step(self, verbose=None, path=None):
+        env.setvar('LIB_PATH', ':'.join(self.search_paths))
+        return super().build_step(verbose, path)
 
     def install_step(self):
         """Install using 'make install', also symlink libiberty/demangle headers if desired."""


### PR DESCRIPTION
This should fix the problem observed in https://github.com/easybuilders/easybuild-easyconfigs/issues/20375

Currently the `binutils` EBlock determines the system search path through `gcc -print-search-dirs` and uses it to rpath builds in case of a system toolchain.

The problem is that the `SEARCH_DIRS` of `ld` are not properly set to the system ones and the default (on eg Debian/Ubuntu) misses `/usr/lib/x86_64-linux-gnu` and `/lib/x86_64-linux-gnu`.
For `nvidia-compilers` this causes failures when liking eg `libc` `libdl` and `libpthread` through `ld` directly.

This is not a problem in GCC based toolchains as gcc does its own logic to add this paths with `-L` statements
`nvc++` in `nvidia-compilers` instead both adds `-lc -ldl -lpthread` to every invocation and passes it directly to `ld` causing failures of the type

```
/home/crivella/.local/easybuild/software/binutils/2.42-GCCcore-14.2.0/bin/ld: cannot find -ldl: No such file or directory
/home/crivella/.local/easybuild/software/binutils/2.42-GCCcore-14.2.0/bin/ld: cannot find -lpthread: No such file or directory
/home/crivella/.local/easybuild/software/binutils/2.42-GCCcore-14.2.0/bin/ld: cannot find -lc: No such file or directory
```

<details><summary>Details</summary>
<p>

```
/tmp/eb-av4z3kjy/tmpf22k8are$ nvc++ minimal.cpp  -v
Export NVCOMPILER=/home/crivella/.local/easybuild/software/nvidia-compilers/25.3-CUDA-12.8.0/Linux_x86_64/25.3
Export PGI=/home/crivella/.local/easybuild/software/nvidia-compilers/25.3-CUDA-12.8.0

/home/crivella/.local/easybuild/software/nvidia-compilers/25.3-CUDA-12.8.0/Linux_x86_64/25.3/compilers/bin/tools/nvcpfe -- --llalign -D__GNUC__=14 -D__GNUC_MINOR__=2 -D__GNUC_PATCHLEVEL__=0 -D__unix -D__unix__ -Dunix -Dlinux -D__linux -D__linux__ -D__ELF__ -D__NO_MATH_INLINES -D__LP64__ -D__x86_64 -D__x86_64__ -D__LONG_MAX__=9223372036854775807L '-D__SIZE_TYPE__=unsigned long int' '-D__PTRDIFF_TYPE__=long int' -D__amd64 -D__amd64__ -D__k8 -D__k8__ -D__MMX__ -D__SSE_MATH__ -D__MMX_WITH_SSE__ -D__SSE__ -D__SSE2__ -D__SSE2_MATH__ -D__SSE3__ -D__SSSE3__ -D__SSE4_1__ -D__SSE4_2__ -D__ABM__ -D__ADX__ -D__AES__ -D__AVX__ -D__AVX2__ -D__AVXVNNI__ -D__BMI__ -D__BMI2__ -D__CLFLUSHOPT__ -D__CLWB__ -D__CX16__ -D__F16C__ -D__FMA__ -D__FSGSBASE__ -D__FXSR__ -D__GFNI__ -D__HRESET__ -D__KL__ -D__LZCNT__ -D__MOVBE__ -D__MOVDIR64B__ -D__MOVDIRI__ -D__PCLMUL__ -D__PCONFIG__ -D__PKU__ -D__POPCNT__ -D__PRFCHW__ -D__PTWRITE__ -D__RDPID__ -D__RDRND__ -D__RDSEED__ -D__LAHF_SAHF__ -D__SERIALIZE__ -D__SHA__ -D__SHSTK__ -D__VAES__ -D__VPCLMULQDQ__ -D__WAITPKG__ -D__WIDEKL__ -D__XSAVE__ -D__XSAVEC__ -D__XSAVEOPT__ -D__XSAVES__ -D__PGI -D__NVCOMPILER -D_GNU_SOURCE -D_PGCG_SOURCE -I- -I/home/crivella/.local/easybuild/software/numactl/2.0.19-GCCcore-14.2.0/include -I/home/crivella/.local/easybuild/software/binutils/2.42-GCCcore-14.2.0/include -I/home/crivella/.local/easybuild/software/zlib/1.3.1-GCCcore-14.2.0/include -I/home/crivella/.local/easybuild/software/CUDA/12.8.0/nvvm/include -I/home/crivella/.local/easybuild/software/CUDA/12.8.0/extras/CUPTI/include -I/home/crivella/.local/easybuild/software/CUDA/12.8.0/targets/x86_64-linux/include --sys_include /home/crivella/.local/easybuild/software/nvidia-compilers/25.3-CUDA-12.8.0/Linux_x86_64/25.3/compilers/include --sys_include /home/crivella/.local/easybuild/software/nvidia-compilers/25.3-CUDA-12.8.0/Linux_x86_64/25.3/compilers/include-stdexec --sys_include /home/crivella/.local/easybuild/software/GCCcore/14.2.0/lib/gcc/x86_64-pc-linux-gnu/14.2.0/../../../../include/c++/14.2.0 --sys_include /home/crivella/.local/easybuild/software/GCCcore/14.2.0/lib/gcc/x86_64-pc-linux-gnu/14.2.0/../../../../include/c++/14.2.0/x86_64-pc-linux-gnu --sys_include /home/crivella/.local/easybuild/software/GCCcore/14.2.0/lib/gcc/x86_64-pc-linux-gnu/14.2.0/../../../../include/c++/14.2.0/backward --sys_include /home/crivella/.local/easybuild/software/GCCcore/14.2.0/lib/gcc/x86_64-pc-linux-gnu/14.2.0/include --sys_include /home/crivella/.local/easybuild/software/GCCcore/14.2.0/include --sys_include /home/crivella/.local/easybuild/software/GCCcore/14.2.0/lib/gcc/x86_64-pc-linux-gnu/14.2.0/include-fixed/x86_64-linux-gnu --sys_include /home/crivella/.local/easybuild/software/GCCcore/14.2.0/lib/gcc/x86_64-pc-linux-gnu/14.2.0/include-fixed --sys_include /usr/include/x86_64-linux-gnu --sys_include /usr/include -D__PGLLVM__ -D__NVCOMPILER_LLVM__ -D__extension__= --preinclude _cplus_preinclude.h --preinclude_macros _cplus_macros.h --gnu_version=140200 -D__pgnu_vsn=140200 --no_fixed_bp -q -o /tmp/nvc++0r1geCKx_rymw.il minimal.cpp -- minimal.cpp -opt 1 -x 119 0xa10000 -x 122 0x40 -x 123 0x1000 -x 127 4 -x 127 17 -x 19 0x400000 -x 28 0x40000 -x 120 0x10000000 -x 70 0x8000 -x 122 1 -x 125 0x20000 -quad -x 59 4 -tp alderlake -x 120 0x1000 -astype 0 -x 121 1 -fn minimal.cpp -il /tmp/nvc++0r1geCKx_rymw.il -x 117 0x200 -x 123 0x80000000 -x 123 4 -x 2 0x400 -x 209 0x10 -x 119 0x20 -def __pgnu_vsn=140200 -x 70 0x40000000 -x 183 4 -x 121 0x800 -x 6 0x20000 -x 249 190 -x 120 0x200000 -x 70 0x40000000 -x 8 0x40000000 -x 164 0x800000 -x 71 0x2000 -x 71 0x4000 -x 34 0x40000000 -x 120 0x1000000 -x 73 0x04 -x 231 0x800 -x 68 0x1 -x 39 4 -x 56 0x10 -x 26 0x10 -x 26 1 -x 56 0x4000 -x 197 0 -x 175 0 -x 203 0 -x 204 0 -x 227 0xFFFF -y 163 0xc0000000 -x 189 0x10 -y 189 0x4000000 -x 187 0x8000000 -x 60 512 -gnuvsn 140200 -x 69 0x200 -mach 0 -nomach 0 -x 123 0x400 -cmdline '+nvc++ minimal.cpp -v' -asm /tmp/nvc++0r1geCh1VHIvs.ll
NVC++/x86-64 Linux 25.3-0: compilation successful

/home/crivella/.local/easybuild/software/nvidia-compilers/25.3-CUDA-12.8.0/Linux_x86_64/25.3/compilers/share/llvm/bin/llc /tmp/nvc++0r1geCh1VHIvs.ll -march=x86-64 -mcpu=native -mattr=+mmx -mattr=+sse -mattr=+sse2 -mattr=+sse3 -mattr=+ssse3 -mattr=+sse4.1 -mattr=+sse4.2 -mattr=+avx -mattr=+avx2 -mattr=+f16c -mattr=+fma -mattr=+xsave -mattr=+xsaveopt -mattr=+xsavec -mattr=+xsaves -mattr=+popcnt -mattr=+sha -mattr=+aes -mattr=+pclmul -mattr=+clflushopt -mattr=+fsgsbase -mattr=+rdrnd -mattr=+bmi -mattr=+bmi2 -mattr=+lzcnt -mattr=+fxsr -mattr=+pku -mattr=+gfni -mattr=+vaes -mattr=+vpclmulqdq -mattr=+movdiri -mattr=+movdir64b -mattr=+adx -mattr=+avxvnni -mattr=+clwb -mattr=+cx16 -mattr=+hreset -mattr=+kl -mattr=+movbe -mattr=+pconfig -mattr=+prfchw -mattr=+ptwrite -mattr=+rdpid -mattr=+rdseed -mattr=+sahf -mattr=+serialize -mattr=+shstk -mattr=+waitpkg -mattr=+widekl -O1 -x86-cmov-converter=0 -dwarf-directory=false -non-global-value-max-name-size=-1 --align-all-functions=6 -nvhpc-memzero -nvhpc-dso-opt -filetype=obj --frame-pointer=none -o /tmp/nvc++ur1ge8cE4jlqm.o

/home/crivella/.local/easybuild/software/binutils/2.42-GCCcore-14.2.0/bin/ld /usr/lib/x86_64-linux-gnu/crt1.o /usr/lib/x86_64-linux-gnu/crti.o /home/crivella/.local/easybuild/software/GCCcore/14.2.0/lib/gcc/x86_64-pc-linux-gnu/14.2.0//crtbegin.o --eh-frame-hdr -m elf_x86_64 -dynamic-linker /lib64/ld-linux-x86-64.so.2 -T /home/crivella/.local/easybuild/software/nvidia-compilers/25.3-CUDA-12.8.0/Linux_x86_64/25.3/compilers/lib/nvhpc.ld -L/home/crivella/.local/easybuild/software/nvidia-compilers/25.3-CUDA-12.8.0/Linux_x86_64/25.3/compilers/lib -L/home/crivella/.local/easybuild/software/numactl/2.0.19-GCCcore-14.2.0/lib -L/home/crivella/.local/easybuild/software/binutils/2.42-GCCcore-14.2.0/lib -L/home/crivella/.local/easybuild/software/zlib/1.3.1-GCCcore-14.2.0/lib -L/home/crivella/.local/easybuild/software/GCCcore/14.2.0/lib64 -L/home/crivella/.local/easybuild/software/GCCcore/14.2.0/lib -L/home/crivella/.local/easybuild/software/CUDA/12.8.0/stubs/lib64 -L/home/crivella/.local/easybuild/software/CUDA/12.8.0/nvvm/lib64 -L/home/crivella/.local/easybuild/software/CUDA/12.8.0/extras/CUPTI/lib64 -L/home/crivella/.local/easybuild/software/CUDA/12.8.0/targets/x86_64-linux/lib -L/home/crivella/.local/easybuild/software/nvidia-compilers/25.3-CUDA-12.8.0/Linux_x86_64/25.3/compilers/lib -L/home/crivella/.local/easybuild/software/nvidia-compilers/25.3-CUDA-12.8.0/Linux_x86_64/25.3/compilers/lib -L/usr/lib64 -L/home/crivella/.local/easybuild/software/GCCcore/14.2.0/lib/gcc/x86_64-pc-linux-gnu/14.2.0/ /tmp/nvc++ur1ge8cE4jlqm.o -rpath /home/crivella/.local/easybuild/software/nvidia-compilers/25.3-CUDA-12.8.0/Linux_x86_64/25.3/compilers/lib -rpath /home/crivella/.local/easybuild/software/nvidia-compilers/25.3-CUDA-12.8.0/Linux_x86_64/25.3/compilers/lib -rpath /home/crivella/.local/easybuild/software/GCCcore/14.2.0/lib64 -L/home/crivella/.local/easybuild/software/GCCcore/14.2.0/lib64 -lstdc++ -lnvomp -ldl -lnvhpcatm --as-needed -latomic --no-as-needed -lpthread -lnvcpumath -lnsnvc -lnvc -lgcc -lc -lgcc_s -lm /home/crivella/.local/easybuild/software/GCCcore/14.2.0/lib/gcc/x86_64-pc-linux-gnu/14.2.0//crtend.o /usr/lib/x86_64-linux-gnu/crtn.o
/home/crivella/.local/easybuild/software/binutils/2.42-GCCcore-14.2.0/bin/ld: cannot find -ldl: No such file or directory
/home/crivella/.local/easybuild/software/binutils/2.42-GCCcore-14.2.0/bin/ld: cannot find -lpthread: No such file or directory
/home/crivella/.local/easybuild/software/binutils/2.42-GCCcore-14.2.0/bin/ld: cannot find -lc: No such file or directory
nvc++-Fatal-linker completed with exit code 1
```

</p>
</details> 

whit this PR the search dirs of ld will include the one given by the system compiler which should solve this issue

<details><summary>SEARCH_DIRS before PR</summary>
<p>

```
crivella@crivella-desktop:~$ module load binutils/2.42-GCCcore-14.2.0 
crivella@crivella-desktop:~$ ld -verbose | grep SEARCH | tr ';' '\n'
SEARCH_DIR("=/home/crivella/.local/easybuild/software/binutils/2.42-GCCcore-14.2.0/x86_64-pc-linux-gnu/lib64")
 SEARCH_DIR("=/home/crivella/.local/easybuild/software/binutils/2.42-GCCcore-14.2.0/lib64")
 SEARCH_DIR("=/usr/local/lib64")
 SEARCH_DIR("=/lib64")
 SEARCH_DIR("=/usr/lib64")
 SEARCH_DIR("=/home/crivella/.local/easybuild/software/binutils/2.42-GCCcore-14.2.0/x86_64-pc-linux-gnu/lib")
 SEARCH_DIR("=/home/crivella/.local/easybuild/software/binutils/2.42-GCCcore-14.2.0/lib")
 SEARCH_DIR("=/usr/local/lib")
 SEARCH_DIR("=/lib")
 SEARCH_DIR("=/usr/lib")

crivella@crivella-desktop:~$ which ld
/home/crivella/.local/easybuild/software/binutils/2.42-GCCcore-14.2.0/bin/ld
```

</p>
</details> 

<details><summary>SEARCH_DIRS after PR</summary>
<p>

```
crivella@crivella-desktop:~$ module use /tmp/eb_tmpdir-hCRyszlA/modules/all/
crivella@crivella-desktop:~$ module load binutils/2.42-GCCcore-14.2.0 
crivella@crivella-desktop:~$ ld -verbose | grep SEARCH | tr ';' '\n'
SEARCH_DIR("=/tmp/eb_tmpdir-hCRyszlA/software/binutils/2.42-GCCcore-14.2.0/x86_64-pc-linux-gnu/lib64")
 SEARCH_DIR("/home/crivella/.local/easybuild/software/zlib/1.3.1-GCCcore-14.2.0/lib64")
 SEARCH_DIR("/home/crivella/.local/easybuild/software/binutils/2.42/lib64")
 SEARCH_DIR("/home/crivella/.local/easybuild/software/flex/2.6.4-GCCcore-14.2.0/lib64")
 SEARCH_DIR("/home/crivella/.local/easybuild/software/GCCcore/14.2.0/lib64")
 SEARCH_DIR("/lib/x86_64-linux-gnu")
 SEARCH_DIR("/lib64")
 SEARCH_DIR("/lib")
 SEARCH_DIR("=/tmp/eb_tmpdir-hCRyszlA/software/binutils/2.42-GCCcore-14.2.0/x86_64-pc-linux-gnu/lib")

crivella@crivella-desktop:~$ which ld
/tmp/eb_tmpdir-hCRyszlA/software/binutils/2.42-GCCcore-14.2.0/bin/ld
crivella@crivella-desktop:~$ 

```

</p>
</details> 

Potentially we might also want to exclude the non system libraries locations that are now detected (eg `zlib` and `flex` which are present due to being loaded at build time)