### PR TITLE
Limit `$OMP_NUM_THREADS` for PyTorch tests to avoid oversubscribing available cores

### DIFF
--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -636,6 +636,12 @@ class EB_PyTorch(PythonPackage):
         # Skip this test(s) which is very flaky
         env.setvar('SKIP_TEST_BOTTLENECK', '1')
         env.setvar('MAX_JOBS', str(self.cfg.parallel))
+        if not os.environ.get('OMP_NUM_THREADS'):
+            # Similar to upstream .ci/pytorch/test.sh:
+            # Limit to a quarter of the CPUs (or less if parallel is set)
+            # and leave some headroom for NUM_PROCS=3 parallel tests.
+            # Use at least 4 threads to avoid numerical mismatches from changed FP reductions.
+            env.setvar('OMP_NUM_THREADS', max(4, self.parallel / 4))
         if self.has_xml_test_reports:
             env.setvar(self.GENERATE_TEST_REPORT_VAR_NAME, '1')
         # Parse excluded_tests and flatten into space separated string

--- a/easybuild/easyblocks/p/pytorch.py
+++ b/easybuild/easyblocks/p/pytorch.py
@@ -637,11 +637,11 @@ class EB_PyTorch(PythonPackage):
         env.setvar('SKIP_TEST_BOTTLENECK', '1')
         env.setvar('MAX_JOBS', str(self.cfg.parallel))
         if not os.environ.get('OMP_NUM_THREADS'):
-            # Similar to upstream .ci/pytorch/test.sh:
+            # Similar to https://github.com/pytorch/pytorch/blob/main/.ci/pytorch/test.sh:
             # Limit to a quarter of the CPUs (or less if parallel is set)
             # and leave some headroom for NUM_PROCS=3 parallel tests.
             # Use at least 4 threads to avoid numerical mismatches from changed FP reductions.
-            env.setvar('OMP_NUM_THREADS', max(4, self.parallel / 4))
+            env.setvar('OMP_NUM_THREADS', str(max(4, self.cfg.parallel // 4)))
         if self.has_xml_test_reports:
             env.setvar(self.GENERATE_TEST_REPORT_VAR_NAME, '1')
         # Parse excluded_tests and flatten into space separated string


### PR DESCRIPTION
Using all processors causes slowdowns due to switching when using busy-waits/spinlocks in OpenMP. Using nproc/4 leaves headroom for the main thread and for NUM_PROCS=3 parallel test processes. Using low OMP_NUM_THREADS (1-2) changes floating-point reduction order, causing numerical mismatches in tests with tight tolerances. Hence use at least 4 threads.

Use the set `parallel` which can be the number of cores or lower when restricted by the user.