### PR TITLE
enhance GROMACS easyblock to allow building with CP2K QM/MM support

### DIFF
--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -245,14 +245,14 @@ class EB_GROMACS(CMakeMake):
         # CP2K detection
         # enable CP2K support if explicitly requested (cp2k = True)
         # and check whether other requirements are met.
-        cp2k_root = get_software_root('CP2K')
-        if self.cfg['cp2k'] and not cp2k_root:
-            msg = "CP2K support has been requested but CP2K is not listed as a dependency."
-            raise EasyBuildError(msg)
-
         if self.cfg['cp2k']:
             if LooseVersion(self.version) < LooseVersion('2022'):
                 msg = 'CP2K support is only available in GROMACS 2022 and newer.'
+                raise EasyBuildError(msg)
+
+            cp2k_root = get_software_root('CP2K')
+            if not cp2k_root:
+                msg = "CP2K support has been requested but CP2K is not listed as a dependency."
                 raise EasyBuildError(msg)
 
             cp2k_version = get_software_version('CP2K')
@@ -264,11 +264,12 @@ class EB_GROMACS(CMakeMake):
                 msg = "GROMACS with CP2K support needs to be built with 'mpi_only = True'"
                 raise EasyBuildError(msg)
 
-            if not run_shell_cmd('pkgconf --exists libcp2k').exit_code == 0:
-                msg = "CP2K needs to be compiled with 'library = True'."
-                raise EasyBuildError(msg)
             if not get_software_root('pkgconf'):
                 msg = "pkgconf is required as a build-dependency for building GROMACS-CP2K"
+                raise EasyBuildError(msg)
+
+            if not run_shell_cmd('pkgconf --exists libcp2k').exit_code == 0:
+                msg = "CP2K needs to be compiled with 'library = True'."
                 raise EasyBuildError(msg)
 
             self.log.info('CP2K support has been enabled.')

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -79,7 +79,7 @@ class EB_GROMACS(CMakeMake):
                        "'native' enables native PLUMED support for GROMACS 2025 and newer." +
                        "'patch' (or True) applies PLUMED patches." +
                        "False disables PLUMED support.", CUSTOM],
-            'cp2k': [None, "Build with CP2K QM/MM. None is auto-detect. True or False forces behaviour.", CUSTOM],
+            'cp2k': [False, "Build with CP2K QM/MM. Forces a static build and implies 'mpi_only'", CUSTOM],
         })
         return extra_vars
 
@@ -93,8 +93,13 @@ class EB_GROMACS(CMakeMake):
         self.cfg['build_shared_libs'] = self.cfg.get('build_shared_libs', False)
 
         if LooseVersion(self.version) >= LooseVersion('2019'):
-            # Building the gmxapi interface requires shared libraries
-            self.cfg['build_shared_libs'] = True
+            if LooseVersion(self.version) >= LooseVersion('2022') and self.cfg['cp2k']:
+                # Building with CP2K requires static build w/o gmxapi.
+                # https://manual.gromacs.org/documentation/2022/install-guide/index.html#building-with-cp2k-qm-mm-support
+                self.cfg['build_shared_libs'] = False
+            else:
+                # Building the gmxapi interface requires shared libraries
+                self.cfg['build_shared_libs'] = True
 
         if self.cfg['build_shared_libs']:
             self.libext = get_shared_lib_ext()
@@ -238,15 +243,12 @@ class EB_GROMACS(CMakeMake):
                 self.cfg.update('configopts', "-DGMX_GPU=OFF")
 
         # CP2K detection
-        # enable CP2K support if CP2K is listed as a dependency
-        # and CP2K support is either explicitly enabled (cp2k = True) or unspecified ('cp2k' not defined)
+        # enable CP2K support if explicitly requested (cp2k = True)
+        # and check whether other requirements are met.
         cp2k_root = get_software_root('CP2K')
         if self.cfg['cp2k'] and not cp2k_root:
             msg = "CP2K support has been requested but CP2K is not listed as a dependency."
             raise EasyBuildError(msg)
-        elif cp2k_root and self.cfg['cp2k'] is False:
-            self.log.info('CP2K was found, but compilation without CP2K has been requested.')
-            cp2k_root = None
 
         if cp2k_root:
             if LooseVersion(self.version) < LooseVersion('2022'):
