### PR TITLE
Correct `buildopts` propagation across iterations for OpenBLAS

### DIFF
--- a/easybuild/easyblocks/o/openblas.py
+++ b/easybuild/easyblocks/o/openblas.py
@@ -84,14 +84,14 @@ class EB_OpenBLAS(ConfigureMake):
 
         # ensure build/test/install options don't persist between iterations
         if self.cfg['enable_ilp64']:
-            if self.iter_idx > 0:
-                # reset to original build/test/install options
-                for key, opt_val in self.orig_opts.items():
-                    self.cfg[key] = opt_val
-            else:
+            if self.iter_idx == 0:
                 # store original options
                 for key in self.orig_opts:
                     self.orig_opts[key] = self.cfg[key]
+            else:
+                # reset to original build/test/install options
+                for key, opt_val in self.orig_opts.items():
+                    self.cfg[key] = opt_val
 
         if '%s=' % TARGET in self.cfg['buildopts']:
             # Add any TARGET in buildopts to default_opts, so it is passed to testopts and installopts

--- a/easybuild/easyblocks/o/openblas.py
+++ b/easybuild/easyblocks/o/openblas.py
@@ -90,7 +90,7 @@ class EB_OpenBLAS(ConfigureMake):
                     self.cfg[key] = opt_val
             else:
                 # store original options
-                for key in self.orig_opts.keys():
+                for key in self.orig_opts:
                     self.orig_opts[key] = self.cfg[key]
 
         if '%s=' % TARGET in self.cfg['buildopts']:

--- a/easybuild/easyblocks/o/openblas.py
+++ b/easybuild/easyblocks/o/openblas.py
@@ -91,7 +91,7 @@ class EB_OpenBLAS(ConfigureMake):
             else:
                 # store original options
                 for key, opt_val in self.orig_opts.items():
-                    self.orig_opts[key] = opt_val
+                    self.orig_opts[key] = self.cfg[key]
 
         if '%s=' % TARGET in self.cfg['buildopts']:
             # Add any TARGET in buildopts to default_opts, so it is passed to testopts and installopts

--- a/easybuild/easyblocks/o/openblas.py
+++ b/easybuild/easyblocks/o/openblas.py
@@ -90,7 +90,7 @@ class EB_OpenBLAS(ConfigureMake):
                     self.cfg[key] = opt_val
             else:
                 # store original options
-                for key, opt_val in self.orig_opts.items():
+                for key in self.orig_opts.keys():
                     self.orig_opts[key] = self.cfg[key]
 
         if '%s=' % TARGET in self.cfg['buildopts']:


### PR DESCRIPTION
AI usage: `GPT-5` for the suggestion on modifying the loop

On one of the machines I use I had to specify `TARGET` in the `OpenBLAS` EC for the installation to be able to discover the correct architecture. However I noticed that `TARGET` doesn't propagate across all the iterations and the installation would die again on iteration 2/3.

In the easyblock there's a specific code block that defines that:
```
# ensure build/test/install options don't persist between iterations
if self.cfg['enable_ilp64']:
            if self.iter_idx > 0:
                # reset to original build/test/install options
                for key, opt_val in self.orig_opts.items():
                    self.cfg[key] = opt_val
            else:
                # store original options
                for key, opt_val in self.orig_opts.items():
                    self.orig_opts[key] = opt_val
```

However the last line indicates that this `else` is not really saving the current values from `self.cfg`, so the `buildopts` are reset to to just nothing.