### PR TITLE
fixes for LAMMPS easyblock: set `$LD_PRELOAD` when crosscompiling NVIDIA GPU build on CPU-only system + disable Arm NEON to work around failing build on Arm when using CUDA < 13.2

### DIFF
--- a/easybuild/easyblocks/k/kokkos.py
+++ b/easybuild/easyblocks/k/kokkos.py
@@ -1,4 +1,4 @@
-## 
+##
 # Copyright 2016-2026 Ghent University
 #
 # This file is part of EasyBuild,

--- a/easybuild/easyblocks/k/kokkos.py
+++ b/easybuild/easyblocks/k/kokkos.py
@@ -1,4 +1,4 @@
-##
+## 
 # Copyright 2016-2026 Ghent University
 #
 # This file is part of EasyBuild,

--- a/easybuild/easyblocks/k/kokkos.py
+++ b/easybuild/easyblocks/k/kokkos.py
@@ -62,7 +62,7 @@ KOKKOS_CPU_ARCH_LIST = [
     'ZEN3',  # AMD Zen3 class CPU (AVX 2)
     'ZEN4',  # AMD Zen4 class CPU (AVX-512), since Kokkos 4.6
     'ZEN5',  # AMD Zen5 class CPU (AVX-512), since Kokkos 4.7
-    'ARMV80',  # ARMv8.0 Compatible CPU
+    'ARMV80',  # ARMv8.0 Compatible CPU 
     'ARMV81',  # ARMv8.1 Compatible CPU
     'ARMV8_THUNDERX',  # ARMv8 Cavium ThunderX CPU
     'ARMV8_THUNDERX2',  # ARMv8 Cavium ThunderX2 CPU

--- a/easybuild/easyblocks/k/kokkos.py
+++ b/easybuild/easyblocks/k/kokkos.py
@@ -68,7 +68,7 @@ KOKKOS_CPU_ARCH_LIST = [
     'ARMV8_THUNDERX2',  # ARMv8 Cavium ThunderX2 CPU
     'A64FX',  # ARMv8.2 with SVE Support
     'ARMV9_GRACE',  # ARMv9 NVIDIA Grace CPU, since Kokkos 4.4.1
-    'ARMV84',  # ARMv8.4 Compatible CPU 
+    'ARMV84',  # ARMv8.4 Compatible CPU
     'ARMV84_SVE',  # ARMv8.4 with SVE compatible CPU
     'BGQ',  # IBM Blue Gene/Q CPU
     'POWER7',  # IBM POWER7 CPU

--- a/easybuild/easyblocks/k/kokkos.py
+++ b/easybuild/easyblocks/k/kokkos.py
@@ -62,7 +62,7 @@ KOKKOS_CPU_ARCH_LIST = [
     'ZEN3',  # AMD Zen3 class CPU (AVX 2)
     'ZEN4',  # AMD Zen4 class CPU (AVX-512), since Kokkos 4.6
     'ZEN5',  # AMD Zen5 class CPU (AVX-512), since Kokkos 4.7
-    'ARMV80',  # ARMv8.0 Compatible CPU 
+    'ARMV80',  # ARMv8.0 Compatible CPU
     'ARMV81',  # ARMv8.1 Compatible CPU
     'ARMV8_THUNDERX',  # ARMv8 Cavium ThunderX CPU
     'ARMV8_THUNDERX2',  # ARMv8 Cavium ThunderX2 CPU

--- a/easybuild/easyblocks/k/kokkos.py
+++ b/easybuild/easyblocks/k/kokkos.py
@@ -69,7 +69,7 @@ KOKKOS_CPU_ARCH_LIST = [
     'A64FX',  # ARMv8.2 with SVE Support
     'ARMV9_GRACE',  # ARMv9 NVIDIA Grace CPU, since Kokkos 4.4.1
     'ARMV84', # ARMv8.4 Compatible CPU
-    'ARMV84_SVE' # ARMv8.4 with SVE compatible CPU
+    'ARMV84_SVE', # ARMv8.4 with SVE compatible CPU
     'BGQ',  # IBM Blue Gene/Q CPU
     'POWER7',  # IBM POWER7 CPU
     'POWER8',  # IBM POWER8 CPU

--- a/easybuild/easyblocks/k/kokkos.py
+++ b/easybuild/easyblocks/k/kokkos.py
@@ -68,8 +68,8 @@ KOKKOS_CPU_ARCH_LIST = [
     'ARMV8_THUNDERX2',  # ARMv8 Cavium ThunderX2 CPU
     'A64FX',  # ARMv8.2 with SVE Support
     'ARMV9_GRACE',  # ARMv9 NVIDIA Grace CPU, since Kokkos 4.4.1
-    'ARMV84', # ARMv8.4 Compatible CPU
-    'ARMV84_SVE', # ARMv8.4 with SVE compatible CPU
+    'ARMV84',  # ARMv8.4 Compatible CPU
+    'ARMV84_SVE',  # ARMv8.4 with SVE compatible CPU
     'BGQ',  # IBM Blue Gene/Q CPU
     'POWER7',  # IBM POWER7 CPU
     'POWER8',  # IBM POWER8 CPU

--- a/easybuild/easyblocks/k/kokkos.py
+++ b/easybuild/easyblocks/k/kokkos.py
@@ -68,6 +68,8 @@ KOKKOS_CPU_ARCH_LIST = [
     'ARMV8_THUNDERX2',  # ARMv8 Cavium ThunderX2 CPU
     'A64FX',  # ARMv8.2 with SVE Support
     'ARMV9_GRACE',  # ARMv9 NVIDIA Grace CPU, since Kokkos 4.4.1
+    'ARMV84', # ARMv8.4 Compatible CPU
+    'ARMV84_SVE' # ARMv8.4 with SVE compatible CPU
     'BGQ',  # IBM Blue Gene/Q CPU
     'POWER7',  # IBM POWER7 CPU
     'POWER8',  # IBM POWER8 CPU

--- a/easybuild/easyblocks/k/kokkos.py
+++ b/easybuild/easyblocks/k/kokkos.py
@@ -68,7 +68,7 @@ KOKKOS_CPU_ARCH_LIST = [
     'ARMV8_THUNDERX2',  # ARMv8 Cavium ThunderX2 CPU
     'A64FX',  # ARMv8.2 with SVE Support
     'ARMV9_GRACE',  # ARMv9 NVIDIA Grace CPU, since Kokkos 4.4.1
-    'ARMV84',  # ARMv8.4 Compatible CPU
+    'ARMV84',  # ARMv8.4 Compatible CPU 
     'ARMV84_SVE',  # ARMv8.4 with SVE compatible CPU
     'BGQ',  # IBM Blue Gene/Q CPU
     'POWER7',  # IBM POWER7 CPU

--- a/easybuild/easyblocks/k/kokkos.py
+++ b/easybuild/easyblocks/k/kokkos.py
@@ -64,12 +64,12 @@ KOKKOS_CPU_ARCH_LIST = [
     'ZEN5',  # AMD Zen5 class CPU (AVX-512), since Kokkos 4.7
     'ARMV80',  # ARMv8.0 Compatible CPU
     'ARMV81',  # ARMv8.1 Compatible CPU
+    'ARMV84',  # ARMv8.4 Compatible CPU
+    'ARMV84_SVE',  # ARMv8.4 with SVE compatible CPU
     'ARMV8_THUNDERX',  # ARMv8 Cavium ThunderX CPU
     'ARMV8_THUNDERX2',  # ARMv8 Cavium ThunderX2 CPU
     'A64FX',  # ARMv8.2 with SVE Support
     'ARMV9_GRACE',  # ARMv9 NVIDIA Grace CPU, since Kokkos 4.4.1
-    'ARMV84',  # ARMv8.4 Compatible CPU
-    'ARMV84_SVE',  # ARMv8.4 with SVE compatible CPU
     'BGQ',  # IBM Blue Gene/Q CPU
     'POWER7',  # IBM POWER7 CPU
     'POWER8',  # IBM POWER8 CPU

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -639,6 +639,11 @@ class EB_LAMMPS(CMakeMake):
                         'from lammps import lammps; l=lammps(cmdargs=["-sf", "kk", "-k", "on", "g", "1"]); '
                         'l.file("%s")' % os.path.join(self.installdir, "examples", "msst", "in.msst")
                     )
+                else: # disable gpu when no gpu pressent
+                    custom_commands.append(
+                        'from lammps import lammps; l=lammps(cmdargs=["-sf", "kk", "-k", "on", "g", "0"]); '
+                        'l.file("%s")' % os.path.join(self.installdir, "examples", "msst", "in.msst")
+                    )
             else:  # CPU only
                 custom_commands.append(
                     'from lammps import lammps; l=lammps(cmdargs=["-sf", "kk", "-k", "on"]); l.file("%s")' %

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -47,7 +47,7 @@ from easybuild.framework.easyconfig import CUSTOM, MANDATORY
 from easybuild.tools.build_log import EasyBuildError, print_warning, print_msg
 from easybuild.tools.config import build_option, IGNORE
 from easybuild.tools.filetools import copy_dir, copy_file, mkdir, read_file, which
-from easybuild.tools.modules import get_software_root, get_software_version
+from easybuild.tools.modules import get_software_root, get_software_version, modules_tool
 from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.systemtools import AARCH64, get_cpu_architecture, get_shared_lib_ext, get_avail_core_count, get_gpu_info
 from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
@@ -509,14 +509,21 @@ class EB_LAMMPS(CMakeMake):
             else:
                 self.cfg['runtest'] = False
 
+        # For crosscompiling LAMMPS with CUDA:
+        # - CUDA stubs need to be explicitly added to the linker
+        # - libcuda.so needs to be added to LD_PRELOAD 
         if self.cuda:
             gpus = get_gpu_info()
             if 'NVIDIA' not in gpus:
-               ld_preload = os.getenv('LD_PRELOAD', '')
-               cuda_root = get_software_root('CUDA')
-               libcuda = cuda_root + '/stubs/lib/libcuda.so' + ':' + cuda_root + '/stubs/lib/libcuda.so.1'
-               ld_preload = libcuda + ":" + ld_preload 
-               env.setvar('LD_PRELOAD', ld_preload)
+                cuda_root = get_software_root('CUDA')
+                libcuda = '%s/lib/stubs/libcuda.so:%s/lib64/stubs/libcuda.so.1' % (cuda_root, cuda_root)
+                self.cfg.update('configopts', '-DCMAKE_EXE_LINKER_FLAGS=-Wl,-rpath-link,%s/lib/stubs' % cuda_root)
+                ld_preload = os.getenv('LD_PRELOAD', '')
+                if ld_preload == '':
+                    self.ld_preload = libcuda
+                else:
+                    self.ld_preload = '%s:%s' % (ld_preload, libcuda)
+                env.setvar('LD_PRELOAD', self.ld_preload)
 
         return super().configure_step()
 
@@ -673,6 +680,25 @@ class EB_LAMMPS(CMakeMake):
             test_core_cnt = min(self.cfg.parallel, get_avail_core_count(), 4)
             self.log.info("Using %s cores for the MPI tests" % test_core_cnt)
             custom_commands = [self.toolchain.mpi_cmd_for(cmd, test_core_cnt) for cmd in custom_commands]
+
+        # When crosscompiling LAMMPS with CUDA the build and testing require LD_PRELOAD being set.
+        # During testing I found that LD_PRELOAD was not picked up in the environment.
+        # It has to be explicitly set in the command.
+        if self.cuda:
+            gpus = get_gpu_info()
+            if 'NVIDIA' not in gpus:
+                ld_preload = os.getenv('LD_PRELOAD', '')
+                # When running --module-only or --sanity-check-only LD_PRELOAD will not be set.
+                # Checking if libcuda.so is in LD_PRELOAD.
+                if 'libcuda.so' not in ld_preload:
+                    cuda_root = get_software_root('CUDA')
+                    libcuda = cuda_root + '/stubs/lib/libcuda.so' + ':' + cuda_root + '/stubs/lib/libcuda.so.1'
+                    if ld_preload == '':
+                        ld_preload = libcuda
+                    else:
+                        ld_preload = '%s:%s' % (ld_preload, libcuda)
+                ld_preload = 'LD_PRELOAD=%s' % ld_preload 
+                custom_commands = [ ld_preload + " " + cmd for cmd in custom_commands]
 
         custom_commands = ["cd %s && " % execution_dir + cmd for cmd in custom_commands]
 

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -698,7 +698,7 @@ class EB_LAMMPS(CMakeMake):
                         ld_preload = libcuda
                     else:
                         ld_preload = '%s:%s' % (ld_preload, libcuda)
-                ld_preload = 'LD_PRELOAD=%s' % ld_preload 
+                ld_preload = 'LD_PRELOAD=%s' % ld_preload
                 custom_commands = [ld_preload + " " + cmd for cmd in custom_commands]
 
         custom_commands = ["cd %s && " % execution_dir + cmd for cmd in custom_commands]

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -428,11 +428,13 @@ class EB_LAMMPS(CMakeMake):
                     self.cfg.update('configopts', '-DCMAKE_CXX_FLAGS="-ccbin $CXX $CXXFLAGS"')
                     self.cfg.update('configopts', '-D%s_ARCH="%s;%s"' % (self.kokkos_prefix, processor_arch, gpu_arch))
 
+                # Disabling ARM NEON as builds on ARM results in build errors for SIMD
+                # https://github.com/kokkos/kokkos/issues/7483 
                 if get_cpu_architecture() == AARCH64:
                     cuda_root = get_software_root('CUDA')
                     if os.path.basename(cuda_root) in ['12.6.0', '12.1.1', '12.4.0']:
-                        self.cfg.update('configopts', '-D%s_ARCH_ARM_NEON=OFF' % (self.kokkos_prefix)) 
-                
+                        self.cfg.update('configopts', '-D%s_ARCH_ARM_NEON=OFF' % (self.kokkos_prefix))
+
             else:
                 if LooseVersion(self.cur_version) >= LooseVersion(self.ref_version):
                     self.cfg.update('configopts', '-D%s_ARCH_%s=yes' % (self.kokkos_prefix, processor_arch))

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -622,7 +622,7 @@ class EB_LAMMPS(CMakeMake):
             if self.cfg['kokkos']:
                 if self.cuda:
                     if run_gpu_tests == False:
-                        lammps_cmd_args = 'cmdargs=["-sf", "kk", "-k", "on"]'
+                        lammps_cmd_args = 'cmdargs=["-sf", "kk", "-k", "on", "neigh", "no"]'
 
 
         custom_commands = [

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -622,7 +622,7 @@ class EB_LAMMPS(CMakeMake):
             if self.cfg['kokkos']:
                 if self.cuda:
                     if run_gpu_tests == False:
-                        lammps_cmd_args = 'cmdargs=["-sf", "kk", "-k", "on", "g", "0"]'
+                        lammps_cmd_args = 'cmdargs=["-sf", "kk", "-k", "on"]'
 
 
         custom_commands = [

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -429,7 +429,7 @@ class EB_LAMMPS(CMakeMake):
                     self.cfg.update('configopts', '-D%s_ARCH="%s;%s"' % (self.kokkos_prefix, processor_arch, gpu_arch))
 
                 # Disabling ARM NEON as builds on ARM results in build errors for SIMD
-                # See https://github.com/kokkos/kokkos/issues/7483
+                # See https://github.com/kokkos/kokkos/issues/7483 
                 if get_cpu_architecture() == AARCH64:
                     cuda_root = get_software_root('CUDA')
                     if LooseVersion(os.path.basename(cuda_root)) < '13.2.0':

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -622,7 +622,7 @@ class EB_LAMMPS(CMakeMake):
             if self.cfg['kokkos']:
                 if self.cuda:
                     if run_gpu_tests == False:
-                        lammps_cmd_args = 'cmdargs=["-sf", "kk", "-k", "on", "neigh", "no"]'
+                        lammps_cmd_args = 'cmdargs=["-sf", "kk", "-k", "off"]'
 
 
         custom_commands = [

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -588,6 +588,16 @@ class EB_LAMMPS(CMakeMake):
     def sanity_check_step(self, *args, **kwargs):
         """Run custom sanity checks for LAMMPS files, dirs and commands."""
 
+        # check if a GPU is available for tests
+        run_gpu_tests = False
+        if self.cuda:
+            if not which('nvidia-smi', on_error=IGNORE):
+                print_warning('Could not find nvidia-smi. Assuming a system without GPUs and skipping GPU tests!')
+            elif os.environ.get('CUDA_VISIBLE_DEVICES') == '-1':
+                print_warning('GPUs explicitely disabled via CUDA_VISIBLE_DEVICES. Skipping GPU tests!')
+            else:
+                run_gpu_tests = True
+
         # Set cur_version when running --sanity-check-only
         if self.cur_version is None:
             self.cur_version = translate_lammps_version(self.version, path=self.installdir)
@@ -605,24 +615,26 @@ class EB_LAMMPS(CMakeMake):
                 'nemd', 'obstacle', 'pour', 'voronoi',
             ]
 
+        # From 22Jul2025 LAMMPS with kokkos requires libcuda.so.1 when running the tests.
+        # When no gpus are present it should be explicitly disabled.
+        lammps_cmd_args = ''
+        if LooseVersion(self.version) >= LooseVersion('22Jul2025'):
+            if self.kokos:
+                if self.cuda:
+                    if run_gpu_tests == False:
+                        cmd_args = 'cmdargs=["-sf", "kk", "-k", "on", "g", "0"]'
+
+
         custom_commands = [
             # LAMMPS test - you need to call specific test file on path
-            'from lammps import lammps; l=lammps(); l.file("%s")' %
-            # Examples are part of the install with paths like (installdir)/examples/filename/in.filename
-            os.path.join(self.installdir, "examples", "%s" % check_file, "in.%s" % check_file)
+            'from lammps import lammps; l=lammps(%s); l.file("%s")' % (
+                lammps_cmd_args,
+                # Examples are part of the install with paths like (installdir)/examples/filename/in.filename
+                os.path.join(self.installdir, "examples", "%s" % check_file, "in.%s" % check_file)
+            )
             # And this should be done for every file specified above
             for check_file in sanity_check_test_inputs
         ]
-
-        # check if a GPU is available for tests
-        run_gpu_tests = False
-        if self.cuda:
-            if not which('nvidia-smi', on_error=IGNORE):
-                print_warning('Could not find nvidia-smi. Assuming a system without GPUs and skipping GPU tests!')
-            elif os.environ.get('CUDA_VISIBLE_DEVICES') == '-1':
-                print_warning('GPUs explicitely disabled via CUDA_VISIBLE_DEVICES. Skipping GPU tests!')
-            else:
-                run_gpu_tests = True
 
         # add accelerator-specific tests
         # INTEL package - it requires mpi4py - run only for updated easyconfigs >= 29Aug2024
@@ -637,11 +649,6 @@ class EB_LAMMPS(CMakeMake):
                 if run_gpu_tests:
                     custom_commands.append(
                         'from lammps import lammps; l=lammps(cmdargs=["-sf", "kk", "-k", "on", "g", "1"]); '
-                        'l.file("%s")' % os.path.join(self.installdir, "examples", "msst", "in.msst")
-                    )
-                else: # disable gpu when no gpu pressent
-                    custom_commands.append(
-                        'from lammps import lammps; l=lammps(cmdargs=["-sf", "kk", "-k", "on", "g", "0"]); '
                         'l.file("%s")' % os.path.join(self.installdir, "examples", "msst", "in.msst")
                     )
             else:  # CPU only

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -622,7 +622,7 @@ class EB_LAMMPS(CMakeMake):
             if self.cfg['kokkos']:
                 if self.cuda:
                     if run_gpu_tests == False:
-                        cmd_args = 'cmdargs=["-sf", "kk", "-k", "on", "g", "0"]'
+                        lammps_cmd_args = 'cmdargs=["-sf", "kk", "-k", "on", "g", "0"]'
 
 
         custom_commands = [

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -221,9 +221,6 @@ class EB_LAMMPS(CMakeMake):
 
             # Disabling ARM NEON as builds on ARM results in build errors for SIMD
             # See https://github.com/kokkos/kokkos/issues/7483
-            print('DEBUG')
-            print(build_option('optarch'))
-            print(build_option('default_optarch'))
             if self.cfg['kokkos']:
                 if get_cpu_architecture() == AARCH64:
                     cuda_root = get_software_root('CUDA')

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -221,13 +221,16 @@ class EB_LAMMPS(CMakeMake):
 
             # Disabling ARM NEON as builds on ARM results in build errors for SIMD
             # See https://github.com/kokkos/kokkos/issues/7483
+            print('DEBUG')
+            print(build_option('optarch'))
+            print(build_option('default_optarch'))
             if self.cfg['kokkos']:
                 if get_cpu_architecture() == AARCH64:
                     cuda_root = get_software_root('CUDA')
                     if LooseVersion(os.path.basename(cuda_root)) < '13.2.0':
                         processor_arch = 'ARMV80'
                         print_msg("Overwrite determined cpu arch to build without NEON: %s" % processor_arch)
-                        
+
         # arch names changed between some releases :(
         if LooseVersion(self.cur_version) < LooseVersion(translate_lammps_version('29Oct2020')):
             if processor_arch in KOKKOS_LEGACY_ARCH_MAPPING.keys():
@@ -445,6 +448,7 @@ class EB_LAMMPS(CMakeMake):
                     if LooseVersion(os.path.basename(cuda_root)) < '13.2.0':
                         self.cfg.update('configopts', '-D%s_ARCH_ARM_NEON=off' % (self.kokkos_prefix))
                         self.cfg.update('configopts', '-D%s_ARCH_ARM_SVE=off' % (self.kokkos_prefix))
+                        self.cfg.update('configopts', '-DCMAKE_CXX_FLAGS="-DKOKKOS_ARCH_ARM_NEON=0 -DKOKKOS_ARCH_ARM_SVE=0"')
 
             else:
                 if LooseVersion(self.cur_version) >= LooseVersion(self.ref_version):

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -510,7 +510,8 @@ class EB_LAMMPS(CMakeMake):
                 self.cfg['runtest'] = False
 
         if self.cuda:
-            if not get_gpu_info():
+            gpus = get_gpu_info()
+            if 'NVIDIA' not in gpus:
                ld_preload = os.getenv('LD_PRELOAD', '')
                cuda_root = get_software_root('CUDA')
                libcuda = cuda_root + '/stubs/lib/libcuda.so' + ':' + cuda_root + '/stubs/lib/libcuda.so.1'

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -198,11 +198,6 @@ class EB_LAMMPS(CMakeMake):
 
             print_msg("Determined cpu arch: %s" % processor_arch)
 
-        # arch names changed between some releases :(
-        if LooseVersion(self.cur_version) < LooseVersion(translate_lammps_version('29Oct2020')):
-            if processor_arch in KOKKOS_LEGACY_ARCH_MAPPING.keys():
-                processor_arch = KOKKOS_LEGACY_ARCH_MAPPING[processor_arch]
-
         # GPU arch
         gpu_arch = None
         if self.cuda:
@@ -223,6 +218,21 @@ class EB_LAMMPS(CMakeMake):
                 error_msg = "Specified GPU ARCH (%s) " % cuda_cc
                 error_msg += "was not found in listed options [%s]." % KOKKOS_GPU_ARCH_TABLE
                 raise EasyBuildError(error_msg)
+
+            # Disabling ARM NEON as builds on ARM results in build errors for SIMD
+            # See https://github.com/kokkos/kokkos/issues/7483
+            if self.cfg['kokkos']:
+                if get_cpu_architecture() == AARCH64:
+                    cuda_root = get_software_root('CUDA')
+                    if LooseVersion(os.path.basename(cuda_root)) < '13.2.0':
+                        processor_arch = 'ARMV80'
+                        print_msg("Overwrite determined cpu arch to build without NEON: %s" % processor_arch)
+                        
+        # arch names changed between some releases :(
+        if LooseVersion(self.cur_version) < LooseVersion(translate_lammps_version('29Oct2020')):
+            if processor_arch in KOKKOS_LEGACY_ARCH_MAPPING.keys():
+                processor_arch = KOKKOS_LEGACY_ARCH_MAPPING[processor_arch]
+
 
         return processor_arch, gpu_arch
 
@@ -429,7 +439,7 @@ class EB_LAMMPS(CMakeMake):
                     self.cfg.update('configopts', '-D%s_ARCH="%s;%s"' % (self.kokkos_prefix, processor_arch, gpu_arch))
 
                 # Disabling ARM NEON as builds on ARM results in build errors for SIMD
-                # See https://github.com/kokkos/kokkos/issues/7483 
+                # See https://github.com/kokkos/kokkos/issues/7483
                 if get_cpu_architecture() == AARCH64:
                     cuda_root = get_software_root('CUDA')
                     if LooseVersion(os.path.basename(cuda_root)) < '13.2.0':

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -434,6 +434,7 @@ class EB_LAMMPS(CMakeMake):
                     cuda_root = get_software_root('CUDA')
                     if os.path.basename(cuda_root) in ['12.6.0', '12.1.1', '12.4.0']:
                         self.cfg.update('configopts', '-D%s_ARCH_ARM_NEON=OFF' % (self.kokkos_prefix))
+                        self.cfg.update('configopts', '-D%s_ARCH_ARM_SVE=OFF' % (self.kokkos_prefix))
 
             else:
                 if LooseVersion(self.cur_version) >= LooseVersion(self.ref_version):

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -433,7 +433,6 @@ class EB_LAMMPS(CMakeMake):
                     self.cfg.update('configopts', '-DCMAKE_CXX_COMPILER="%s"' % nvcc_wrapper_path)
                     self.cfg.update('configopts', '-DCMAKE_CXX_FLAGS="-ccbin $CXX $CXXFLAGS"')
                     self.cfg.update('configopts', '-D%s_ARCH="%s;%s"' % (self.kokkos_prefix, processor_arch, gpu_arch))
-
                 # Disabling ARM NEON as builds on ARM results in build errors for SIMD
                 # See https://github.com/kokkos/kokkos/issues/7483
                 if get_cpu_architecture() == AARCH64:
@@ -442,7 +441,6 @@ class EB_LAMMPS(CMakeMake):
                         cxxflags = os.getenv('CXXFLAGS', '')
                         cxxflags += ' -march=armv8-a+nosimd'
                         env.setvar('CXXFLAGS', cxxflags)
-
             else:
                 if LooseVersion(self.cur_version) >= LooseVersion(self.ref_version):
                     self.cfg.update('configopts', '-D%s_ARCH_%s=yes' % (self.kokkos_prefix, processor_arch))

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -588,16 +588,6 @@ class EB_LAMMPS(CMakeMake):
     def sanity_check_step(self, *args, **kwargs):
         """Run custom sanity checks for LAMMPS files, dirs and commands."""
 
-        # check if a GPU is available for tests
-        run_gpu_tests = False
-        if self.cuda:
-            if not which('nvidia-smi', on_error=IGNORE):
-                print_warning('Could not find nvidia-smi. Assuming a system without GPUs and skipping GPU tests!')
-            elif os.environ.get('CUDA_VISIBLE_DEVICES') == '-1':
-                print_warning('GPUs explicitely disabled via CUDA_VISIBLE_DEVICES. Skipping GPU tests!')
-            else:
-                run_gpu_tests = True
-
         # Set cur_version when running --sanity-check-only
         if self.cur_version is None:
             self.cur_version = translate_lammps_version(self.version, path=self.installdir)
@@ -615,26 +605,24 @@ class EB_LAMMPS(CMakeMake):
                 'nemd', 'obstacle', 'pour', 'voronoi',
             ]
 
-        # From 22Jul2025 LAMMPS with kokkos requires libcuda.so.1 when running the tests.
-        # When no gpus are present it should be explicitly disabled.
-        lammps_cmd_args = ''
-        if LooseVersion(self.version) >= LooseVersion('22Jul2025'):
-            if self.cfg['kokkos']:
-                if self.cuda:
-                    if run_gpu_tests == False:
-                        lammps_cmd_args = 'cmdargs=["-sf", "kk", "-k", "off"]'
-
-
         custom_commands = [
             # LAMMPS test - you need to call specific test file on path
-            'from lammps import lammps; l=lammps(%s); l.file("%s")' % (
-                lammps_cmd_args,
-                # Examples are part of the install with paths like (installdir)/examples/filename/in.filename
-                os.path.join(self.installdir, "examples", "%s" % check_file, "in.%s" % check_file)
-            )
+            'from lammps import lammps; l=lammps(); l.file("%s")' %
+            # Examples are part of the install with paths like (installdir)/examples/filename/in.filename
+            os.path.join(self.installdir, "examples", "%s" % check_file, "in.%s" % check_file)
             # And this should be done for every file specified above
             for check_file in sanity_check_test_inputs
         ]
+
+        # check if a GPU is available for tests
+        run_gpu_tests = False
+        if self.cuda:
+            if not which('nvidia-smi', on_error=IGNORE):
+                print_warning('Could not find nvidia-smi. Assuming a system without GPUs and skipping GPU tests!')
+            elif os.environ.get('CUDA_VISIBLE_DEVICES') == '-1':
+                print_warning('GPUs explicitely disabled via CUDA_VISIBLE_DEVICES. Skipping GPU tests!')
+            else:
+                run_gpu_tests = True
 
         # add accelerator-specific tests
         # INTEL package - it requires mpi4py - run only for updated easyconfigs >= 29Aug2024

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -47,9 +47,10 @@ from easybuild.framework.easyconfig import CUSTOM, MANDATORY
 from easybuild.tools.build_log import EasyBuildError, print_warning, print_msg
 from easybuild.tools.config import build_option, IGNORE
 from easybuild.tools.filetools import copy_dir, copy_file, mkdir, read_file, which
-from easybuild.tools.modules import get_software_root, get_software_version, modules_tool
+from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_shell_cmd
-from easybuild.tools.systemtools import AARCH64, get_cpu_architecture, get_shared_lib_ext, get_avail_core_count, get_gpu_info
+from easybuild.tools.systemtools import (AARCH64, get_cpu_architecture, get_shared_lib_ext,
+                                         get_avail_core_count, get_gpu_info)
 from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
 
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
@@ -511,7 +512,7 @@ class EB_LAMMPS(CMakeMake):
 
         # For crosscompiling LAMMPS with CUDA:
         # - CUDA stubs need to be explicitly added to the linker
-        # - libcuda.so needs to be added to LD_PRELOAD 
+        # - libcuda.so needs to be added to LD_PRELOAD
         if self.cuda:
             gpus = get_gpu_info()
             if 'NVIDIA' not in gpus:
@@ -698,7 +699,7 @@ class EB_LAMMPS(CMakeMake):
                     else:
                         ld_preload = '%s:%s' % (ld_preload, libcuda)
                 ld_preload = 'LD_PRELOAD=%s' % ld_preload 
-                custom_commands = [ ld_preload + " " + cmd for cmd in custom_commands]
+                custom_commands = [ld_preload + " " + cmd for cmd in custom_commands]
 
         custom_commands = ["cd %s && " % execution_dir + cmd for cmd in custom_commands]
 

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -429,7 +429,7 @@ class EB_LAMMPS(CMakeMake):
                     self.cfg.update('configopts', '-D%s_ARCH="%s;%s"' % (self.kokkos_prefix, processor_arch, gpu_arch))
 
                 # Disabling ARM NEON as builds on ARM results in build errors for SIMD
-                # https://github.com/kokkos/kokkos/issues/7483
+                # See https://github.com/kokkos/kokkos/issues/7483
                 if get_cpu_architecture() == AARCH64:
                     cuda_root = get_software_root('CUDA')
                     if os.path.basename(cuda_root) in ['12.6.0', '12.1.1', '12.4.0']:

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -49,7 +49,7 @@ from easybuild.tools.config import build_option, IGNORE
 from easybuild.tools.filetools import copy_dir, copy_file, mkdir, read_file, which
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_shell_cmd
-from easybuild.tools.systemtools import AARCH64, get_cpu_architecture, get_shared_lib_ext, get_avail_core_count
+from easybuild.tools.systemtools import AARCH64, get_cpu_architecture, get_shared_lib_ext, get_avail_core_count, get_gpu_info
 from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
 
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
@@ -509,10 +509,29 @@ class EB_LAMMPS(CMakeMake):
             else:
                 self.cfg['runtest'] = False
 
+        if self.cuda:
+            if not get_gpu_info():
+               ld_preload = os.getenv('LD_PRELOAD', '')
+               cuda_root = get_software_root('CUDA')
+               libcuda = cuda_root + '/stubs/lib/libcuda.so' + ':' + cuda_root + '/stubs/lib/libcuda.so.1'
+               ld_preload = libcuda + ":" + ld_preload
+             
+               env.setvar('LD_PRELOAD', ld_preload)
+               print(cuda_root)
+               print(ld_preload) 
+
         return super().configure_step()
 
+    def build_step(self):
+        """DEBUG"""
+        cuda_root = get_software_root('CUDA')
+        print(cuda_root)
+        ld_preload = os.getenv('LD_PRELOAD', '')
+        print(ld_preload)
+        return super().build_step()
+
     def install_step(self):
-        """Install LAMMPS and examples/potentials."""
+        """Install LAMMPS and examples/potentials.""" 
         super().install_step()
 
         # Copy LICENSE and version file so these can be used with `--module-only`

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -432,9 +432,9 @@ class EB_LAMMPS(CMakeMake):
                 # See https://github.com/kokkos/kokkos/issues/7483
                 if get_cpu_architecture() == AARCH64:
                     cuda_root = get_software_root('CUDA')
-                    if os.path.basename(cuda_root) in ['12.6.0', '12.1.1', '12.4.0']:
-                        self.cfg.update('configopts', '-D%s_ARCH_ARM_NEON=OFF' % (self.kokkos_prefix))
-                        self.cfg.update('configopts', '-D%s_ARCH_ARM_SVE=OFF' % (self.kokkos_prefix))
+                    if LooseVersion(os.path.basename(cuda_root)) < '13.2.0':
+                        self.cfg.update('configopts', '-D%s_ARCH_ARM_NEON=off' % (self.kokkos_prefix))
+                        self.cfg.update('configopts', '-D%s_ARCH_ARM_SVE=off' % (self.kokkos_prefix))
 
             else:
                 if LooseVersion(self.cur_version) >= LooseVersion(self.ref_version):

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -521,7 +521,7 @@ class EB_LAMMPS(CMakeMake):
         return super().configure_step()
 
     def install_step(self):
-        """Install LAMMPS and examples/potentials.""" 
+        """Install LAMMPS and examples/potentials."""
         super().install_step()
 
         # Copy LICENSE and version file so these can be used with `--module-only`
@@ -658,7 +658,6 @@ class EB_LAMMPS(CMakeMake):
             'from lammps import lammps; l=lammps(cmdargs=["-sf", "opt"]); l.file("%s")' %
             os.path.join(self.installdir, "examples", "msst", "in.msst")
         )
-
 
         # mpirun command needs an l.finalize() in the sanity check from LAMMPS 29Sep2021
         # This is actually not needed if mpi4py is installed, and can cause a crash in version 2025+

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -198,6 +198,11 @@ class EB_LAMMPS(CMakeMake):
 
             print_msg("Determined cpu arch: %s" % processor_arch)
 
+        # arch names changed between some releases :(
+        if LooseVersion(self.cur_version) < LooseVersion(translate_lammps_version('29Oct2020')):
+            if processor_arch in KOKKOS_LEGACY_ARCH_MAPPING.keys():
+                processor_arch = KOKKOS_LEGACY_ARCH_MAPPING[processor_arch]
+
         # GPU arch
         gpu_arch = None
         if self.cuda:
@@ -218,21 +223,6 @@ class EB_LAMMPS(CMakeMake):
                 error_msg = "Specified GPU ARCH (%s) " % cuda_cc
                 error_msg += "was not found in listed options [%s]." % KOKKOS_GPU_ARCH_TABLE
                 raise EasyBuildError(error_msg)
-
-            # Disabling ARM NEON as builds on ARM results in build errors for SIMD
-            # See https://github.com/kokkos/kokkos/issues/7483
-            if self.cfg['kokkos']:
-                if get_cpu_architecture() == AARCH64:
-                    cuda_root = get_software_root('CUDA')
-                    if LooseVersion(os.path.basename(cuda_root)) < '13.2.0':
-                        processor_arch = 'ARMV80'
-                        print_msg("Overwrite determined cpu arch to build without NEON: %s" % processor_arch)
-
-        # arch names changed between some releases :(
-        if LooseVersion(self.cur_version) < LooseVersion(translate_lammps_version('29Oct2020')):
-            if processor_arch in KOKKOS_LEGACY_ARCH_MAPPING.keys():
-                processor_arch = KOKKOS_LEGACY_ARCH_MAPPING[processor_arch]
-
 
         return processor_arch, gpu_arch
 
@@ -430,7 +420,13 @@ class EB_LAMMPS(CMakeMake):
                 nvcc_wrapper_path = os.path.join(self.start_dir, "lib", "kokkos", "bin", "nvcc_wrapper")
                 self.cfg.update('configopts', '-D%s_ENABLE_CUDA=yes' % self.kokkos_prefix)
                 if LooseVersion(self.cur_version) >= LooseVersion(self.ref_version):
-                    self.cfg.update('configopts', '-D%s_ARCH_%s=yes' % (self.kokkos_prefix, processor_arch))
+                    # Disabling ARM NEON as builds on ARM results in build errors for SIMD
+                    # See https://github.com/kokkos/kokkos/issues/7483
+                    cuda_root = get_software_root('CUDA')
+                    if get_cpu_architecture() == AARCH64 and LooseVersion(os.path.basename(cuda_root)) < '13.2.0':
+                        self.cfg.update('configopts', '-D%s_ARCH_%s=no' % (self.kokkos_prefix, processor_arch))
+                    else:
+                        self.cfg.update('configopts', '-D%s_ARCH_%s=yes' % (self.kokkos_prefix, processor_arch))
                     self.cfg.update('configopts', '-D%s_ARCH_%s=yes' % (self.kokkos_prefix, gpu_arch))
                 else:
                     # Older versions of Kokkos required us to tweak the C++ compiler
@@ -443,9 +439,9 @@ class EB_LAMMPS(CMakeMake):
                 if get_cpu_architecture() == AARCH64:
                     cuda_root = get_software_root('CUDA')
                     if LooseVersion(os.path.basename(cuda_root)) < '13.2.0':
-                        self.cfg.update('configopts', '-D%s_ARCH_ARM_NEON=off' % (self.kokkos_prefix))
-                        self.cfg.update('configopts', '-D%s_ARCH_ARM_SVE=off' % (self.kokkos_prefix))
-                        self.cfg.update('configopts', '-DCMAKE_CXX_FLAGS="-DKOKKOS_ARCH_ARM_NEON=0 -DKOKKOS_ARCH_ARM_SVE=0"')
+                        cxxflags = os.getenv('CXXFLAGS', '')
+                        cxxflags += ' -march=armv8-a+nosimd'
+                        env.setvar('CXXFLAGS', cxxflags)
 
             else:
                 if LooseVersion(self.cur_version) >= LooseVersion(self.ref_version):

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -429,7 +429,7 @@ class EB_LAMMPS(CMakeMake):
                     self.cfg.update('configopts', '-D%s_ARCH="%s;%s"' % (self.kokkos_prefix, processor_arch, gpu_arch))
 
                 # Disabling ARM NEON as builds on ARM results in build errors for SIMD
-                # https://github.com/kokkos/kokkos/issues/7483 
+                # https://github.com/kokkos/kokkos/issues/7483
                 if get_cpu_architecture() == AARCH64:
                     cuda_root = get_software_root('CUDA')
                     if os.path.basename(cuda_root) in ['12.6.0', '12.1.1', '12.4.0']:

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -427,6 +427,12 @@ class EB_LAMMPS(CMakeMake):
                     self.cfg.update('configopts', '-DCMAKE_CXX_COMPILER="%s"' % nvcc_wrapper_path)
                     self.cfg.update('configopts', '-DCMAKE_CXX_FLAGS="-ccbin $CXX $CXXFLAGS"')
                     self.cfg.update('configopts', '-D%s_ARCH="%s;%s"' % (self.kokkos_prefix, processor_arch, gpu_arch))
+
+                if get_cpu_architecture() == AARCH64:
+                    cuda_root = get_software_root('CUDA')
+                    if os.path.basename(cuda_root) in ['12.6.0', '12.1.1', '12.4.0']:
+                        self.cfg.update('configopts', '-D%s_ARCH_ARM_NEON=OFF' % (self.kokkos_prefix)) 
+                
             else:
                 if LooseVersion(self.cur_version) >= LooseVersion(self.ref_version):
                     self.cfg.update('configopts', '-D%s_ARCH_%s=yes' % (self.kokkos_prefix, processor_arch))

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -510,26 +510,14 @@ class EB_LAMMPS(CMakeMake):
                 self.cfg['runtest'] = False
 
         if self.cuda:
-            gpus = get_gpu_info()
-            if 'NVIDIA' not in gpus:
+            if not get_gpu_info():
                ld_preload = os.getenv('LD_PRELOAD', '')
                cuda_root = get_software_root('CUDA')
                libcuda = cuda_root + '/stubs/lib/libcuda.so' + ':' + cuda_root + '/stubs/lib/libcuda.so.1'
-               ld_preload = libcuda + ":" + ld_preload
-             
+               ld_preload = libcuda + ":" + ld_preload 
                env.setvar('LD_PRELOAD', ld_preload)
-               print(cuda_root)
-               print(ld_preload) 
 
         return super().configure_step()
-
-    def build_step(self):
-        """DEBUG"""
-        cuda_root = get_software_root('CUDA')
-        print(cuda_root)
-        ld_preload = os.getenv('LD_PRELOAD', '')
-        print(ld_preload)
-        return super().build_step()
 
     def install_step(self):
         """Install LAMMPS and examples/potentials.""" 
@@ -583,7 +571,13 @@ class EB_LAMMPS(CMakeMake):
             test_cmd = 'ctest'
             if LooseVersion(self.cmake_version) >= '3.17.0':
                 test_cmd += ' --no-tests=error'
-            test_cmd += ' -LE unstable -E "TestMliapPyUnified|AtomicPairStyle:meam_spline|KSpaceStyle:scafacos.*"'
+            skipped_tests = "TestMliapPyUnified|AtomicPairStyle:meam_spline|KSpaceStyle:scafacos.*"
+            if self.cuda:
+                gpus = get_gpu_info()
+                if 'NVIDIA' not in gpus:
+                    # These tests require libcuda.so that is not a stub
+                    skipped_tests += "|LibraryOpen|LibraryProperties|LammpsClass|NeighborClass"
+            test_cmd += ' -LE unstable -E "%s"' % skipped_tests
             self.log.debug(f"Running tests using test_cmd = '{test_cmd}' as test_cmd")
             self.cfg['test_cmd'] = test_cmd
 
@@ -663,6 +657,7 @@ class EB_LAMMPS(CMakeMake):
             'from lammps import lammps; l=lammps(cmdargs=["-sf", "opt"]); l.file("%s")' %
             os.path.join(self.installdir, "examples", "msst", "in.msst")
         )
+
 
         # mpirun command needs an l.finalize() in the sanity check from LAMMPS 29Sep2021
         # This is actually not needed if mpi4py is installed, and can cause a crash in version 2025+

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -619,7 +619,7 @@ class EB_LAMMPS(CMakeMake):
         # When no gpus are present it should be explicitly disabled.
         lammps_cmd_args = ''
         if LooseVersion(self.version) >= LooseVersion('22Jul2025'):
-            if self.kokos:
+            if self.cfg['kokkos']:
                 if self.cuda:
                     if run_gpu_tests == False:
                         cmd_args = 'cmdargs=["-sf", "kk", "-k", "on", "g", "0"]'

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -113,6 +113,7 @@ def translate_lammps_version(version, path=None):
 
 def get_ld_preload_value_cuda_stubs():
     """
+    Determine value for $LD_PRELOAD that includes CUDA stub libraries
     """
     ld_preload = os.getenv('LD_PRELOAD')
     ld_preload = ld_preload.split(os.pathsep) if ld_preload else []

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -180,7 +180,6 @@ class EB_LAMMPS(CMakeMake):
             # and it should use the compiler (optimization) flags set by EasyBuild for this architecture.
             if get_cpu_architecture() == AARCH64:
                 processor_arch = 'ARMV80'
-                    
             else:
                 processor_arch = 'EASYBUILD_GENERIC'
             _log.info("Generic build requested, setting CPU ARCH to %s." % processor_arch)
@@ -430,16 +429,12 @@ class EB_LAMMPS(CMakeMake):
                 nvcc_wrapper_path = os.path.join(self.start_dir, "lib", "kokkos", "bin", "nvcc_wrapper")
                 self.cfg.update('configopts', '-D%s_ENABLE_CUDA=yes' % self.kokkos_prefix)
                 if LooseVersion(self.cur_version) >= LooseVersion(self.ref_version):
+                    self.cfg.update('configopts', '-D%s_ARCH_%s=yes' % (self.kokkos_prefix, processor_arch))
                     # Disabling ARM NEON as builds on ARM results in build errors for SIMD
                     # See https://github.com/kokkos/kokkos/issues/7483
                     cuda_root = get_software_root('CUDA')
-                    self.cfg.update('configopts', '-D%s_ARCH_%s=yes' % (self.kokkos_prefix, processor_arch))
                     if get_cpu_architecture() == AARCH64 and LooseVersion(os.path.basename(cuda_root)) < '13.2.0':
-                        #self.cfg.update('configopts', '-D%s_ARCH_%s=no' % (self.kokkos_prefix, processor_arch))
-                        #self.cfg.update('configopts', '-D%s_ARCH_ARM81=yes' % self.kokkos_prefix)
                         self.cfg.update('configopts', '-D%s_ARCH_ARM_NEON=no' % self.kokkos_prefix)
-                    #else:
-                        #self.cfg.update('configopts', '-D%s_ARCH_%s=yes' % (self.kokkos_prefix, processor_arch))
                     self.cfg.update('configopts', '-D%s_ARCH_%s=yes' % (self.kokkos_prefix, gpu_arch))
                 else:
                     # Older versions of Kokkos required us to tweak the C++ compiler

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -435,6 +435,9 @@ class EB_LAMMPS(CMakeMake):
                     cuda_root = get_software_root('CUDA')
                     if get_cpu_architecture() == AARCH64 and LooseVersion(os.path.basename(cuda_root)) < '13.2.0':
                         self.cfg.update('configopts', '-D%s_ARCH_ARM_NEON=no' % self.kokkos_prefix)
+                        # For neoverse-v2 we need to also disable SVE
+                        if processor_arch == 'ARMV9_GRACE':
+                            self.cfg.update('configopts', '-D%s_ARCH_ARM_SVE=no' % self.kokkos_prefix)
                     self.cfg.update('configopts', '-D%s_ARCH_%s=yes' % (self.kokkos_prefix, gpu_arch))
                 else:
                     # Older versions of Kokkos required us to tweak the C++ compiler

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -54,6 +54,11 @@ from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
 
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 
+AARCH64_MARCH_MAPPING = {
+    'neoverse_v1': 'armv8.4',
+    'neoverse_n1': 'armv8.2',
+    'neoverse_v2': 'armv9',
+}
 
 # lammps version, which caused the most changes. This may not be precise, but it does work with existing easyconfigs
 ref_version = '29Sep2021'
@@ -175,6 +180,7 @@ class EB_LAMMPS(CMakeMake):
             # and it should use the compiler (optimization) flags set by EasyBuild for this architecture.
             if get_cpu_architecture() == AARCH64:
                 processor_arch = 'ARMV80'
+                    
             else:
                 processor_arch = 'EASYBUILD_GENERIC'
             _log.info("Generic build requested, setting CPU ARCH to %s." % processor_arch)
@@ -184,7 +190,11 @@ class EB_LAMMPS(CMakeMake):
             # for LAMMPS >= 2Aug2023: use native CPU arch
             # If we specify a CPU arch, Kokkos' CMake will add the correspondent -march and -mtune flags to the
             # compilation line, possibly overriding the ones set by EasyBuild.
-            processor_arch = 'NATIVE'
+            cuda_root = get_software_root('CUDA')
+            if get_cpu_architecture() == AARCH64 and LooseVersion(os.path.basename(cuda_root)) < '13.2.0':
+                processor_arch = self.kokkos_cpu_mapping.get(get_cpu_arch())
+            else:
+                processor_arch = 'NATIVE'
         else:
             # for old versions: try to auto-detect CPU arch
             warning_msg = "kokkos_arch not set. Trying to auto-detect CPU arch."
@@ -423,10 +433,13 @@ class EB_LAMMPS(CMakeMake):
                     # Disabling ARM NEON as builds on ARM results in build errors for SIMD
                     # See https://github.com/kokkos/kokkos/issues/7483
                     cuda_root = get_software_root('CUDA')
+                    self.cfg.update('configopts', '-D%s_ARCH_%s=yes' % (self.kokkos_prefix, processor_arch))
                     if get_cpu_architecture() == AARCH64 and LooseVersion(os.path.basename(cuda_root)) < '13.2.0':
-                        self.cfg.update('configopts', '-D%s_ARCH_%s=no' % (self.kokkos_prefix, processor_arch))
-                    else:
-                        self.cfg.update('configopts', '-D%s_ARCH_%s=yes' % (self.kokkos_prefix, processor_arch))
+                        #self.cfg.update('configopts', '-D%s_ARCH_%s=no' % (self.kokkos_prefix, processor_arch))
+                        #self.cfg.update('configopts', '-D%s_ARCH_ARM81=yes' % self.kokkos_prefix)
+                        self.cfg.update('configopts', '-D%s_ARCH_ARM_NEON=no' % self.kokkos_prefix)
+                    #else:
+                        #self.cfg.update('configopts', '-D%s_ARCH_%s=yes' % (self.kokkos_prefix, processor_arch))
                     self.cfg.update('configopts', '-D%s_ARCH_%s=yes' % (self.kokkos_prefix, gpu_arch))
                 else:
                     # Older versions of Kokkos required us to tweak the C++ compiler
@@ -438,8 +451,18 @@ class EB_LAMMPS(CMakeMake):
                 if get_cpu_architecture() == AARCH64:
                     cuda_root = get_software_root('CUDA')
                     if LooseVersion(os.path.basename(cuda_root)) < '13.2.0':
+                        if build_option('optarch') == OPTARCH_GENERIC:
+                            march_flag = ' -march=-march=armv8-a+nosimd'
+                        else:
+                            cpu_arch = get_cpu_arch()
+                            if cpu_arch in AARCH64_MARCH_MAPPING:
+                                march_flag = ' -march=%s-a+nosimd' % AARCH64_MARCH_MAPPING[cpu_arch]
+                            else:
+                                error_msg = "Specified CPU ARCH (%s) " % cpu_arch
+                                error_msg += "was not found in listed options [%s]." % AARCH64_MARCH_MAPPING
+                                raise EasyBuildError(error_msg)
                         cxxflags = os.getenv('CXXFLAGS', '')
-                        cxxflags += ' -march=armv8-a+nosimd'
+                        cxxflags += march_flag
                         env.setvar('CXXFLAGS', cxxflags)
             else:
                 if LooseVersion(self.cur_version) >= LooseVersion(self.ref_version):

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -49,8 +49,8 @@ from easybuild.tools.config import build_option, IGNORE
 from easybuild.tools.filetools import copy_dir, copy_file, mkdir, read_file, which
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_shell_cmd
-from easybuild.tools.systemtools import (AARCH64, get_cpu_architecture, get_shared_lib_ext,
-                                         get_avail_core_count, get_gpu_info)
+from easybuild.tools.systemtools import AARCH64
+from easybuild.tools.systemtools import get_avail_core_count, get_cpu_architecture, get_gpu_info, get_shared_lib_ext
 from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
 
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
@@ -111,6 +111,33 @@ def translate_lammps_version(version, path=None):
             raise ValueError(f"LAMMPS version {version} cannot be translated")
 
 
+def get_ld_preload_value_cuda_stubs():
+    """
+    """
+    ld_preload = os.getenv('LD_PRELOAD')
+    ld_preload = ld_preload.split(os.pathsep) if ld_preload else []
+
+    cuda_stub_libs = [
+            os.path.join('lib', 'stubs', 'libcuda.so'),
+            os.path.join('lib64', 'stubs', 'libcuda.so.1')
+    ]
+
+    cuda_stub_lib_paths = []
+
+    # check if CUDA stubs library is already included, to avoid doing so twice
+    if not any(x.endswith(cuda_stub_libs[0]) for x in ld_preload):
+
+        cuda_root = get_software_root('CUDA')
+        cuda_stub_lib_paths = [os.path.join(cuda_root, x) for x in cuda_stub_libs]
+
+        # make sure these paths exist before we shove them into $LD_PRELOAD
+        for path in cuda_stub_lib_paths:
+            if not os.path.exists(path):
+                raise EasyBuildError(f"CUDA stub library at {path} does not exist!")
+
+    return os.pathsep.join(cuda_stub_lib_paths + ld_preload)
+
+
 class EB_LAMMPS(CMakeMake):
     """
     Support for building and installing LAMMPS
@@ -125,6 +152,12 @@ class EB_LAMMPS(CMakeMake):
         self.cuda = cuda_dep or cuda_toolchain
 
         self.cur_version = None
+
+        # check if an NVIDIA GPU is available;
+        # we need to know this because are steps are required
+        # when we're crosscompiling an NVIDIA GPU build on a CPU-only system
+        gpus = get_gpu_info()
+        self.nvidia_gpu_found = 'NVIDIA' in gpus
 
     def update_kokkos_cpu_mapping(self):
         """
@@ -513,18 +546,20 @@ class EB_LAMMPS(CMakeMake):
         # For crosscompiling LAMMPS with CUDA:
         # - CUDA stubs need to be explicitly added to the linker
         # - libcuda.so needs to be added to LD_PRELOAD
-        if self.cuda:
-            gpus = get_gpu_info()
-            if 'NVIDIA' not in gpus:
+        if self.cuda and not self.nvidia_gpu_found:
+
+            # we need to make sure that the path to the CUDA stub libraries is found when linking
+            # but does not get baked into the RPATH section so they will be used at runtime,
+            # so we use -rpath-link (as opposed to -rpath)
+            if self.toolchain.use_rpath:
                 cuda_root = get_software_root('CUDA')
-                libcuda = '%s/lib/stubs/libcuda.so:%s/lib64/stubs/libcuda.so.1' % (cuda_root, cuda_root)
-                self.cfg.update('configopts', '-DCMAKE_EXE_LINKER_FLAGS=-Wl,-rpath-link,%s/lib/stubs' % cuda_root)
-                ld_preload = os.getenv('LD_PRELOAD', '')
-                if ld_preload == '':
-                    self.ld_preload = libcuda
-                else:
-                    self.ld_preload = '%s:%s' % (ld_preload, libcuda)
-                env.setvar('LD_PRELOAD', self.ld_preload)
+                self.cfg.update('configopts', f'-DCMAKE_EXE_LINKER_FLAGS=-Wl,-rpath-link,{cuda_root}/lib/stubs')
+
+            ld_preload = get_ld_preload_value_cuda_stubs()
+            env.setvar('LD_PRELOAD', ld_preload)
+            msg = "Cross-compiling NVIDIA GPU build on CPU-only system, "
+            msg += f"so $LD_PRELOAD updated to include CUDA stub libraries: {ld_preload}"
+            self.log.info(msg)
 
         return super().configure_step()
 
@@ -581,12 +616,10 @@ class EB_LAMMPS(CMakeMake):
             if LooseVersion(self.cmake_version) >= '3.17.0':
                 test_cmd += ' --no-tests=error'
             skipped_tests = "TestMliapPyUnified|AtomicPairStyle:meam_spline|KSpaceStyle:scafacos.*"
-            if self.cuda:
-                gpus = get_gpu_info()
-                if 'NVIDIA' not in gpus:
-                    # These tests require libcuda.so that is not a stub
-                    skipped_tests += "|LibraryOpen|LibraryProperties|LammpsClass|NeighborClass"
-            test_cmd += ' -LE unstable -E "%s"' % skipped_tests
+            if self.cuda and not self.nvidia_gpu_found:
+                # these tests require libcuda.so that is *not* a stub, so skip them
+                skipped_tests += "|LibraryOpen|LibraryProperties|LammpsClass|NeighborClass"
+            test_cmd += f' -LE unstable -E "{skipped_tests}"'
             self.log.debug(f"Running tests using test_cmd = '{test_cmd}' as test_cmd")
             self.cfg['test_cmd'] = test_cmd
 
@@ -682,24 +715,12 @@ class EB_LAMMPS(CMakeMake):
             self.log.info("Using %s cores for the MPI tests" % test_core_cnt)
             custom_commands = [self.toolchain.mpi_cmd_for(cmd, test_core_cnt) for cmd in custom_commands]
 
-        # When crosscompiling LAMMPS with CUDA the build and testing require LD_PRELOAD being set.
-        # During testing I found that LD_PRELOAD was not picked up in the environment.
+        # When crosscompiling LAMMPS with CUDA the build and testing require $LD_PRELOAD being set.
+        # During testing I found that $LD_PRELOAD was not picked up in the environment.
         # It has to be explicitly set in the command.
-        if self.cuda:
-            gpus = get_gpu_info()
-            if 'NVIDIA' not in gpus:
-                ld_preload = os.getenv('LD_PRELOAD', '')
-                # When running --module-only or --sanity-check-only LD_PRELOAD will not be set.
-                # Checking if libcuda.so is in LD_PRELOAD.
-                if 'libcuda.so' not in ld_preload:
-                    cuda_root = get_software_root('CUDA')
-                    libcuda = cuda_root + '/stubs/lib/libcuda.so' + ':' + cuda_root + '/stubs/lib/libcuda.so.1'
-                    if ld_preload == '':
-                        ld_preload = libcuda
-                    else:
-                        ld_preload = '%s:%s' % (ld_preload, libcuda)
-                ld_preload = 'LD_PRELOAD=%s' % ld_preload
-                custom_commands = [ld_preload + " " + cmd for cmd in custom_commands]
+        if self.cuda and not self.nvidia_gpu_found:
+            ld_preload = get_ld_preload_value_cuda_stubs()
+            custom_commands = [f'LD_PRELOAD="{ld_preload}" {cmd}' for cmd in custom_commands]
 
         custom_commands = ["cd %s && " % execution_dir + cmd for cmd in custom_commands]
 

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -155,7 +155,7 @@ class EB_LAMMPS(CMakeMake):
         self.cur_version = None
 
         # check if an NVIDIA GPU is available;
-        # we need to know this because are steps are required
+        # we need to know this because extra steps are required
         # when we're crosscompiling an NVIDIA GPU build on a CPU-only system
         gpus = get_gpu_info()
         self.nvidia_gpu_found = 'NVIDIA' in gpus

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -57,7 +57,7 @@ from easybuild.easyblocks.generic.cmakemake import CMakeMake
 AARCH64_MARCH_MAPPING = {
     'neoverse_v1': 'armv8.4',
     'neoverse_n1': 'armv8.2',
-    'neoverse_v2': 'armv9',
+    'neoverse_v2': 'armv8.4',
 }
 
 # lammps version, which caused the most changes. This may not be precise, but it does work with existing easyconfigs
@@ -435,9 +435,6 @@ class EB_LAMMPS(CMakeMake):
                     cuda_root = get_software_root('CUDA')
                     if get_cpu_architecture() == AARCH64 and LooseVersion(os.path.basename(cuda_root)) < '13.2.0':
                         self.cfg.update('configopts', '-D%s_ARCH_ARM_NEON=no' % self.kokkos_prefix)
-                        # For neoverse-v2 we need to also disable SVE
-                        if processor_arch == 'ARMV9_GRACE':
-                            self.cfg.update('configopts', '-D%s_ARCH_ARM_SVE=no' % self.kokkos_prefix)
                     self.cfg.update('configopts', '-D%s_ARCH_%s=yes' % (self.kokkos_prefix, gpu_arch))
                 else:
                     # Older versions of Kokkos required us to tweak the C++ compiler

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -46,20 +46,13 @@ from easybuild.easyblocks.kokkos import KOKKOS_LEGACY_ARCH_MAPPING, KOKKOS_CPU_M
 from easybuild.framework.easyconfig import CUSTOM, MANDATORY
 from easybuild.tools.build_log import EasyBuildError, print_warning, print_msg
 from easybuild.tools.config import build_option, IGNORE
-from easybuild.tools.filetools import copy_dir, copy_file, mkdir, read_file, which
+from easybuild.tools.filetools import apply_regex_substitutions, copy_dir, copy_file, mkdir, read_file, which
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.systemtools import AARCH64, get_cpu_architecture, get_shared_lib_ext, get_avail_core_count
 from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
 
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
-
-# see https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html for values that can be passed to -march
-AARCH64_MARCH_MAPPING = {
-    'neoverse_n1': 'armv8.2-a',
-    'neoverse_v1': 'armv8.4-a',
-    'neoverse_v2': 'armv9-a',
-}
 
 # lammps version, which caused the most changes. This may not be precise, but it does work with existing easyconfigs
 ref_version = '29Sep2021'
@@ -131,6 +124,13 @@ class EB_LAMMPS(CMakeMake):
 
         self.cur_version = None
 
+        # see https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html for values that can be passed to -march
+        self.aarch64_march_mapping = {
+            'neoverse_n1': 'armv8.2-a',
+            'neoverse_v1': 'armv8.4-a',
+            'neoverse_v2': 'armv9-a',
+        }
+
     def update_kokkos_cpu_mapping(self):
         """
         Update mapping to Kokkos CPU targets based on LAMMPS version
@@ -139,6 +139,10 @@ class EB_LAMMPS(CMakeMake):
             self.kokkos_cpu_mapping['neoverse_n1'] = 'ARMV81'
             self.kokkos_cpu_mapping['neoverse_v1'] = 'ARMV81'
             self.kokkos_cpu_mapping['cortex_a72'] = 'ARMV81'
+            # we also need to replace the values for -march to avoid conflicts with compiler options used by Kokkos;
+            # see also https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html
+            self.aarch64_march_mapping['neoverse_n1'] = 'armv8.1-a'
+            self.aarch64_march_mapping['neoverse_v1'] = 'armv8.1-a'
 
         if LooseVersion(self.cur_version) >= LooseVersion(translate_lammps_version('21sep2021')):
             self.kokkos_cpu_mapping['a64fx'] = 'A64FX'
@@ -154,6 +158,12 @@ class EB_LAMMPS(CMakeMake):
             self.kokkos_cpu_mapping['zen4'] = 'ZEN4'
         if LooseVersion(self.cur_version) >= LooseVersion(translate_lammps_version('22Jul2025')):
             self.kokkos_cpu_mapping['zen5'] = 'ZEN5'
+
+        if LooseVersion(self.cur_version) > LooseVersion(translate_lammps_version('22Jul2025')):
+            # for newer versions of LAMMPS (which include Kokkos 4.7+)
+            # we should use ARMV84_SVE in kokkos_cpu_mapping for neoverse_v1,
+            # see https://github.com/kokkos/kokkos/commit/16726efdd5cbe272fe873e0e73feb7d1befb8122
+            print_warning(f"update_kokkos_cpu_mapping function needs to be updated for LAMMPS {self.version}!")
 
     def get_kokkos_arch(self, cuda_cc, kokkos_arch, cuda_pre_13_2=False):
         """
@@ -407,7 +417,7 @@ class EB_LAMMPS(CMakeMake):
         # see https://github.com/kokkos/kokkos/issues/7483
         cuda_pre_13_2 = False
         if self.cuda:
-            cuda_ver = get_software_root('CUDA')
+            cuda_ver = get_software_version('CUDA')
             if cuda_ver:
                 cuda_pre_13_2 = LooseVersion(cuda_ver) < '13.2.0'
             else:
@@ -455,31 +465,50 @@ class EB_LAMMPS(CMakeMake):
                     self.cfg.update('configopts', '-DCMAKE_CXX_FLAGS="-ccbin $CXX $CXXFLAGS"')
                     self.cfg.update('configopts', '-D%s_ARCH="%s;%s"' % (self.kokkos_prefix, processor_arch, gpu_arch))
 
-                # add -march option in $CXXFLAGS (after -mcpu=native which is there already)
-                # to disable ARM NEON when building on Arm with CUDA < 13.2,
+                # add -march option with +nosimd to $CXXFLAGS to disable ARM NEON when building on Arm with CUDA < 13.2,
+                # and patch Kokkos script to inject +nosimd to the -march option it adds;
                 # to work around build errors like ".../arm_neon.h(46): error: identifier";
                 # See https://github.com/kokkos/kokkos/issues/7483
                 if get_cpu_architecture() == AARCH64 and cuda_pre_13_2:
                     if build_option('optarch') == OPTARCH_GENERIC:
-                        march_flag = '-march=-march=armv8-a+nosimd'
+                        march_flag = 'armv8-a+nosimd'
                     else:
                         cpu_arch = get_cpu_arch()
-                        if cpu_arch in AARCH64_MARCH_MAPPING:
-                            march_flag = '-march=' + AARCH64_MARCH_MAPPING[cpu_arch]
-                            # for some LAMMPS versions we shouldn't use SVE2, so fall back to ARMv8.4 (only SVE)
-                            if any(self.version.startswith(x) for x in ['22Jul2025']):
-                                march_flag = march_flag.replace('armv9-a', 'armv8.4-a')
+                        if cpu_arch in self.aarch64_march_mapping:
+                            march_flag = self.aarch64_march_mapping[cpu_arch]
+                            # for some LAMMPS versions we can't use ARMV9-A as target architecture yet,
+                            # because the SVE2 it implies leads to trouble
+                            if march_flag == 'armv9-a' and any(self.version.startswith(x) for x in ['22Jul2025']):
+                                march_flag = 'armv8.4-a'
 
                             march_flag += '+nosimd'
                         else:
                             error_msg = "Specified CPU ARCH (%s) " % cpu_arch
-                            error_msg += "was not found in listed options [%s]." % AARCH64_MARCH_MAPPING
+                            error_msg += "was not found in listed options [%s]." % self.aarch64_march_mapping
                             raise EasyBuildError(error_msg)
 
+                    # add -march option determined above in addition to -mcpu=native in $CXXFLAGS,
+                    # to take control of the target architecture;
+                    # if -mcpu is used in conjunction with -march (or -mtune),
+                    # those options take precedence over the appropriate part of this option;
+                    # see also https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html
                     orig_cxxflags = os.getenv('CXXFLAGS', '')
-                    cxxflags = orig_cxxflags + ' ' + march_flag
+
+                    # strip out -mcpu=native from $CXXFLAGS, since that will clash with the -march flag being added,
+                    # resulting in warnings like "switch '-mcpu=...' conflicts with '-march=...' switch
+                    cxxflags = orig_cxxflags.replace('-mcpu=native', '')
+
+                    # add -march flag determined above to $CXXFLAGS
+                    cxxflags += ' -march=' + march_flag
+
                     env.setvar('CXXFLAGS', cxxflags)
                     self.log.info(f'Modified $CXXFLAGS to disable Arm NEON: "{cxxflags}" (was: "{orig_cxxflags}")')
+
+                    # patch lib/kokkos/cmake/kokkos_arch.cmake to append +nosimd to all '-march=armv.*' entries;
+                    # this is necessary to avoid that an -march option that is added by Kokkos overrules
+                    # what we added to $CXXFLAGS above
+                    kokkos_arch_cmake = os.path.join('lib', 'kokkos', 'cmake', 'kokkos_arch.cmake')
+                    apply_regex_substitutions(kokkos_arch_cmake, [(r'-march=(armv[^\s]+)', r'-march=\1+nosimd')])
             else:
                 if LooseVersion(self.cur_version) >= LooseVersion(self.ref_version):
                     self.cfg.update('configopts', '-D%s_ARCH_%s=yes' % (self.kokkos_prefix, processor_arch))

--- a/easybuild/easyblocks/l/lammps.py
+++ b/easybuild/easyblocks/l/lammps.py
@@ -54,10 +54,11 @@ from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
 
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 
+# see https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html for values that can be passed to -march
 AARCH64_MARCH_MAPPING = {
-    'neoverse_v1': 'armv8.4',
-    'neoverse_n1': 'armv8.2',
-    'neoverse_v2': 'armv8.4',
+    'neoverse_n1': 'armv8.2-a',
+    'neoverse_v1': 'armv8.4-a',
+    'neoverse_v2': 'armv9-a',
 }
 
 # lammps version, which caused the most changes. This may not be precise, but it does work with existing easyconfigs
@@ -154,7 +155,7 @@ class EB_LAMMPS(CMakeMake):
         if LooseVersion(self.cur_version) >= LooseVersion(translate_lammps_version('22Jul2025')):
             self.kokkos_cpu_mapping['zen5'] = 'ZEN5'
 
-    def get_kokkos_arch(self, cuda_cc, kokkos_arch):
+    def get_kokkos_arch(self, cuda_cc, kokkos_arch, cuda_pre_13_2=False):
         """
         Return KOKKOS ARCH in LAMMPS required format, which is 'CPU_ARCH' and 'GPU_ARCH'.
 
@@ -189,8 +190,7 @@ class EB_LAMMPS(CMakeMake):
             # for LAMMPS >= 2Aug2023: use native CPU arch
             # If we specify a CPU arch, Kokkos' CMake will add the correspondent -march and -mtune flags to the
             # compilation line, possibly overriding the ones set by EasyBuild.
-            cuda_root = get_software_root('CUDA')
-            if get_cpu_architecture() == AARCH64 and LooseVersion(os.path.basename(cuda_root)) < '13.2.0':
+            if get_cpu_architecture() == AARCH64 and cuda_pre_13_2:
                 processor_arch = self.kokkos_cpu_mapping.get(get_cpu_arch())
             else:
                 processor_arch = 'NATIVE'
@@ -402,8 +402,19 @@ class EB_LAMMPS(CMakeMake):
             if '-DFFT_PACK=' not in self.cfg['configopts']:
                 self.cfg.update('configopts', '-DFFT_PACK=array')
 
+        # check whether CUDA version older than 13.2 is used,
+        # since then we need to work around a problem with Arm NEON,
+        # see https://github.com/kokkos/kokkos/issues/7483
+        cuda_pre_13_2 = False
+        if self.cuda:
+            cuda_ver = get_software_root('CUDA')
+            if cuda_ver:
+                cuda_pre_13_2 = LooseVersion(cuda_ver) < '13.2.0'
+            else:
+                raise EasyBuildError("Could not determine CUDA version!")
+
         # detect the CPU and GPU architecture (used for Intel and Kokkos packages below)
-        processor_arch, gpu_arch = self.get_kokkos_arch(cuda_cc, self.cfg['kokkos_arch'])
+        processor_arch, gpu_arch = self.get_kokkos_arch(cuda_cc, self.cfg['kokkos_arch'], cuda_pre_13_2=cuda_pre_13_2)
 
         # INTEL package
         if processor_arch in KOKKOS_INTEL_PACKAGE_ARCH_LIST or \
@@ -430,35 +441,45 @@ class EB_LAMMPS(CMakeMake):
                 self.cfg.update('configopts', '-D%s_ENABLE_CUDA=yes' % self.kokkos_prefix)
                 if LooseVersion(self.cur_version) >= LooseVersion(self.ref_version):
                     self.cfg.update('configopts', '-D%s_ARCH_%s=yes' % (self.kokkos_prefix, processor_arch))
-                    # Disabling ARM NEON as builds on ARM results in build errors for SIMD
+
+                    # disable ARM NEON in Kokkos when building on Arm with CUDA < 13.2,
+                    # to work around build errors like ".../arm_neon.h(46): error: identifier";
                     # See https://github.com/kokkos/kokkos/issues/7483
-                    cuda_root = get_software_root('CUDA')
-                    if get_cpu_architecture() == AARCH64 and LooseVersion(os.path.basename(cuda_root)) < '13.2.0':
+                    if get_cpu_architecture() == AARCH64 and cuda_pre_13_2:
                         self.cfg.update('configopts', '-D%s_ARCH_ARM_NEON=no' % self.kokkos_prefix)
+
                     self.cfg.update('configopts', '-D%s_ARCH_%s=yes' % (self.kokkos_prefix, gpu_arch))
                 else:
                     # Older versions of Kokkos required us to tweak the C++ compiler
                     self.cfg.update('configopts', '-DCMAKE_CXX_COMPILER="%s"' % nvcc_wrapper_path)
                     self.cfg.update('configopts', '-DCMAKE_CXX_FLAGS="-ccbin $CXX $CXXFLAGS"')
                     self.cfg.update('configopts', '-D%s_ARCH="%s;%s"' % (self.kokkos_prefix, processor_arch, gpu_arch))
-                # Disabling ARM NEON as builds on ARM results in build errors for SIMD
+
+                # add -march option in $CXXFLAGS (after -mcpu=native which is there already)
+                # to disable ARM NEON when building on Arm with CUDA < 13.2,
+                # to work around build errors like ".../arm_neon.h(46): error: identifier";
                 # See https://github.com/kokkos/kokkos/issues/7483
-                if get_cpu_architecture() == AARCH64:
-                    cuda_root = get_software_root('CUDA')
-                    if LooseVersion(os.path.basename(cuda_root)) < '13.2.0':
-                        if build_option('optarch') == OPTARCH_GENERIC:
-                            march_flag = ' -march=-march=armv8-a+nosimd'
+                if get_cpu_architecture() == AARCH64 and cuda_pre_13_2:
+                    if build_option('optarch') == OPTARCH_GENERIC:
+                        march_flag = '-march=-march=armv8-a+nosimd'
+                    else:
+                        cpu_arch = get_cpu_arch()
+                        if cpu_arch in AARCH64_MARCH_MAPPING:
+                            march_flag = '-march=' + AARCH64_MARCH_MAPPING[cpu_arch]
+                            # for some LAMMPS versions we shouldn't use SVE2, so fall back to ARMv8.4 (only SVE)
+                            if any(self.version.startswith(x) for x in ['22Jul2025']):
+                                march_flag = march_flag.replace('armv9-a', 'armv8.4-a')
+
+                            march_flag += '+nosimd'
                         else:
-                            cpu_arch = get_cpu_arch()
-                            if cpu_arch in AARCH64_MARCH_MAPPING:
-                                march_flag = ' -march=%s-a+nosimd' % AARCH64_MARCH_MAPPING[cpu_arch]
-                            else:
-                                error_msg = "Specified CPU ARCH (%s) " % cpu_arch
-                                error_msg += "was not found in listed options [%s]." % AARCH64_MARCH_MAPPING
-                                raise EasyBuildError(error_msg)
-                        cxxflags = os.getenv('CXXFLAGS', '')
-                        cxxflags += march_flag
-                        env.setvar('CXXFLAGS', cxxflags)
+                            error_msg = "Specified CPU ARCH (%s) " % cpu_arch
+                            error_msg += "was not found in listed options [%s]." % AARCH64_MARCH_MAPPING
+                            raise EasyBuildError(error_msg)
+
+                    orig_cxxflags = os.getenv('CXXFLAGS', '')
+                    cxxflags = orig_cxxflags + ' ' + march_flag
+                    env.setvar('CXXFLAGS', cxxflags)
+                    self.log.info(f'Modified $CXXFLAGS to disable Arm NEON: "{cxxflags}" (was: "{orig_cxxflags}")')
             else:
                 if LooseVersion(self.cur_version) >= LooseVersion(self.ref_version):
                     self.cfg.update('configopts', '-D%s_ARCH_%s=yes' % (self.kokkos_prefix, processor_arch))


### PR DESCRIPTION
This PR combines the following two PRs for the LAMMPS easyblock:
- #4175
- #4190
Testing LAMMPS quite a while, so this PR is mainly intended to make thorough testing of both PRs combined a bit easier.
Scenarios that should be tested include:
- [x] regular LAMMPS build (CPU-only);
- [x] cross-compiling LAMMPS NVIDIA GPU build on CPU-only system (cfr. fixes in PR #4190);
- [x] LAMMPS NVIDIA GPU build on GPU system (no cross-compiling);
- [x] CPU-only build on Arm system;
- [x] NVIDIA build on Arm system (cfr. fixes in PR #4175);
@boegel promised he could take care of uploading test reports for all these scenarios... :)