@@ -262,12 +264,9 @@ class EB_GROMACS(CMakeMake):
                 msg = "GROMACS with CP2K support needs to be built with 'mpi_only = True'"
                 raise EasyBuildError(msg)
 
-            if not os.path.exists(os.path.join(cp2k_root, 'lib', 'libcp2k.a')):
-                msg = 'CP2K needs to be compiled with "library = True".'
+            if not run_shell_cmd('pkg-config --exists libcp2k').exit_code == 0:
+                msg = "CP2K needs to be compiled with 'library = True'."
                 raise EasyBuildError(msg)
-            #if not os.path.exists(os.path.join(cp2k_root, 'lib', 'pkgconfig', 'libcp2k.pc')):
-            #    msg = "pkgconf is required as a build-dependency for CP2K"
-            #    raise EasyBuildError(msg)
             if not (get_software_root('pkgconf') or get_software_root('pkg-config')):
                 msg = "Either pkgconf or pkg-config is required as a build-dependency for building GROMACS-CP2K"
                 raise EasyBuildError(msg)
@@ -714,8 +713,12 @@ class EB_GROMACS(CMakeMake):
                     self.log.info(f"No sub-directory with GROMACS libraries found in installation: {error}")
                     self.log.info("You are forcing module creation for a non-existent installation!")
                 elif not self.cfg['build_shared_libs']:
-                    self.log.info(f"No sub-directory with GROMACS libraries found in installation: {error}")
-                    self.log.info("This is expected when only building static executables.")
+                    msg = ' '.join([
+                        "GROMACS is built with 'build_shared_libs = False',"
+                        "therefore it is expected to not have any sub-directory for libraries."
+                    ])
+                    self.log.info(msg)
+                    pass
                 else:
                     raise error
 

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -70,6 +70,7 @@ class EB_GROMACS(CMakeMake):
             'mpisuffix': ['_mpi', "Suffix to append to MPI-enabled executables (only for GROMACS < 4.6)", CUSTOM],
             'mpiexec': ['mpirun', "MPI executable to use when running tests", CUSTOM],
             'mpiexec_numproc_flag': ['-np', "Flag to introduce the number of MPI tasks when running tests", CUSTOM],
+            'mpi_only': [False, "Only build for MPI and skip nompi.", CUSTOM],
             'mpi_numprocs': [0, "Number of MPI tasks to use when running tests", CUSTOM],
             'python_pkg': [None, "Build gmxapi Python package. None (default) is auto-detect." +
                            "True or False forces behaviour.", CUSTOM],
@@ -734,8 +735,12 @@ class EB_GROMACS(CMakeMake):
             else:
                 mpisuff = '_mpi'
 
-            mpi_bins.extend([binary + mpisuff for binary in mpi_bins])
-            mpi_libnames.extend([libname + mpisuff for libname in mpi_libnames])
+            if self.cfg['mpi_only']:
+                mpi_bins = [binary + mpisuff for binary in mpi_bins]
+                mpi_libnames = [libname + mpisuff for libname in mpi_libnames]
+            else:
+                mpi_bins.extend([binary + mpisuff for binary in mpi_bins])
+                mpi_libnames.extend([libname + mpisuff for libname in mpi_libnames])
 
         suffixes = ['']
 
@@ -851,9 +856,12 @@ class EB_GROMACS(CMakeMake):
         if precisions == []:
             raise EasyBuildError("No precision selected. At least one of single/double_precision must be unset or True")
 
-        mpitypes = ['nompi']
-        if self.toolchain.options.get('usempi', None):
-            mpitypes.append('mpi')
+        if self.cfg['mpi_only']:
+            mpitypes = ['mpi']
+        else:
+            mpitypes = ['nompi']
+            if self.toolchain.options.get('usempi', None):
+                mpitypes.append('mpi')
 
         # We need to count the number of variations to build.
         versions_built = []

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -264,11 +264,11 @@ class EB_GROMACS(CMakeMake):
                 msg = "GROMACS with CP2K support needs to be built with 'mpi_only = True'"
                 raise EasyBuildError(msg)
 
-            if not run_shell_cmd('pkg-config --exists libcp2k').exit_code == 0:
+            if not run_shell_cmd('pkgconf --exists libcp2k').exit_code == 0:
                 msg = "CP2K needs to be compiled with 'library = True'."
                 raise EasyBuildError(msg)
-            if not (get_software_root('pkgconf') or get_software_root('pkg-config')):
-                msg = "Either pkgconf or pkg-config is required as a build-dependency for building GROMACS-CP2K"
+            if not get_software_root('pkgconf'):
+                msg = "pkgconf is required as a build-dependency for building GROMACS-CP2K"
                 raise EasyBuildError(msg)
 
             self.log.info('CP2K support has been enabled.')
@@ -300,11 +300,11 @@ class EB_GROMACS(CMakeMake):
             cp2k_linker_flags += [
                 "-L%s" % os.path.join(cp2k_root, 'lib', 'exts', 'dbcsr'),
                 # get dependencies for libcp2k.a:
-                "$(pkg-config --libs-only-l libcp2k)"
+                "$(pkgconf --libs libcp2k)"
             ]
-            if get_software_root('Libint'):
-                # for some reason libint2 is not discovered by pkg-config:
-                cp2k_linker_flags.append('-lint2')
+            #if get_software_root('Libint'):
+            #    # for some reason libint2 is not discovered by pkgconf:
+            #    cp2k_linker_flags.append('-lint2')
             self.cfg.update('configopts', '-DCP2K_LINKER_FLAGS="%s"' % " ".join(cp2k_linker_flags))
 
         # PLUMED detection

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -79,6 +79,7 @@ class EB_GROMACS(CMakeMake):
                        "'native' enables native PLUMED support for GROMACS 2025 and newer." +
                        "'patch' (or True) applies PLUMED patches." +
                        "False disables PLUMED support.", CUSTOM],
+            'cp2k': [None, "Build with CP2K QM/MM. None is auto-detect. True or False forces behaviour.", CUSTOM],
         })
         return extra_vars
 
@@ -236,6 +237,77 @@ class EB_GROMACS(CMakeMake):
                 # to avoid that GROMACS finds and uses a system-wide CUDA compiler
                 self.cfg.update('configopts', "-DGMX_GPU=OFF")
 
+        # CP2K detection
+        # enable CP2K support if CP2K is listed as a dependency
+        # and CP2K support is either explicitly enabled (cp2k = True) or unspecified ('cp2k' not defined)
+        cp2k_root = get_software_root('CP2K')
+        if self.cfg['cp2k'] and not cp2k_root:
+            msg = "CP2K support has been requested but CP2K is not listed as a dependency."
+            raise EasyBuildError(msg)
+        elif cp2k_root and self.cfg['cp2k'] is False:
+            self.log.info('CP2K was found, but compilation without CP2K has been requested.')
+            cp2k_root = None
+
+        if cp2k_root:
+            if LooseVersion(self.version) < LooseVersion('2022'):
+                msg = 'CP2K support is only available in GROMACS 2022 and newer.'
+                raise EasyBuildError(msg)
+
+            cp2k_version = get_software_version('CP2K')
+            if LooseVersion(cp2k_version) < LooseVersion('8.1'):
+                msg = 'CP2K support in GROMACS requires CP2K version 8.1 or higher.'
+                raise EasyBuildError(msg)
+
+            if not self.cfg['mpi_only']:
+                msg = "GROMACS with CP2K support needs to be built with 'mpi_only = True'"
+                raise EasyBuildError(msg)
+
+            if not os.path.exists(os.path.join(cp2k_root, 'lib', 'libcp2k.a')):
+                msg = 'CP2K needs to be compiled with "library = True".'
+                raise EasyBuildError(msg)
+            #if not os.path.exists(os.path.join(cp2k_root, 'lib', 'pkgconfig', 'libcp2k.pc')):
+            #    msg = "pkgconf is required as a build-dependency for CP2K"
+            #    raise EasyBuildError(msg)
+            if not (get_software_root('pkgconf') or get_software_root('pkg-config')):
+                msg = "Either pkgconf or pkg-config is required as a build-dependency for building GROMACS-CP2K"
+                raise EasyBuildError(msg)
+
+            self.log.info('CP2K support has been enabled.')
+            # Building with CP2K requires static build w/o gmxapi.
+            # https://manual.gromacs.org/documentation/2022/install-guide/index.html#building-with-cp2k-qm-mm-support
+            self.log.info("Building with CP2K QM/MM.")
+            self.cfg['build_shared_libs'] = False
+            self.libext = 'a'
+
+            self.cfg.update('configopts', "-DGMX_INSTALL_NBLIB_API=OFF")
+            self.cfg.update('configopts', "-DGMXAPI=OFF")
+            self.cfg.update('configopts', "-DGMX_CP2K=ON")
+            # Ensure that the GROMACS log files report that CP2K was enabled and which version was used.
+            self.cfg.update('configopts', "-DGMX_VERSION_STRING_OF_FORK=CP2K-{:}".format(cp2k_version))
+            self.cfg.update('configopts', "-DCP2K_DIR=%s" % os.path.join(cp2k_root, 'lib'))
+
+            cp2k_linker_flags = []
+            # Need MPI linker flags b/c libcp2k.a is compiled with mpifort.
+            # Unfortunately they are not listed in CP2K's $EBROOTCP2K/lib/pkgconfig/libcp2k.pc
+            if get_software_root('OpenMPI'):
+                # for OpenMPI (mpifort --showme).
+                cp2k_linker_flags.append("-lmpi_usempif08 -lmpi_usempi_ignore_tkr -lmpi_mpifh")
+            elif get_software_root('IntelMPI'):
+                # for Intel MPI (mpiifort -show)
+                cp2k_linker_flags.append("-lmpifort")
+            else:
+                msg = "Currently OpenMPI and IntelMPI are the only supported MPI implementations."
+                raise EasyBuildError(msg)
+            cp2k_linker_flags += [
+                "-L%s" % os.path.join(cp2k_root, 'lib', 'exts', 'dbcsr'),
+                # get dependencies for libcp2k.a:
+                "$(pkg-config --libs-only-l libcp2k)"
+            ]
+            if get_software_root('Libint'):
+                # for some reason libint2 is not discovered by pkg-config:
+                cp2k_linker_flags.append('-lint2')
+            self.cfg.update('configopts', '-DCP2K_LINKER_FLAGS="%s"' % " ".join(cp2k_linker_flags))
+
         # PLUMED detection
         # enable PLUMED support if PLUMED is listed as a dependency.
         # plumed = 'native' will enable GROMACS' native PLUMED support ('-DGMX_USE_PLUMED=ON')
@@ -392,7 +464,7 @@ class EB_GROMACS(CMakeMake):
                               mpiexec_path, self.cfg.get('mpiexec_numproc_flag'),
                               mpi_numprocs)
 
-            if gromacs_version >= '2019':
+            if gromacs_version >= '2019' and self.cfg['build_shared_libs']:
                 # Building the gmxapi interface requires shared libraries,
                 # this is handled in the class initialisation so --module-only works
                 self.cfg.update('configopts', "-DGMXAPI=ON")
@@ -641,6 +713,9 @@ class EB_GROMACS(CMakeMake):
                 if build_option('force') and build_option('module_only'):
                     self.log.info(f"No sub-directory with GROMACS libraries found in installation: {error}")
                     self.log.info("You are forcing module creation for a non-existent installation!")
+                elif not self.cfg['build_shared_libs']:
+                    self.log.info(f"No sub-directory with GROMACS libraries found in installation: {error}")
+                    self.log.info("This is expected when only building static executables.")
                 else:
                     raise error
 

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -303,9 +303,6 @@ class EB_GROMACS(CMakeMake):
                 # get dependencies for libcp2k.a:
                 "$(pkgconf --libs libcp2k)"
             ]
-            #if get_software_root('Libint'):
-            #    # for some reason libint2 is not discovered by pkgconf:
-            #    cp2k_linker_flags.append('-lint2')
             self.cfg.update('configopts', '-DCP2K_LINKER_FLAGS="%s"' % " ".join(cp2k_linker_flags))
 
         # PLUMED detection

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -250,7 +250,7 @@ class EB_GROMACS(CMakeMake):
             msg = "CP2K support has been requested but CP2K is not listed as a dependency."
             raise EasyBuildError(msg)
 
-        if cp2k_root:
+        if self.cfg['cp2k']:
             if LooseVersion(self.version) < LooseVersion('2022'):
                 msg = 'CP2K support is only available in GROMACS 2022 and newer.'
                 raise EasyBuildError(msg)


### PR DESCRIPTION
test with: easybuilders/easybuild-easyconfigs#26756 `GROMACS-2026.2-foss-2025b-CP2K.eb`
also requires: easybuilders/easybuild-easyconfigs#26754 `CP2K-2025.2-foss-2025b.eb`